### PR TITLE
standard(RVS-AGENT-001): Comment, Don't Delete — Agent Audit Trail

### DIFF
--- a/standards/COMMENT-DONT-DELETE.md
+++ b/standards/COMMENT-DONT-DELETE.md
@@ -1,0 +1,261 @@
+# Standard: Comment, Don't Delete — Agent Audit Trail
+
+**Standard ID:** RVS-AGENT-001  
+**Status:** ACTIVE  
+**Author:** Audrey Evans (@midnghtsapphire)  
+**Created:** 2026-05-06  
+**Last updated:** 2026-05-06  
+**Applies to:** All Revvel repos — all agents (OpenHands, Copilot, SWE-agent, Cursor, any LLM-powered tool)
+
+---
+
+## The Rule
+
+**Agents MUST NOT delete code. They MUST comment it out.**
+
+Every removal, replacement, or disabling of existing code by any agent or human contributor must be preserved in-place as a structured comment block. This is non-negotiable across all Revvel repositories.
+
+---
+
+## Why
+
+Agents — especially OpenHands — have a pattern of commenting out or deleting code silently to get a build to pass or a test to merge. Without a record, this creates:
+
+- Lost context on why something was tried
+- No way to know which tool failed and why
+- No audit trail for debugging regressions
+- No metrics on agent reliability by tool/model
+- No signal for when to jump in manually
+
+Commented-out code with a structured header turns every agent action into a **reviewable, queryable audit log** embedded directly in the codebase.
+
+---
+
+## Required Comment Format
+
+Every commented-out block must include a structured header. Templates by language:
+
+### TypeScript / JavaScript
+
+```typescript
+// ============================================================
+// REVVEL-DISABLED
+// Author:      <agent-name or github-username>
+// Date:        YYYY-MM-DD
+// WR / Issue:  #<issue-number> (link if available)
+// Tool:        <OpenHands | Copilot | SWE-agent | Cursor | Human>
+// Model:       <claude-3.7-sonnet | gpt-5.2 | deepseek-v3.2 | etc>
+// Reason:      <why this was disabled — be specific>
+// Status:      <FAILED | BYPASSED | REPLACED | PENDING-REVIEW>
+// Replaced by: <what replaced it, or "nothing yet">
+// ============================================================
+// <original code here, indented one level>
+// ============================================================
+```
+
+### Python
+
+```python
+# ============================================================
+# REVVEL-DISABLED
+# Author:      <agent-name or github-username>
+# Date:        YYYY-MM-DD
+# WR / Issue:  #<issue-number>
+# Tool:        <OpenHands | Copilot | SWE-agent | Cursor | Human>
+# Model:       <model-name>
+# Reason:      <specific reason>
+# Status:      <FAILED | BYPASSED | REPLACED | PENDING-REVIEW>
+# Replaced by: <replacement or "nothing yet">
+# ============================================================
+# <original code>
+# ============================================================
+```
+
+### CSS / SCSS
+
+```css
+/* ============================================================
+   REVVEL-DISABLED
+   Author:      <agent or username>
+   Date:        YYYY-MM-DD
+   WR / Issue:  #<number>
+   Tool:        <tool>
+   Model:       <model>
+   Reason:      <reason>
+   Status:      <FAILED | BYPASSED | REPLACED | PENDING-REVIEW>
+   Replaced by: <replacement or "nothing yet">
+   ============================================================
+   <original css>
+   ============================================================ */
+```
+
+### YAML / GitHub Actions
+
+```yaml
+# ============================================================
+# REVVEL-DISABLED
+# Author:      <agent or username>
+# Date:        YYYY-MM-DD
+# WR / Issue:  #<number>
+# Tool:        <tool>
+# Model:       <model>
+# Reason:      <reason>
+# Status:      <FAILED | BYPASSED | REPLACED | PENDING-REVIEW>
+# Replaced by: <replacement or "nothing yet">
+# ============================================================
+# <original yaml lines>
+# ============================================================
+```
+
+### JSON (use a `_disabled` key wrapper — JSON has no comments)
+
+```json
+{
+  "_REVVEL_DISABLED": {
+    "author": "<agent or username>",
+    "date": "YYYY-MM-DD",
+    "wr_issue": "#<number>",
+    "tool": "<tool>",
+    "model": "<model>",
+    "reason": "<reason>",
+    "status": "FAILED | BYPASSED | REPLACED | PENDING-REVIEW",
+    "replaced_by": "<replacement or null>",
+    "original": { }
+  }
+}
+```
+
+---
+
+## Status Values
+
+| Status | Meaning |
+|---|---|
+| `FAILED` | Agent tried this, it didn't work — specific error in Reason |
+| `BYPASSED` | Commented out to unblock a merge, needs proper fix |
+| `REPLACED` | Superseded by the code immediately below/above this block |
+| `PENDING-REVIEW` | Human needs to evaluate before deciding to keep or delete |
+
+---
+
+## Real Example
+
+Before (what OpenHands was doing — silent removal):
+
+```typescript
+// (nothing — the original auth middleware just vanished)
+export const authenticate = async (req, res, next) => {
+  // new simplified version
+  next();
+};
+```
+
+After (what this standard requires):
+
+```typescript
+// ============================================================
+// REVVEL-DISABLED
+// Author:      openhands-agent
+// Date:        2026-05-06
+// WR / Issue:  #4821
+// Tool:        OpenHands
+// Model:       claude-3.7-sonnet
+// Reason:      JWT verify was throwing "invalid signature" on all requests.
+//              Root cause unknown. Commented out to unblock PR merge.
+//              Full auth bypassed — NOT SAFE FOR PRODUCTION.
+// Status:      BYPASSED
+// Replaced by: Passthrough stub below — needs real fix
+// ============================================================
+// export const authenticate = async (req, res, next) => {
+//   const token = req.headers.authorization?.split(' ')[1];
+//   if (!token) return res.status(401).json({ error: 'No token' });
+//   const payload = jwt.verify(token, process.env.JWT_SECRET);
+//   req.user = payload;
+//   next();
+// };
+// ============================================================
+
+// STUB — replace with fixed auth above after root cause found
+export const authenticate = async (req, res, next) => {
+  next();
+};
+```
+
+Now you know: what broke, which agent did it, which model, which WR, and that production auth is bypassed.
+
+---
+
+## Enforcement
+
+### Pre-commit hook (local)
+
+Add to `.pre-commit-config.yaml`:
+
+```yaml
+- repo: local
+  hooks:
+    - id: revvel-no-silent-delete
+      name: Check for REVVEL-DISABLED headers on commented blocks
+      language: python
+      entry: python scripts/check-revvel-disabled.py
+      types: [text]
+      exclude: '^(node_modules|dist|build|\.git)/'
+```
+
+### PR review check (GitHub Actions)
+
+See `standards/audit-trail-check.yml` — the workflow scans the PR diff for large comment blocks missing a `REVVEL-DISABLED` header and posts a warning comment.
+
+### Agent instruction injection
+
+Add to `.openhands/microagent/repo.md` and to any Cursor rules / Copilot instructions file:
+
+```
+CRITICAL: Never delete existing code. If you must disable, comment it out with a
+REVVEL-DISABLED header block. Include: your agent name, date, WR/issue number,
+your model name, specific reason it was disabled, and status (FAILED/BYPASSED/REPLACED).
+See standards/COMMENT-DONT-DELETE.md for the required format.
+```
+
+---
+
+## Metrics This Enables
+
+Because every disabled block has a structured header, you can now query the codebase as a database:
+
+```bash
+# How many things did OpenHands bypass this month?
+grep -r 'Tool:.*OpenHands' . | grep 'Status:.*BYPASSED' | wc -l
+
+# What did claude-3.7-sonnet fail at?
+grep -r 'Model:.*claude-3.7-sonnet' . -A5 | grep 'Reason:'
+
+# Everything still pending human review
+grep -r 'Status:.*PENDING-REVIEW' . --include='*.ts' -l
+
+# Full audit trail for a specific WR
+grep -r 'WR / Issue:.*#4821' . -A20
+```
+
+This gives you agent performance metrics, failure pattern analysis, and a full audit trail — all from `grep`.
+
+---
+
+## Cleanup
+
+Disabled blocks are **not permanent**. Once the issue is resolved:
+
+1. If the fix is confirmed working → delete the `REVVEL-DISABLED` block entirely
+2. If the disabled code is permanently replaced → delete the block, note in PR description
+3. If still unresolved after 30 days → flag as `PENDING-REVIEW` and open a new WR
+
+**Never leave a `BYPASSED` block in production without a follow-up WR tracking the real fix.**
+
+---
+
+## Related Standards
+
+- `standards/AGENT-ROUTING.md` — which agent gets which task
+- `standards/WR-TEMPLATE.md` — work request format
+- `AGENT-DEPLOY-ONEFILE_Guardrails.md` — agent guardrails (root-level)
+- `.openhands/microagent/repo.md` — OpenHands-specific instructions

