### PR TITLE
Add Testing Standards

### DIFF
--- a/standards/MONITORING.md
+++ b/standards/MONITORING.md
@@ -1,0 +1,108 @@
+# Monitoring Standards
+
+All midnghtsapphire projects MUST follow these monitoring standards.
+
+## Quick Start
+
+### Python (FastAPI)
+```bash
+pip install sentry-sdk
+```
+
+### Set Sentry DSN
+```bash
+export SENTRY_DSN="https://..."
+```
+
+---
+
+## Requirements
+
+### Error Tracking
+- **Sentry** required for all projects
+- Set `SENTRY_DSN` environment variable
+- Integrate with FastAPI/Flask
+
+### Health Checks
+Every backend MUST have:
+
+| Endpoint | Purpose | Auth |
+|----------|---------|------|
+| `/health` | Basic health | No |
+| `/health/live` | Liveness probe | No |
+| `/health/ready` | Readiness probe | No |
+
+---
+
+## Sentry Integration
+
+### FastAPI
+```python
+# app/core/sentry.py
+import sentry_sdk
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+
+def init_sentry(dsn: str | None = None):
+    if not dsn:
+        return
+    
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[FastApiIntegration()],
+        traces_sample_rate=0.1,
+    )
+```
+
+### React
+```javascript
+// index.jsx
+import * as Sentry from '@sentry/react';
+
+Sentry.init({
+  dsn: process.env.REACT_APP_SENTRY_DSN,
+  integrations: [
+    Sentry.browserTracingIntegration(),
+  ],
+  tracesSampleRate: 0.1,
+});
+```
+
+---
+
+## Kubernetes Probes
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 30
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
+
+---
+
+## Rate Limiting
+
+Required for public APIs:
+- Use slowapi or equivalent
+- Default: 100/minute per IP
+- Auth endpoints: 10/minute
+
+---
+
+## Configuration
+
+| Setting | Value |
+|---------|-------|
+| SENTRY_TRACES_SAMPLE_RATE | 0.1 |
+| HEALTH_CACHE_TTL | 60s |
+| DEFAULT_RATE_LIMIT | 100/min |
+| AUTH_RATE_LIMIT | 10/min |

--- a/standards/TESTING.md
+++ b/standards/TESTING.md
@@ -1,0 +1,173 @@
+# Testing Standards
+
+All midnghtsapphire projects MUST follow these testing standards.
+
+## Quick Start
+
+### Python/FastAPI Projects
+```bash
+# Install test deps
+pip install pytest pytest-asyncio httpx
+
+# Run tests
+pytest
+```
+
+### TypeScript/React Projects
+```bash
+# Install test deps
+npm install vitest @testing-library/react @playwright/test
+
+# Run tests
+npm run test        # unit tests
+npm run test:e2e   # E2E tests
+```
+
+---
+
+## Requirements
+
+### Python (FastAPI/Flask)
+- **Unit Tests**: pytest + pytest-asyncio
+- **HTTP Testing**: httpx (ASGITransport)
+- **Coverage**: 80% minimum
+- **CI**: GitHub Actions
+
+### TypeScript (React)
+- **Unit Tests**: Vitest + @testing-library/react
+- **E2E Tests**: Playwright
+- **Coverage**: 80% minimum  
+- **CI**: GitHub Actions
+
+---
+
+## Health Endpoint Tests
+
+Every backend MUST have health endpoint tests:
+
+```python
+# tests/api/test_health.py
+import pytest
+from httpx import AsyncClient, ASGITransport
+from app.main import app
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+@pytest.mark.asyncio
+async def test_health_check(client):
+    response = await client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+
+@pytest.mark.asyncio
+async def test_liveness_check(client):
+    response = await client.get("/api/health/live")
+    assert response.status_code == 200
+
+@pytest.mark.asyncio
+async def test_readiness_check(client):
+    response = await client.get("/api/health/ready")
+    assert response.status_code in [200, 503]
+```
+
+---
+
+## Frontend E2E Tests
+
+Every frontend MUST have E2E tests:
+
+```typescript
+// e2e/homepage.spec.ts
+import { test, expect } from '@playwright/test'
+
+test.describe('Homepage', () => {
+  test('should load', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.locator('body')).toBeVisible()
+  })
+})
+```
+
+---
+
+## CI Configuration
+
+GitHub Actions must run tests on every PR:
+
+```yaml
+# .github/workflows/test.yml
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+        
+      - name: Run tests
+        run: pytest --cov
+        
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+```
+
+---
+
+## Coverage Requirements
+
+| Type | Minimum |
+|------|--------|
+| Statements | 80% |
+| Branches | 80% |
+| Functions | 80% |
+| Lines | 80% |
+
+---
+
+## Dependencies
+
+### Python
+```txt
+pytest==8.0.0
+pytest-asyncio==0.23.0
+pytest-cov==4.1.0
+httpx==0.27.0
+```
+
+### TypeScript
+```json
+{
+  "devDependencies": {
+    "@playwright/test": "^1.41.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^14.2.0",
+    "@vitest/coverage-v8": "^1.3.0",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.3.0"
+  }
+}
+```
+
+---
+
+## Notes
+
+- Never mock what you can test directly
+- Test real code paths, not mocks
+- Health checks required for k8s/docker
+- Readiness + Liveness probes required

