### PR TITLE
🧪 [testing improvement] Add missing edge case tests for compute_opportunity_score

### DIFF
--- a/penny-sovereign-yield-scout/tests/test_yield_scraper_cli.py
+++ b/penny-sovereign-yield-scout/tests/test_yield_scraper_cli.py
@@ -21,6 +21,10 @@ def test_compute_opportunity_score():
     assert compute_opportunity_score(-5, 1000, "none", 1) == 0.0
     assert compute_opportunity_score(10, 0, "none", 1) == 0.0
     assert compute_opportunity_score(10, -100, "none", 1) == 0.0
+    assert compute_opportunity_score(0, 0, "none", 1) == 0.0
+    assert compute_opportunity_score(-1, -1, "none", 1) == 0.0
+    assert compute_opportunity_score(0, -1, "none", 1) == 0.0
+    assert compute_opportunity_score(-1, 0, "none", 1) == 0.0
 
     # Varying risk levels
     score_high_risk = compute_opportunity_score(apy=10.0, tvl_usd=100_000, il_risk="high", tier=3)


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap in `compute_opportunity_score` within `yield_scraper_cli.py`. Previously, the code handled the condition `if apy <= 0 or tvl_usd <= 0:` by returning `0.0`. The test suite verified individual `<= 0` scenarios for `apy` and `tvl_usd` independently, but didn't verify when *both* parameters were zero or negative.

📊 **Coverage:** Added four missing test scenarios in `test_compute_opportunity_score`:
* Both parameters exactly zero: `(0, 0)`
* Both parameters negative: `(-1, -1)`
* One zero, one negative: `(0, -1)`
* One negative, one zero: `(-1, 0)`

✨ **Result:** Improved test reliability by ensuring the `compute_opportunity_score` fallback logic correctly handles all combinations of missing or negative core input metrics, maintaining high statement and branch coverage in the target module.

---
*PR created automatically by Jules for task [11407425860538596805](https://jules.google.com/task/11407425860538596805) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds four missing edge case tests for the `compute_opportunity_score` function to verify that it correctly returns `0.0` when both `apy` and `tvl_usd` parameters are zero or negative simultaneously. The new test cases cover all combinations of zero and negative values for both parameters, addressing a gap in the existing test suite that only verified these conditions independently.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `penny-sovereign-yield-scout/tests/test_yield_scraper_cli.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->