--- a/standards/audit-trail-check.yml
+++ b/standards/audit-trail-check.yml
@@ -1,0 +1,111 @@
+# GitHub Actions: Audit Trail Enforcement
+# Checks PRs for commented-out code blocks missing REVVEL-DISABLED headers
+# Intended location: .github/workflows/audit-trail-check.yml
+# Copy this file there to activate enforcement.
+#
+# Standard: RVS-AGENT-001
+# See: standards/COMMENT-DONT-DELETE.md
+
+name: Revvel Audit Trail Check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  check-disabled-headers:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get PR diff
+        run: |
+          git diff origin/${{ github.base_ref }}...HEAD > /tmp/pr.diff
+
+      - name: Check for bare comment-out blocks without REVVEL-DISABLED header
+        id: audit_check
+        run: |
+          python3 << 'EOF'
+          import re, sys
+
+          with open('/tmp/pr.diff', 'r', errors='replace') as f:
+              diff = f.read()
+
+          added_lines = [l[1:] for l in diff.split('\n') if l.startswith('+') and not l.startswith('++')]
+
+          violations = []
+          consec = 0
+          block_start = 0
+
+          for i, line in enumerate(added_lines):
+              stripped = line.strip()
+              is_comment = (
+                  stripped.startswith('// ') or
+                  stripped.startswith('# ') or
+                  stripped.startswith('* ') or
+                  stripped == '//' or stripped == '#'
+              )
+              if is_comment:
+                  if consec == 0:
+                      block_start = i
+                  consec += 1
+              else:
+                  if consec >= 3:
+                      context = added_lines[max(0, block_start-5):block_start+consec]
+                      if not any('REVVEL-DISABLED' in l for l in context):
+                          violations.append(f'Line ~{block_start}: {consec} consecutive commented lines without REVVEL-DISABLED header')
+                  consec = 0
+
+          if violations:
+              with open('/tmp/violations.txt', 'w') as f:
+                  f.write('\n'.join(violations))
+              print('AUDIT_FAIL=true')
+              sys.exit(1)
+          else:
+              print('AUDIT_PASS=true')
+          EOF
+
+      - name: Comment on PR if violations found
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let violations = '';
+            try { violations = fs.readFileSync('/tmp/violations.txt', 'utf8'); } catch(e) { violations = 'See workflow logs'; }
+
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `⚠️ **Audit Trail Violation — Missing REVVEL-DISABLED Headers**
+
+This PR contains commented-out code blocks without a structured \`REVVEL-DISABLED\` header.
+
+**Violations found:**
+\`\`\`
+${violations}
+\`\`\`
+
+**Required format** per [RVS-AGENT-001](../blob/main/standards/COMMENT-DONT-DELETE.md):
+\`\`\`
+// ============================================================
+// REVVEL-DISABLED
+// Author:      <agent or username>
+// Date:        YYYY-MM-DD
+// WR / Issue:  #<number>
+// Tool:        <OpenHands | Copilot | SWE-agent | Cursor | Human>
+// Model:       <model-name>
+// Reason:      <specific reason this was disabled>
+// Status:      <FAILED | BYPASSED | REPLACED | PENDING-REVIEW>
+// Replaced by: <replacement or "nothing yet">
+// ============================================================
+\`\`\`
+
+Update all commented-out blocks with the required header before this PR can merge.`
+            });


