### PR TITLE
test: implement dynamic empty state selector in panel template

### DIFF
--- a/templates/testing/panel-data-void.spec.ts
+++ b/templates/testing/panel-data-void.spec.ts
@@ -16,18 +16,21 @@ const PAGES_TO_CHECK: Array<{
   name: string;
   path: string;
   panelSelector: string;
+  emptyStateSelector?: string;
   requiresAuth?: boolean;
 }> = [
   {
     name: 'Home page',
     path: '/',                          // [PAGE_PATH]
     panelSelector: 'main',              // [PANEL_SELECTOR] — replace with specific selector
+    emptyStateSelector: '[data-testid="empty-state"]', // Default empty state selector
     requiresAuth: false,
   },
   {
     name: 'Dashboard',
     path: '/dashboard',                 // [PAGE_PATH]
     panelSelector: '.dashboard-panel',  // [PANEL_SELECTOR]
+    emptyStateSelector: '[data-testid="empty-state"]', // Default empty state selector
     requiresAuth: true,
   },
   // TODO: Add all pages you want to validate
@@ -35,6 +38,7 @@ const PAGES_TO_CHECK: Array<{
   //   name: '[PAGE_NAME]',
   //   path: '[PAGE_PATH]',
   //   panelSelector: '[PANEL_SELECTOR]',
+  //   emptyStateSelector: '[EMPTY_STATE_SELECTOR]', // Optional
   //   requiresAuth: true,
   // },
 ];
@@ -120,13 +124,14 @@ test.describe('Panel Data Void Check — no empty states in production', () => {
       await expect(panel).not.toContainText('500', { ignoreCase: false });
 
       // Panel must not be the only content visible (empty state only)
-      // TODO: Replace with your actual empty state selector if you have one
-      // const emptyState = panel.locator('[data-testid="empty-state"]');
-      // const emptyStateCount = await emptyState.count();
-      // const allContent = panel.locator(':not([data-testid="empty-state"])');
-      // if (emptyStateCount > 0) {
-      //   await expect(allContent).not.toHaveCount(0);
-      // }
+      if (pageConfig.emptyStateSelector) {
+        const emptyState = panel.locator(pageConfig.emptyStateSelector);
+        const emptyStateCount = await emptyState.count();
+        const allContent = panel.locator(`:not(${pageConfig.emptyStateSelector})`);
+        if (emptyStateCount > 0) {
+          await expect(allContent).not.toHaveCount(0);
+        }
+      }
     });
   }
 });


### PR DESCRIPTION
This commit addresses the issue of the hardcoded TODO for the empty state selector in the `panel-data-void.spec.ts` template.

Instead of leaving a commented-out code block that forces users to heavily modify the core assertion loop, the configuration interface `PAGES_TO_CHECK` was updated to include an optional `emptyStateSelector` string property. The test logic was subsequently updated to conditionally look for this selector and enforce the "panel must not be the only content visible" rule if it is provided.

This approach resolves the issue while making the template significantly cleaner and easier for end-users to adopt via configuration rather than code modification.

---
*PR created automatically by Jules for task [9108164119398254344](https://jules.google.com/task/9108164119398254344) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances a test template by replacing a hardcoded TODO section with a configurable `emptyStateSelector` property. Instead of requiring users to manually modify the assertion logic for empty state detection, the `PAGES_TO_CHECK` configuration interface now accepts an optional `emptyStateSelector` string. The test conditionally checks for empty states when this selector is provided, making the template more user-friendly and maintainable through configuration rather than code changes.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `templates/testing/panel-data-void.spec.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->