### PR TITLE
chore: replace TODOs with INSTRUCTIONs in ui-db-map template

### DIFF
--- a/templates/testing/ui-db-map.test.ts
+++ b/templates/testing/ui-db-map.test.ts
@@ -42,7 +42,7 @@ vi.mock('@/db', () => ({
 
 const MOCK_TABLE_NAME_ROW = {
   id: 1,
-  // Replace with your actual field names and types
+  // INSTRUCTION: Replace with your actual field names and types
   '[FIELD_NAME_1]': '[mock value]',
   '[FIELD_NAME_2]': 42,
   '[FIELD_NAME_3]': true,
@@ -52,7 +52,7 @@ const MOCK_TABLE_NAME_ROW = {
 
 describe('[ROUTER_NAME] router — UI/DB shape validation', () => {
   beforeAll(async () => {
-    // TODO: Set up test environment (e.g., mock auth context)
+    // INSTRUCTION: Set up test environment (e.g., mock auth context)
     // vi.mock('@/auth', () => ({
     //   auth: vi.fn().mockResolvedValue({ userId: 'test-user-1' }),
     // }));
@@ -60,7 +60,7 @@ describe('[ROUTER_NAME] router — UI/DB shape validation', () => {
   });
 
   afterAll(async () => {
-    // TODO: Clean up
+    // INSTRUCTION: Clean up
     // vi.restoreAllMocks();
     // vi.unstubAllEnvs();
   });
@@ -91,7 +91,7 @@ describe('[ROUTER_NAME] router — UI/DB shape validation', () => {
       expect(row).toHaveProperty('id');
       expect(typeof row.id).toBe('number');
 
-      // TODO: Add assertions for each field your UI components use
+      // INSTRUCTION: Add assertions for each field your UI components use
       expect(row).toHaveProperty('[FIELD_NAME_1]');
       expect(typeof row['[FIELD_NAME_1]']).toBe('string');
 
@@ -109,7 +109,7 @@ describe('[ROUTER_NAME] router — UI/DB shape validation', () => {
     });
 
     it('should return an empty array when no records exist', async () => {
-      // TODO: Replace with your actual mock setup and caller
+      // INSTRUCTION: Replace with your actual mock setup and caller
       // const { db } = await import('@/db');
       // vi.mocked(db.query.[TABLE_NAME].findMany).mockResolvedValue([]);
 


### PR DESCRIPTION
This prevents automated issue scanners from creating false-positive tasks for placeholders intended for end users.

---
*PR created automatically by Jules for task [925687834330365452](https://jules.google.com/task/925687834330365452) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR replaces all `TODO` comments with `INSTRUCTION` comments in the ui-db-map test template. This change prevents automated issue scanners from mistakenly creating tasks for placeholder comments that are meant to guide end users who copy this template, rather than being actual tasks for the codebase maintainers.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `templates/testing/ui-db-map.test.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->