### PR DESCRIPTION
## Summary

Adds **RVS-AGENT-001** — the official Revvel standard requiring agents to comment out code (never delete) with a structured `REVVEL-DISABLED` header.

## Problem

OpenHands and other agents were silently deleting or commenting out code to get builds to pass/merge — with zero record of what was removed, why, which model did it, or which WR it was for. This made debugging regressions and tracking agent reliability impossible.

## What's added

### `standards/COMMENT-DONT-DELETE.md`
- Full standard (RVS-AGENT-001) with rationale
- Required `REVVEL-DISABLED` comment block format for: TypeScript/JS, Python, CSS/SCSS, YAML, JSON
- Status values: `FAILED | BYPASSED | REPLACED | PENDING-REVIEW`
- Real before/after example showing an auth bypass that was silently removed
- Enforcement instructions: pre-commit hook + agent prompt injection
- `grep`-based metrics queries built into the standard
- Cleanup policy (disabled blocks are not permanent)

### `standards/audit-trail-check.yml`
- GitHub Actions workflow (copy to `.github/workflows/` to activate)
- Scans PR diff for 3+ consecutive commented lines missing `REVVEL-DISABLED` header
- Posts a detailed comment on the PR listing each violation with the required format

## Next steps after merge
- Add the agent instruction snippet to `.openhands/microagent/repo.md`
- Copy `standards/audit-trail-check.yml` → `.github/workflows/audit-trail-check.yml` to enforce on all PRs
- Add to `.cursorrules` and any Copilot instructions file

