### PR TITLE
🧪 Add test for fetch_aave_markets HTTPError fallback

### DIFF
--- a/penny-sovereign-yield-scout/tests/test_sample_aave_optimizer.py
+++ b/penny-sovereign-yield-scout/tests/test_sample_aave_optimizer.py
@@ -1,0 +1,38 @@
+import sys
+import os
+import pytest
+import httpx
+
+# Add samples to path so we can import sample_aave_optimizer
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../samples')))
+
+import sample_aave_optimizer
+
+def test_fetch_aave_markets_http_error(mocker):
+    """
+    Test that fetch_aave_markets handles httpx.HTTPError by falling back
+    to mock data.
+    """
+    # Mock httpx.get to raise an HTTPError
+    mocker.patch(
+        'sample_aave_optimizer.httpx.get',
+        side_effect=httpx.HTTPError("Mock HTTP Error")
+    )
+
+    # Also mock the console to avoid printing to stdout during tests, if desired
+    # mocker.patch('sample_aave_optimizer.console.print')
+
+    # Call the function with an asset filter
+    result = sample_aave_optimizer.fetch_aave_markets(asset_filter="USDC")
+
+    # It should return the mock data filtered by USDC
+    # Let's get what _mock_aave_markets would return directly
+    expected_mock_result = sample_aave_optimizer._mock_aave_markets("USDC")
+
+    assert len(result) > 0
+    assert len(result) == len(expected_mock_result)
+
+    # Verify the first item has the expected attributes
+    # Check that all returned items have "USDC" in their symbol
+    for market in result:
+        assert "USDC" in market.symbol.upper()


### PR DESCRIPTION
🎯 **What:** Added a missing error test for `fetch_aave_markets` to verify it correctly handles `httpx.HTTPError` exceptions by returning mock data.
📊 **Coverage:** The `except httpx.HTTPError:` branch in `sample_aave_optimizer.py` is now tested.
✨ **Result:** Test coverage improved, preventing regressions when modifying API call error handling logic.

---
*PR created automatically by Jules for task [2031679473339808012](https://jules.google.com/task/2031679473339808012) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a test case to verify that the `fetch_aave_markets` function correctly handles `httpx.HTTPError` exceptions by falling back to mock data. The test uses mocking to simulate an HTTP error and validates that the function returns the expected mock data filtered by the specified asset (USDC). This improves test coverage for the error handling path in the Aave optimizer sample code.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `penny-sovereign-yield-scout/tests/test_sample_aave_optimizer.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->