### PR TITLE
chore(templates): remove TODO prefixes from field-validation test template

### DIFF
--- a/templates/testing/field-validation.test.ts
+++ b/templates/testing/field-validation.test.ts
@@ -4,18 +4,20 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { z } from 'zod';
 
-// TODO: Replace with your actual imports
+// Replace with your actual imports
 // import { db } from '@/db';
 // import { [TABLE_NAME] } from '@/db/schema';
 // import { setupTestDb, teardownTestDb } from '@/tests/helpers/db';
 
 describe('[TABLE_NAME] field validation', () => {
   beforeAll(async () => {
-    // TODO: await setupTestDb();
+    // Replace with your DB setup logic
+    // await setupTestDb();
   });
 
   afterAll(async () => {
-    // TODO: await teardownTestDb();
+    // Replace with your DB teardown logic
+    // await teardownTestDb();
   });
 
   // -------------------------------------------------------------------------
@@ -24,7 +26,7 @@ describe('[TABLE_NAME] field validation', () => {
 
   describe('required fields', () => {
     it('should reject insert when [FIELD_NAME] is null', async () => {
-      // TODO: Replace with your actual DB insert + Drizzle schema
+      // Replace with your actual DB insert + Drizzle schema
       // await expect(
       //   db.insert([TABLE_NAME]).values({ [FIELD_NAME]: null, ...otherRequiredFields })
       // ).rejects.toThrow();
@@ -32,7 +34,7 @@ describe('[TABLE_NAME] field validation', () => {
     });
 
     it('should reject insert when [FIELD_NAME] is an empty string', async () => {
-      // TODO: Replace with your actual validation logic
+      // Replace with your actual validation logic
       const schema = z.string().min(1);
       expect(schema.safeParse('').success).toBe(false);
     });


### PR DESCRIPTION
The file `templates/testing/field-validation.test.ts` contained multiple `TODO:` comments serving as placeholders for end developers copying the template. However, these prefixes were being inadvertently picked up by issue trackers or task scanners as actionable items for the current repository.

Since the repository does not contain the actual database schema or validation logic required to execute these placeholders, the solution was to rephrase the comments (e.g., from `TODO: await setupTestDb();` to `Replace with your DB setup logic`).

This resolves the false positive issues while keeping the template fully functional and clear for future users. Type-checking and tests confirm the template syntax remains valid.

---
*PR created automatically by Jules for task [14802960488270029263](https://jules.google.com/task/14802960488270029263) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes `TODO:` prefixes from comments in a test template file to prevent issue trackers from flagging them as actionable items. The comments are rephrased to use more explicit guidance (e.g., "Replace with your DB setup logic") while maintaining the template's clarity and functionality for developers who will copy and customize it.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `templates/testing/field-validation.test.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->