### PR TITLE
Update auth check placeholder in UI/DB validation test template

### DIFF
--- a/templates/testing/ui-db-map.test.ts
+++ b/templates/testing/ui-db-map.test.ts
@@ -126,10 +126,11 @@ describe('[ROUTER_NAME] router — UI/DB shape validation', () => {
       // await expect(unauthCaller.[ROUTER_NAME].[ENDPOINT_NAME]()).rejects.toThrow('UNAUTHORIZED');
 
       // Placeholder — replace with real auth check
-      const isAuthenticated = false;
-      if (!isAuthenticated) {
-        expect(isAuthenticated).toBe(false);
-      }
+      const mockUnauthCall = async () => {
+        throw new Error('UNAUTHORIZED');
+      };
+
+      await expect(mockUnauthCall()).rejects.toThrow('UNAUTHORIZED');
     });
   });
 });


### PR DESCRIPTION
Replaces the arbitrary `expect(false).toBe(false)` placeholder inside `templates/testing/ui-db-map.test.ts` with a structurally valid `mockUnauthCall` function that explicitly throws `UNAUTHORIZED` and expects the rejection, which acts as a more helpful example of what actual logic in this template should look like.

---
*PR created automatically by Jules for task [11825812062880403775](https://jules.google.com/task/11825812062880403775) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves the authentication check placeholder in the UI/DB validation test template by replacing a meaningless `expect(false).toBe(false)` assertion with a more instructive example that uses `mockUnauthCall` to demonstrate proper async rejection testing with an `UNAUTHORIZED` error.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `templates/testing/ui-db-map.test.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->