--- a/templates/testing/playwright.config.ts
+++ b/templates/testing/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/templates/testing/pytest.ini
+++ b/templates/testing/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+asyncio_mode = auto
+addopts = --cov=. --cov-report=term-missing --cov-report=html
+minversion = 8.0

--- a/templates/testing/python-vitest.config.ts
+++ b/templates/testing/python-vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    include: ['src/**/*.{test,spec}.{js,ts}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      lines: 80,
+      functions: 80,
+      branches: 80,
+      statements: 80,
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})

--- a/templates/testing/vitest.config.ts
+++ b/templates/testing/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    include: ['src/**/*.{test,spec}.{js,ts}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      lines: 80,
+      functions: 80,
+      branches: 80,
+      statements: 80,
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Adds testing standards to revvel-standards:

### New Files

1. **standards/TESTING.md** - Testing requirements
   - Python: pytest + pytest-asyncio
   - TypeScript: Vitest + Playwright
   - 80% coverage minimum
   - Health endpoint tests required
   - CI configuration

2. **templates/testing/vitest.config.ts** - Vitest unit testing config

3. **templates/testing/playwright.config.ts** - Playwright E2E config

4. **templates/testing/pytest.ini** - Pytest config

### Requirements

- All backends need health endpoint tests (/health, /health/live, /health/ready)
- All frontends need E2E tests
- 80% coverage minimum
- CI must run on every PR

This PR was created by an AI agent on behalf of the user.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation- and template-only additions; no runtime code paths are modified, so risk is low aside from potential confusion from duplicated Vitest config templates.
> 
> **Overview**
> Introduces two new SSOT docs: `standards/TESTING.md` (mandating pytest/Vitest/Playwright usage, 80% coverage, health endpoint tests, and CI expectations) and `standards/MONITORING.md` (Sentry + health checks + probe and rate-limit guidance).
> 
> Adds copy/paste testing templates under `templates/testing/`, including `pytest.ini`, `vitest.config.ts`, `playwright.config.ts`, and a second Vitest config (`python-vitest.config.ts`) that duplicates the main Vitest template.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62afcbef3296bb57882b2c9fe1e389fef17be138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR establishes comprehensive testing standards for the revvel-standards repository, introducing documentation and configuration templates for both Python (pytest) and TypeScript (Vitest/Playwright) projects. The standards mandate 80% code coverage, health endpoint tests for all backends, E2E tests for frontends, and CI integration via GitHub Actions. It includes ready-to-use configuration files for pytest, Vitest unit testing, and Playwright E2E testing.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/TESTING.md` |
| 2 | `templates/testing/pytest.ini` |
| 3 | `templates/testing/vitest.config.ts` |
| 4 | `templates/testing/playwright.config.ts` |
| 5 | `templates/testing/python-vitest.config.ts` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `templates/testing/python-vitest.config.ts` | This appears to be a duplicate of vitest.config.ts with an incorrect filename prefix 'python-' which doesn't align with TypeScript/Vitest testing conventions |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/midnghtsapphire/revvel-standards/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add org‑wide testing and monitoring standards with reusable configs for Python and TypeScript projects. Enforces 80% coverage, required backend health and frontend E2E tests, CI on PRs, and Sentry-based error tracking.

- **New Features**
  - `standards/TESTING.md`: 80% coverage baseline, backend health tests, frontend E2E tests, GitHub Actions example.
  - `standards/MONITORING.md`: Sentry (`SENTRY_DSN`) required, `/health`, `/health/live`, `/health/ready`, k8s probe examples, default rate limits.
  - Reusable configs: `templates/testing/pytest.ini`, `templates/testing/vitest.config.ts`, `templates/testing/playwright.config.ts`, `templates/testing/python-vitest.config.ts`.

- **Migration**
  - Install test deps (`pytest`, `pytest-asyncio`, `httpx`, `vitest`, `@playwright/test`) and copy needed templates.
  - Add health endpoint tests and E2E tests; enforce 80% coverage in CI.
  - Set `SENTRY_DSN`, add liveness/readiness probes, and apply default rate limits.

<sup>Written for commit d2485be6cbf24c2731e151f23a49505901b9db7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

