### PR TITLE
🧹 [Code Health] Implement actual database query logic in MCP server template

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,10 @@
+🎯 **What:** Implemented actual database query logic for `example_query` and `create_record` tools in the MCP custom server template (`templates/mcp/custom-server/mcp_server/server.py`), replacing the dummy TODO placeholders with functional psycopg2 code when a `DATABASE_URL` is provided.
+
+💡 **Why:** Returning a placeholder dictionary instead of actually querying the DB makes the template less useful as a starting point. By implementing the database logic and maintaining the in-memory mock as a fallback, we improve the template's robustness and immediate utility without breaking functionality for users who haven't yet configured their database.
+
+✅ **Verification:**
+- Modified the code to parse correctly by running `python -m py_compile`.
+- Validated via `pytest` on the root Python test suite to ensure no broader functionality was broken.
+- Manually checked the implemented psycopg2 logic.
+
+✨ **Result:** A more complete and maintainable template that actually performs database queries when connected, resolving the outstanding unimplemented code issues.

--- a/templates/mcp/custom-server/mcp_server/server.py
+++ b/templates/mcp/custom-server/mcp_server/server.py
@@ -67,16 +67,21 @@ def example_query(query: str, limit: int = 10) -> list[dict]:
     Returns:
         A list of matching records as dictionaries.
     """
-    # TODO: implement actual database query using DATABASE_URL
-    # Example with psycopg2:
-    # import psycopg2
-    # conn = psycopg2.connect(DATABASE_URL)
-    # cur = conn.cursor()
-    # cur.execute("SELECT * FROM table WHERE name ILIKE %s LIMIT %s", (f"%{query}%", limit))
-    # rows = cur.fetchall()
-    # return [dict(row) for row in rows]
+    if DATABASE_URL:
+        import psycopg2
+        import psycopg2.extras
 
-    # Mock search across in-memory records
+        conn = psycopg2.connect(DATABASE_URL)
+        cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        try:
+            cur.execute("SELECT * FROM table WHERE name ILIKE %s LIMIT %s", (f"%{query}%", limit))
+            rows = cur.fetchall()
+            return [dict(row) for row in rows]
+        finally:
+            cur.close()
+            conn.close()
+
+    # Fallback: Mock search across in-memory records
     results = [
         r for r in RECORDS.values()
         if query.lower() in r["name"].lower()
@@ -95,20 +100,25 @@ def create_record(name: str, data: dict) -> dict:
     Returns:
         The created record including its generated ID.
     """
-    # TODO: implement actual record creation using DATABASE_URL
-    # Example with psycopg2:
-    # import psycopg2
-    # import json
-    # conn = psycopg2.connect(DATABASE_URL)
-    # cur = conn.cursor()
-    # cur.execute(
-    #     "INSERT INTO table (name, data) VALUES (%s, %s) RETURNING id, created_at",
-    #     (name, json.dumps(data))
-    # )
-    # record_id, created_at = cur.fetchone()
-    # conn.commit()
-    # return {"id": record_id, "name": name, "data": data, "created_at": created_at}
+    if DATABASE_URL:
+        import psycopg2
+        import json
 
+        conn = psycopg2.connect(DATABASE_URL)
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "INSERT INTO table (name, data) VALUES (%s, %s) RETURNING id, created_at",
+                (name, json.dumps(data))
+            )
+            record_id, created_at = cur.fetchone()
+            conn.commit()
+            return {"id": record_id, "name": name, "data": data, "created_at": created_at}
+        finally:
+            cur.close()
+            conn.close()
+
+    # Fallback: Mock creation
     record_id = str(uuid.uuid4())
     record = {"id": record_id, "name": name, "data": data}
     RECORDS[record_id] = record


### PR DESCRIPTION
🎯 **What:** Implemented actual database query logic for `example_query` and `create_record` tools in the MCP custom server template (`templates/mcp/custom-server/mcp_server/server.py`), replacing the dummy TODO placeholders with functional psycopg2 code when a `DATABASE_URL` is provided.

💡 **Why:** Returning a placeholder dictionary instead of actually querying the DB makes the template less useful as a starting point. By implementing the database logic and maintaining the in-memory mock as a fallback, we improve the template's robustness and immediate utility without breaking functionality for users who haven't yet configured their database.

✅ **Verification:** 
- Modified the code to parse correctly by running `python -m py_compile`.
- Validated via `pytest` on the root Python test suite to ensure no broader functionality was broken.
- Manually checked the implemented psycopg2 logic.

✨ **Result:** A more complete and maintainable template that actually performs database queries when connected, resolving the outstanding unimplemented code issues.

---
*PR created automatically by Jules for task [9217343800985157993](https://jules.google.com/task/9217343800985157993) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR replaces TODO placeholders in the MCP custom server template with actual database query implementation using **psycopg2**. The changes add functional database operations for `example_query` and `create_record` tools when a `DATABASE_URL` is configured, while preserving the existing in-memory mock behavior as a fallback. This makes the template more immediately useful as a starting point for developers building MCP servers with database connectivity.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `templates/mcp/custom-server/mcp_server/server.py` |
| 2 | `pr-body.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->