## Standard ID
`RVS-AGENT-001`

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces **RVS-AGENT-001**, a new organizational standard requiring AI agents and contributors to comment out code with structured `REVVEL-DISABLED` headers instead of silently deleting it. The standard provides language-specific templates for TypeScript, Python, CSS, YAML, and JSON, requiring metadata like author, date, tool/model used, reason for disabling, and status (FAILED/BYPASSED/REPLACED/PENDING-REVIEW). It also includes a GitHub Actions workflow that enforces this policy by scanning PR diffs for consecutive commented lines missing the required header and posting violation warnings.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/COMMENT-DONT-DELETE.md` |
| 2 | `standards/audit-trail-check.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds documentation and an optional GitHub Actions workflow template without changing runtime code paths. Main risk is process noise/false positives if the workflow is enabled as-is.
> 
> **Overview**
> Introduces **RVS-AGENT-001** via `standards/COMMENT-DONT-DELETE.md`, defining a required `REVVEL-DISABLED` header format (with status semantics and examples) for any code agents/humans disable instead of deleting.
> 
> Adds `standards/audit-trail-check.yml`, a GitHub Actions workflow *template* that scans PR-added lines for 3+ consecutive commented lines lacking a nearby `REVVEL-DISABLED` header and, on failure, posts a warning comment listing violations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aee959628614a540935d5df6087d7bc632748d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RVS-AGENT-001 requiring code to be commented, not deleted, using a `REVVEL-DISABLED` header to create a clear audit trail. Includes a GitHub Actions workflow that flags large commented blocks in PRs when the header is missing.

- **New Features**
  - `standards/COMMENT-DONT-DELETE.md`: Required `REVVEL-DISABLED` header format for TS/JS, Python, CSS/SCSS, YAML, JSON; status values; example; enforcement guidance and queries; cleanup policy.
  - `standards/audit-trail-check.yml`: Scans PR diffs for 3+ consecutive commented lines without the header and comments on the PR with violations.

- **Migration**
  - Copy `standards/audit-trail-check.yml` to `.github/workflows/audit-trail-check.yml` to enable checks.
  - Add the instruction snippet to `.openhands/microagent/repo.md` and editor rules (e.g., `.cursorrules`, Copilot).

<sup>Written for commit 3aee959628614a540935d5df6087d7bc632748d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

