### PR TITLE
🧹 [Code Health] Remove unused httpx import in auto_compounder_api.py

### DIFF
--- a/penny-sovereign-yield-scout/tools/auto_compounder_api.py
+++ b/penny-sovereign-yield-scout/tools/auto_compounder_api.py
@@ -25,7 +25,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-import httpx
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware


### PR DESCRIPTION
🎯 **What:** Removed the unused `httpx` import from `penny-sovereign-yield-scout/tools/auto_compounder_api.py`.
💡 **Why:** To improve code health and maintainability by removing dead code.
✅ **Verification:** Ran the `pytest` suite locally and confirmed 100% test pass rates to ensure no regressions were introduced.
✨ **Result:** Cleaned up code without affecting the API's functionality.

---
*PR created automatically by Jules for task [17816104351415108422](https://jules.google.com/task/17816104351415108422) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes an unused `httpx` import from the auto_compounder_api.py file to improve code health and maintainability. The change was verified with the pytest suite to ensure no functionality was affected.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `penny-sovereign-yield-scout/tools/auto_compounder_api.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->