### PR TITLE
🔒 [security] Redact sensitive data from OpenRouter error logging

### DIFF
--- a/scripts/research-module.js
+++ b/scripts/research-module.js
@@ -77,13 +77,13 @@ function callOpenRouter(model, systemPrompt, userPrompt) {
         try {
           const parsed = JSON.parse(data);
           if (parsed.error) {
-            reject(new Error(`OpenRouter error: ${JSON.stringify(parsed.error)}`));
+            reject(new Error(`OpenRouter error: ${parsed.error.message || "Unknown error"}`));
             return;
           }
           const content = parsed.choices?.[0]?.message?.content ?? "";
           resolve(content);
         } catch (err) {
-          reject(new Error(`Failed to parse OpenRouter response: ${err.message}\nRaw: ${data}`));
+          reject(new Error(`Failed to parse OpenRouter response: ${err.message}`));
         }
       });
     });

--- a/scripts/run-human-testing-api.js
+++ b/scripts/run-human-testing-api.js
@@ -87,13 +87,13 @@ function callOpenRouter(model, systemPrompt, userPrompt) {
         try {
           const parsed = JSON.parse(data);
           if (parsed.error) {
-            reject(new Error(`OpenRouter error: ${JSON.stringify(parsed.error)}`));
+            reject(new Error(`OpenRouter error: ${parsed.error.message || "Unknown error"}`));
             return;
           }
           const content = parsed.choices?.[0]?.message?.content ?? "";
           resolve(content);
         } catch (err) {
-          reject(new Error(`Failed to parse OpenRouter response: ${err.message}\nRaw: ${data}`));
+          reject(new Error(`Failed to parse OpenRouter response: ${err.message}`));
         }
       });
     });


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is sensitive data exposure in OpenRouter API error logging. Specifically, raw response data and full error metadata were being included in error messages.

⚠️ **Risk:** Potential impact if left unfixed includes leaking API keys, user data, or internal system metadata through logs or error reports if the API response is malformed or returns an error.

🛡️ **Solution:** Modified the `callOpenRouter` function in both `scripts/run-human-testing-api.js` and `scripts/research-module.js` to:
1. Only log `parsed.error.message` instead of stringifying the entire error object.
2. Remove the raw response `data` from the `catch` block that handles JSON parsing failures.

---
*PR created automatically by Jules for task [5262494849097779018](https://jules.google.com/task/5262494849097779018) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a security vulnerability in OpenRouter API error logging by redacting sensitive data that could potentially leak through logs. The changes prevent the exposure of API keys, user data, or internal system metadata by modifying error handling in two files to only log the error message instead of the full error object, and removing raw response data from JSON parsing error messages.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/research-module.js` |
| 2 | `scripts/run-human-testing-api.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->