### PR TITLE
🧪 Add testing for OpenRouter failure handling in run-human-testing-api

### DIFF
--- a/scripts/run-human-testing-api.js
+++ b/scripts/run-human-testing-api.js
@@ -349,7 +349,11 @@ async function main() {
   console.log(`   ${document.length.toLocaleString()} characters`);
 }
 
+if (require.main === module) {
 main().catch((err) => {
   console.error("Fatal error:", err);
   process.exit(1);
 });
+}
+
+if (typeof module !== "undefined" && module.exports) { module.exports = { main, callOpenRouter }; }

--- a/tests/scripts/run-human-testing-api.test.js
+++ b/tests/scripts/run-human-testing-api.test.js
@@ -1,0 +1,164 @@
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+
+const testOutputPath = path.join(__dirname, "test-output.md");
+process.env.OPENROUTER_API_KEY = "test-key";
+process.env.TARGET_URL = "https://example.com";
+process.env.OUTPUT_FILE = testOutputPath;
+process.env.APP_NAME = "Test App";
+
+const script = require("../../scripts/run-human-testing-api.js");
+
+async function runTests() {
+  console.log("Running run-human-testing-api tests...");
+  let failed = false;
+
+  const originalRequest = https.request;
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  try {
+    let requestCount = 0;
+    https.request = function (options, callback) {
+      requestCount++;
+      const req = {
+        _events: {},
+        on: function(event, cb) {
+            this._events[event] = cb;
+        },
+        emit: function(event, ...args) {
+            if (this._events[event]) {
+                this._events[event](...args);
+            }
+        },
+        end: () => {},
+        write: () => {},
+      };
+
+      if (requestCount === 1) {
+        // Agent 1 fails with a network error
+        process.nextTick(() => {
+          req.emit('error', new Error("Simulated network failure"));
+        });
+      } else {
+        process.nextTick(() => {
+          const res = {
+            on: (event, cb) => {
+              if (event === "data") cb(Buffer.from(JSON.stringify({ choices: [{ message: { content: "Agent success" } }] })));
+              if (event === "end") cb();
+            },
+          };
+          callback(res);
+        });
+      }
+
+      return req;
+    };
+
+    console.log("  Testing agent failure handling...");
+
+    let warnings = [];
+    console.log = () => {};
+    console.warn = (msg) => { warnings.push(msg); };
+    console.error = () => {};
+
+    await script.main();
+
+    // Restore output temporarily
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+
+    assert(warnings.some(w => w.includes("Failed: Simulated network failure")), "Should log warning about agent failure");
+    console.log("  ✅ Agent failure handling test passed.");
+
+  } catch (err) {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.error("  ❌ Test failed:", err);
+    failed = true;
+  } finally {
+    https.request = originalRequest;
+    if (fs.existsSync(testOutputPath)) fs.unlinkSync(testOutputPath);
+  }
+
+  try {
+    let requestCount = 0;
+    https.request = function (options, callback) {
+      requestCount++;
+      const req = {
+        _events: {},
+        on: function(event, cb) {
+            this._events[event] = cb;
+        },
+        emit: function(event, ...args) {
+            if (this._events[event]) {
+                this._events[event](...args);
+            }
+        },
+        end: () => {},
+        write: () => {},
+      };
+
+      if (requestCount <= 5) {
+        // All agents succeed
+        process.nextTick(() => {
+          const res = {
+            on: (event, cb) => {
+              if (event === "data") cb(Buffer.from(JSON.stringify({ choices: [{ message: { content: "Agent success" } }] })));
+              if (event === "end") cb();
+            },
+          };
+          callback(res);
+        });
+      } else {
+        // Synthesizer fails with network error
+        process.nextTick(() => {
+          req.emit('error', new Error("Synthesizer network failure"));
+        });
+      }
+
+      return req;
+    };
+
+    console.log("  Testing synthesizer failure handling...");
+
+    let errors = [];
+    console.log = () => {};
+    console.warn = () => {};
+    console.error = (msg) => { errors.push(msg); };
+
+    await script.main();
+
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+
+    const output = fs.readFileSync(testOutputPath, "utf8");
+    assert(errors.some(e => e.includes("Synthesis failed: Synthesizer network failure")), "Should log synthesis failure");
+    assert(output.includes("Agent success"), "Should contain raw reports as fallback");
+    console.log("  ✅ Synthesizer failure handling test passed.");
+
+  } catch (err) {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.error("  ❌ Test failed:", err);
+    failed = true;
+  } finally {
+    https.request = originalRequest;
+    if (fs.existsSync(testOutputPath)) fs.unlinkSync(testOutputPath);
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  runTests().catch(err => { console.error(err); process.exit(1); });
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests covering the error handling logic in `scripts/run-human-testing-api.js` for when an OpenRouter API call fails.

📊 **Coverage:** This PR adds two test cases:
1. Simulating a network error for one of the S.H.I.F.T. agents to verify that the `catch` block correctly captures the error, outputs a warning, and creates a fallback failure record instead of aborting the entire process.
2. Simulating a network error for the synthesizer step to verify it correctly captures the synthesis failure and gracefully falls back to generating a raw report comprising the individual agent findings.

✨ **Result:** The test suite now explicitly covers error paths during external API communication, increasing the codebase's reliability and ensuring proper degraded-state fallback behavior is maintained during future refactoring.

---
*PR created automatically by Jules for task [9531447826713102096](https://jules.google.com/task/9531447826713102096) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds unit tests for error handling in the `run-human-testing-api.js` script, specifically testing failure scenarios when OpenRouter API calls fail. The changes include making the script testable by exporting its main functions and adding two test cases: one simulating network errors during S.H.I.F.T. agent execution (verifying graceful fallback with warning logs), and another simulating synthesizer failures (verifying fallback to raw reports). This improves test coverage for error paths and ensures degraded-state behavior works correctly.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/run-human-testing-api.js` |
| 2 | `tests/scripts/run-human-testing-api.test.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->