### PR TITLE
🧪 [Add unit tests for render function in blue_ocean_generator]

### DIFF
--- a/penny-sovereign-yield-scout/tests/test_blue_ocean_generator.py
+++ b/penny-sovereign-yield-scout/tests/test_blue_ocean_generator.py
@@ -1,0 +1,50 @@
+import pytest
+import sys
+import os
+
+# Add tools to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../tools')))
+
+from blue_ocean_generator import render
+
+def test_render_standard_replacement():
+    template = "Hello, {{name}}! Welcome to {{place}}."
+    context = {"name": "Alice", "place": "Wonderland"}
+    expected = "Hello, Alice! Welcome to Wonderland."
+    assert render(template, context) == expected
+
+def test_render_multiple_occurrences():
+    template = "{{name}} is here. Yes, {{name}} is really here."
+    context = {"name": "Bob"}
+    expected = "Bob is here. Yes, Bob is really here."
+    assert render(template, context) == expected
+
+def test_render_non_string_values():
+    template = "The port is {{port}} and the score is {{score}}."
+    context = {"port": 8080, "score": 0.95}
+    expected = "The port is 8080 and the score is 0.95."
+    assert render(template, context) == expected
+
+def test_render_missing_context_keys():
+    template = "Hello, {{name}}! How is {{other}}?"
+    context = {"name": "Alice"}
+    expected = "Hello, Alice! How is {{other}}?"
+    assert render(template, context) == expected
+
+def test_render_extra_context_keys():
+    template = "Hello, {{name}}!"
+    context = {"name": "Alice", "unused": "data"}
+    expected = "Hello, Alice!"
+    assert render(template, context) == expected
+
+def test_render_empty_template():
+    template = ""
+    context = {"name": "Alice"}
+    expected = ""
+    assert render(template, context) == expected
+
+def test_render_empty_context():
+    template = "Hello, {{name}}!"
+    context = {}
+    expected = "Hello, {{name}}!"
+    assert render(template, context) == expected


### PR DESCRIPTION
🎯 **What:**
Added unit tests for the `render` function in `penny-sovereign-yield-scout/tools/blue_ocean_generator.py` which was previously untested.

📊 **Coverage:**
The following scenarios are now covered:
- Standard template replacement with multiple keys.
- Multiple occurrences of the same key in a template.
- Replacement with non-string values (integers, floats).
- Template with keys not present in the context.
- Context with keys not present in the template.
- Empty template and empty context scenarios.

✨ **Result:**
Improved test coverage for the core template rendering utility, ensuring that scaffold generation remains reliable across different input types and edge cases. Total 7 new test cases added and verified passing.

---
*PR created automatically by Jules for task [462648659912369161](https://jules.google.com/task/462648659912369161) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive unit tests for the `render` function in the blue ocean generator module. The tests cover standard template replacement, multiple key occurrences, non-string value handling, missing and extra context keys, and edge cases like empty templates and contexts. This improves test coverage for a previously untested template rendering utility.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `penny-sovereign-yield-scout/tests/test_blue_ocean_generator.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->