### PR TITLE
fix(templates): uncomment cleanup logic in ui-db-map template

### DIFF
--- a/templates/testing/ui-db-map.test.ts
+++ b/templates/testing/ui-db-map.test.ts
@@ -61,8 +61,8 @@ describe('[ROUTER_NAME] router — UI/DB shape validation', () => {
 
   afterAll(async () => {
     // INSTRUCTION: Clean up
-    // vi.restoreAllMocks();
-    // vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Uncomments `vi.restoreAllMocks()` and `vi.unstubAllEnvs()` in the `afterAll` block of `templates/testing/ui-db-map.test.ts`. This provides functional cleanup by default for users copying the template.

Verified with:
- Visual check of the file content.
- TypeScript syntax check (tsc).
- Running the test file using Vitest.

---
*PR created automatically by Jules for task [15671035669434512730](https://jules.google.com/task/15671035669434512730) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR uncomments two cleanup function calls (`vi.restoreAllMocks()` and `vi.unstubAllEnvs()`) in the `afterAll` block of a test template file, enabling proper test cleanup by default for users who copy this template.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `templates/testing/ui-db-map.test.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->