### PR TITLE
🧪 Add edge case tests for score_signal in listener.py

### DIFF
--- a/penny-sovereign-yield-scout/tests/test_listener.py
+++ b/penny-sovereign-yield-scout/tests/test_listener.py
@@ -1,0 +1,49 @@
+import pytest
+from tools.listener import SocialSignal, score_signal
+
+def test_score_signal_normal():
+    """Test standard conditions to ensure proper weighting calculation."""
+    signal = SocialSignal(
+        ticker="TEST",
+        platform="twitter",
+        mention_count_24h=1250,  # 1250 / 5000 = 0.25 -> * 0.25 = 0.0625
+        yield_keywords_found=["APY", "yield"],  # 2 keywords > 0 weight
+        penny_keywords_found=["gem"],  # 1 keyword
+        risk_flags=["scam"],  # 1 flag -> 0.15 penalty
+        raw_text_sample="TEST is a hidden gem with high APY yield"
+    )
+    score = score_signal(signal)
+
+    assert 0.0 <= score <= 1.0
+
+def test_score_signal_inflated():
+    """Test massive inputs to guarantee the score maxes out at the maximum possible theoretical score 0.85 (0.35 + 0.25 + 0.25)."""
+    # Massive mentions and many keywords
+    signal = SocialSignal(
+        ticker="TEST",
+        platform="reddit",
+        mention_count_24h=1_000_000,
+        yield_keywords_found=["APY"] * 100,
+        penny_keywords_found=["gem"] * 100,
+        risk_flags=[],
+        raw_text_sample="TO THE MOON" * 100
+    )
+    score = score_signal(signal)
+
+    # max possible score = 0.35 + 0.25 + 0.25 = 0.85
+    assert score == 0.85
+
+def test_score_signal_penalized():
+    """Test with extreme negative attributes to ensure the score floors at 0.0."""
+    signal = SocialSignal(
+        ticker="TEST",
+        platform="telegram",
+        mention_count_24h=0,
+        yield_keywords_found=[],
+        penny_keywords_found=[],
+        risk_flags=["scam", "rug", "hack", "exploit", "drain"], # 5 flags -> big penalty
+        raw_text_sample="RUN AWAY SCAM RUG HACK EXPLOIT DRAIN"
+    )
+    score = score_signal(signal)
+
+    assert score == 0.0


### PR DESCRIPTION
🎯 What: Added tests to cover the edge case gaps in score_signal function within tools/listener.py.
📊 Coverage: Added test coverage for normal sentiment calculation, max bounds testing (extremely inflated sentiment) to ensure capping at max scores, and min bounds testing (penalised signals) to ensure capping at 0.0.
✨ Result: Improved test reliability and prevents future regressions on social sentiment score caps.

---
*PR created automatically by Jules for task [6809473067131271606](https://jules.google.com/task/6809473067131271606) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive edge case test coverage for the `score_signal` function in `tools/listener.py`. The tests validate normal sentiment calculation behavior, ensure proper score capping at the maximum theoretical value of **0.85** when inputs are extremely inflated, and verify that heavily penalized signals are correctly floored at **0.0**. These tests improve reliability and prevent future regressions around social sentiment scoring boundaries.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `penny-sovereign-yield-scout/tests/test_listener.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->