### PR TITLE
🧪 [testing improvement] Add test edge case for position_usd <= 0 in optimal_compound_interval

### DIFF
--- a/penny-sovereign-yield-scout/tests/test_auto_compounder_api.py
+++ b/penny-sovereign-yield-scout/tests/test_auto_compounder_api.py
@@ -182,6 +182,17 @@ def test_optimal_interval():
     # Invalid request (negative APY)
     res = client.get("/optimal-interval?position_usd=10000&apy=-5&gas_cost_usd=1.0")
     assert res.status_code == 400
+    assert res.json()["detail"] == "position_usd and apy must be > 0"
+
+    # Invalid request (zero position)
+    res = client.get("/optimal-interval?position_usd=0&apy=10&gas_cost_usd=1.0")
+    assert res.status_code == 400
+    assert res.json()["detail"] == "position_usd and apy must be > 0"
+
+    # Invalid request (negative position)
+    res = client.get("/optimal-interval?position_usd=-1000&apy=10&gas_cost_usd=1.0")
+    assert res.status_code == 400
+    assert res.json()["detail"] == "position_usd and apy must be > 0"
 
 def test_audit_verify_empty():
     # Without any logs


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the error responses on the FastAPI endpoints where position_usd <= 0 since this expects a 400 error.

📊 **Coverage:** The scenarios now tested are `position_usd=0` and `position_usd=-1000`. We have also included assertions for the correct HTTP message.

✨ **Result:** The improvement in test coverage gives us more robustness to handle position_usd errors.

---
*PR created automatically by Jules for task [4638505822105225387](https://jules.google.com/task/4638505822105225387) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances test coverage for the `optimal-interval` endpoint by adding edge case tests for invalid `position_usd` values (zero and negative). The new tests verify that the endpoint correctly returns a 400 status code with the appropriate error message when `position_usd` is less than or equal to zero. Additionally, an assertion for the error detail message was added to the existing negative APY test case.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `penny-sovereign-yield-scout/tests/test_auto_compounder_api.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->