### PR TITLE
feat(standards): Add AGENT_STACK_SETUP and DELIVERY_MATRIX

### DIFF
--- a/standards/AGENT_STACK_SETUP.md
+++ b/standards/AGENT_STACK_SETUP.md
@@ -1,0 +1,45 @@
+# AI Agent Stack Setup
+
+## What this does
+When you open a WR issue:
+1. **auto-route.yml** reads the body, applies labels (`fix-me`, `swe-fix`, routing profile, model tags), assigns bot.
+2. **openhands-resolver.yml** triggers on `fix-me` → calls OpenRouter (claude-3.7-sonnet → deepseek-v3.2 fallback) → attempts a PR.
+3. **swe-agent.yml** triggers on `swe-fix` → runs SWE-agent with OpenRouter backend → attempts a PR.
+4. **augment-check.yml** checks every new PR for Augment Code review — prompts you to install the App if missing.
+5. If any agent fails, it comments on the issue with a direct workflow log link.
+
+## Setup checklist
+
+### 1. Bot account
+- [ ] Create GitHub account: `yourorg-openrouter-bot`
+- [ ] Enable 2FA on it
+- [ ] Add to this repo with **Write** access
+- [ ] Generate a PAT with `repo` + `workflow` scope on that account
+
+### 2. Repo secrets (Settings → Secrets → Actions)
+| Secret | Value |
+|---|---|
+| `BOT_GITHUB_TOKEN` | PAT from bot account |
+| `OPENROUTER_API_KEY` | Your OpenRouter API key |
+
+### 3. Repo variables (Settings → Variables → Actions)
+| Variable | Value |
+|---|---|
+| `BOT_USERNAME` | e.g. `yourorg-openrouter-bot` |
+
+### 4. Repo Actions permissions (Settings → Actions → General)
+- [x] Read and write permissions
+- [x] Allow GitHub Actions to create and approve pull requests
+
+### 5. Augment Code GitHub App (manual install)
+👉 https://app.augmentcode.com/settings/code-review
+- Click Install GitHub App
+- Select this repo
+- Done — Augment Code will auto-review every PR
+
+## Usage
+Open an issue using the WR template. Everything else is automatic.
+
+## Failure path
+Agent fails → comments on issue with log link → you jump in.
+No silent failures.

--- a/standards/DELIVERY_MATRIX.md
+++ b/standards/DELIVERY_MATRIX.md
@@ -1,0 +1,208 @@
+# Ship to Market: Full Delivery Matrix for AI Agent Stacks
+
+## Overview
+
+Every work request (WR) produces an artifact that needs to ship somewhere. Most agent stacks handle code generation but leave the delivery layer — PDF, API, CLI, video, MCP server, app bundle, marketplace listing — completely unaddressed. This document maps every major output type to the correct toolchain, GitHub workflow trigger, agent action, and failure handoff so that "done" means shipped, not just merged.
+
+---
+
+## The Core Problem
+
+When Copilot, OpenHands, or SWE-agent closes a WR by opening a PR, that PR contains code. What it does not contain is:
+
+- a deployed endpoint,
+- a packaged CLI binary,
+- a rendered PDF or documentation artifact,
+- a published npm/PyPI package,
+- a video demo,
+- a registered MCP server,
+- an app store submission, or
+- a working API with auth and rate limits.
+
+Each of those requires a separate delivery workflow wired to the same WR trigger. The table below maps every output type to what needs to happen after the agent merges code.
+
+---
+
+## Delivery Matrix
+
+| Output type | Trigger label | Agent action | Key toolchain | Auto or manual | Failure signal |
+|---|---|---|---|---|---|
+| **PDF / Report** | `deliver:pdf` | Render markdown/HTML to PDF, attach to PR or release | `pandoc`, `weasyprint`, `puppeteer`, GitHub Release asset | Auto | Missing release asset → comment on PR |
+| **API (REST/GraphQL)** | `deliver:api` | Deploy to cloud, run smoke test, return live URL | Vercel, Railway, Render, Fly.io, AWS Lambda | Auto | Health check fails → comment + block merge |
+| **App (web)** | `deliver:app` | Build bundle, deploy to CDN or hosting, return preview URL | Vercel, Netlify, Cloudflare Pages, Firebase Hosting | Auto | Deploy fails or build errors → comment on PR |
+| **App (mobile)** | `deliver:mobile` | Build iOS/Android, upload to TestFlight / Play internal | Fastlane, Expo EAS, Bitrise | Semi-auto | Build failure → comment, human submits to store |
+| **CLI tool** | `deliver:cli` | Build binary, publish to npm/PyPI/Homebrew, or attach to GitHub Release | `pkg`, `pyinstaller`, `ncc`, `oclif`, npm publish | Auto | Publish fails → comment with error |
+| **npm / PyPI package** | `deliver:package` | Bump version, tag release, publish to registry | `semantic-release`, `release-please`, `twine`, `npm publish` | Auto | Registry auth fails → comment, human publishes |
+| **Video / Demo** | `deliver:video` | Record screen or render from script, upload to YouTube/S3 | `ffmpeg`, `playwright` screen recording, `remotion`, `manim` | Semi-auto | Render fails → comment, human records |
+| **MCP server** | `deliver:mcp` | Package server, register with MCP registry or deploy as endpoint, update manifest | Docker, Fly.io, MCP SDK, `mcp.json` manifest | Auto | Registration fails → comment with manifest diff |
+| **Chrome extension** | `deliver:extension` | Zip, validate manifest, upload to Chrome Web Store draft | `web-ext`, CWS Upload API | Semi-auto | Validation fails → comment with lint output |
+| **VS Code extension** | `deliver:vscode` | Build VSIX, publish to VS Marketplace | `vsce`, `@vscode/vsce` | Auto | Publish fails → comment with VSCE output |
+| **GitHub Action** | `deliver:action` | Tag release, update `action.yml`, publish to GitHub Marketplace | `release-please`, GitHub Release | Auto | Missing `action.yml` → comment |
+| **Docker image** | `deliver:docker` | Build image, push to registry (GHCR, Docker Hub, ECR) | `docker buildx`, `ghcr.io`, `docker push` | Auto | Push fails → comment with build log |
+| **Documentation site** | `deliver:docs` | Build from markdown/JSDoc/OpenAPI spec, deploy to GitHub Pages or Vercel | `docusaurus`, `mintlify`, `nextra`, `mkdocs` | Auto | Build fails or broken links → comment |
+| **OpenAPI spec** | `deliver:openapi` | Generate/validate spec, publish to API gateway or docs | `swagger-ui`, `redoc`, `zod-to-openapi`, `openapi-generator` | Auto | Spec validation errors → comment |
+| **Database migration** | `deliver:migration` | Run migration in staging, validate schema, await human approval for prod | `prisma migrate`, `alembic`, `flyway` | Semi-auto | Migration fails → block deploy, comment |
+| **Marketplace listing** | `deliver:marketplace` | Draft listing copy, screenshots, metadata — human reviews and publishes | Notion/Linear draft, store-specific tools | Manual | N/A — human always reviews before submit |
+
+---
+
+## GitHub Workflow Pattern
+
+Every delivery type follows the same three-step wiring pattern inside `.github/workflows/`:
+
+### Step 1 — Detect label on PR merge
+
+```yaml
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  deliver:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'deliver:api')
+```
+
+### Step 2 — Run delivery action
+
+Each delivery type has its own job. They can be in the same workflow file with different `if` conditions, or split into separate files per output type for clarity.
+
+### Step 3 — Report result to the originating issue
+
+Every delivery job ends with a success or failure comment on the originating issue, not just the PR, so the WR is fully closed or flagged in the place you opened it:
+
+```yaml
+- name: Report delivery result
+  uses: actions/github-script@v7
+  with:
+    script: |
+      const success = process.env.DELIVERY_STATUS === 'success';
+      github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.payload.pull_request.number,
+        body: success
+          ? "✅ **Shipped.** Live URL: " + process.env.DEPLOY_URL
+          : "⚠️ **Delivery failed.** [View logs](" + process.env.LOG_URL + ") — human review needed."
+      });
+```
+
+---
+
+## MCP Server Delivery (Detail)
+
+MCP (Model Context Protocol) is the most underspecified delivery type in most agent stacks. A WR that produces an MCP server needs to:
+
+1. Package the server using the MCP SDK (TypeScript or Python).
+2. Generate or update `mcp.json` with the correct tool manifest, schema, and endpoint.
+3. Deploy to a persistent runtime (Fly.io, Railway, or a Lambda with a public URL).
+4. Register the endpoint with any MCP router or client config in the consuming application.
+5. Run a smoke test: call one tool, verify the response schema.
+6. Comment on the WR with the live endpoint, manifest diff, and tool list.
+
+Label: `deliver:mcp`. If the smoke test fails, the workflow comments on the issue and does not complete the delivery — human jumps in.
+
+---
+
+## PDF / Documentation Delivery (Detail)
+
+For WRs that produce research outputs, specs, or reports:
+
+1. Agent writes output as markdown in `/docs/` or as a PR artifact.
+2. `pandoc` or `puppeteer`/`weasyprint` renders to PDF.
+3. PDF is attached to the GitHub Release for that version, or uploaded as a PR artifact.
+4. A comment on the WR includes a direct download link.
+
+For API documentation specifically, the preferred path is: OpenAPI spec → `redoc` or `swagger-ui` static build → deploy to GitHub Pages or docs subdomain.
+
+---
+
+## Video / Demo Delivery (Detail)
+
+Video is the hardest to fully automate but is achievable for structured demos:
+
+- **Playwright screen recording**: works for web app demos. The agent runs the app in headless Chromium, records the key user flow, and uploads the `.webm` to S3 or GitHub Release.
+- **`remotion` or `manim`**: for programmatic video (code walkthroughs, animated diagrams). The agent writes the script, renders to MP4, uploads.
+- **Manual recording**: if neither works, the workflow comments on the WR with a Loom or OBS recording checklist so the human knows exactly what to record.
+
+Label: `deliver:video`. Failure path: workflow comments with recording checklist + draft YouTube metadata.
+
+---
+
+## Routing Profile to Delivery Type
+
+Most WR routing profiles map naturally to one or more delivery types:
+
+| Routing profile | Most likely delivery types |
+|---|---|
+| `repo_surgery` | `deliver:api`, `deliver:docker`, `deliver:migration` |
+| `cheap_batch_edits` | `deliver:package`, `deliver:docs`, `deliver:openapi` |
+| `hard_debug` | `deliver:api` (re-deploy after fix), `deliver:pdf` (incident report) |
+| New feature | `deliver:app`, `deliver:api`, `deliver:docs`, `deliver:video` |
+| CLI tool | `deliver:cli`, `deliver:package`, `deliver:docs` |
+| MCP integration | `deliver:mcp`, `deliver:docs`, `deliver:openapi` |
+
+---
+
+## Updated WR Template (Delivery Extension)
+
+Add this section to the existing WR template to capture delivery intent at the time the WR is opened, so the agent and workflow know what "done" looks like before they start:
+
+```markdown
+## Delivery targets
+<!-- Check all that apply — these labels will trigger the matching delivery workflows after merge -->
+- [ ] `deliver:api` — deploy live endpoint, return URL
+- [ ] `deliver:app` — deploy web app, return preview URL
+- [ ] `deliver:cli` — publish binary or npm/PyPI package
+- [ ] `deliver:pdf` — render and attach PDF artifact
+- [ ] `deliver:docs` — build and deploy documentation
+- [ ] `deliver:openapi` — publish/update API spec
+- [ ] `deliver:docker` — build and push Docker image
+- [ ] `deliver:mcp` — package and deploy MCP server
+- [ ] `deliver:video` — record or render demo video
+- [ ] `deliver:package` — publish to npm / PyPI / Homebrew
+- [ ] `deliver:extension` — build and upload Chrome / VS Code extension
+- [ ] `deliver:action` — publish GitHub Action to Marketplace
+- [ ] `deliver:marketplace` — draft store listing (human review required)
+- [ ] `deliver:migration` — run and validate database migration
+
+**Definition of done for this WR:**
+<!-- One sentence: what does "shipped" look like? -->
+```
+
+---
+
+## Failure Handoff Protocol
+
+No silent failures. Every delivery workflow follows the same protocol:
+
+1. **Attempt delivery** — automated, no human needed.
+2. **On success** — comment on originating issue with live URL, artifact link, or confirmation.
+3. **On failure** — comment on originating issue with:
+   - what was attempted,
+   - the error summary,
+   - a direct link to the workflow log,
+   - the exact manual step needed to unblock.
+4. **Label the issue** `needs-human` so it surfaces in triage.
+5. **Never close the issue automatically on failure** — only close on confirmed successful delivery.
+
+This protocol means you always know the state of every WR: delivered, failed with log, or waiting for human input. No guessing.
+
+---
+
+## What Was Missing Before
+
+The original agent stack handled:
+
+- ✅ Issue routing (labels, auto-assign)
+- ✅ Code generation (OpenHands, SWE-agent)
+- ✅ PR opening
+- ✅ Code review (Augment Code)
+- ❌ Deployment
+- ❌ Packaging / publishing
+- ❌ Documentation generation
+- ❌ MCP registration
+- ❌ Demo / video
+- ❌ Marketplace submission
+- ❌ Delivery confirmation back to originating issue
+
+This document fills all of those gaps. Each `deliver:*` label added to a WR activates the matching post-merge workflow, and every outcome — success or failure — closes the loop on the originating issue.


### PR DESCRIPTION
## Summary
Add delivery matrix standards for shipping WR artifacts

## Files
- standards/AGENT_STACK_SETUP.md
- standards/DELIVERY_MATRIX.md

## Why
Complete the delivery layer for AI agent stacks

## Who/When
- Who: Claude (openhands)
- When: 2026-05-06

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions; no runtime/codepath changes and no security-sensitive logic modified.
> 
> **Overview**
> Adds two new standards docs: `AGENT_STACK_SETUP.md` (repo setup checklist for bot/secrets/permissions and how the issue→label→agent workflows behave) and `DELIVERY_MATRIX.md` (a label-driven delivery framework mapping `deliver:*` labels to post-merge shipping actions, tooling, and failure-handoff expectations, plus a WR template extension).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4efc1e4c8173338a7abf38d3dfebb2939768ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces comprehensive documentation standards for AI agent delivery workflows. It adds `AGENT_STACK_SETUP.md` which provides a setup checklist for configuring bot accounts, secrets, and workflow integrations (OpenHands, SWE-agent, Augment Code). It also adds `DELIVERY_MATRIX.md` which defines a complete delivery framework mapping output types (PDF, API, CLI, MCP servers, mobile apps, packages, etc.) to their corresponding GitHub workflow triggers, toolchains, and failure handoff protocols. Together, these documents establish the delivery layer for shipping artifacts produced by AI agent stacks, ensuring work requests result in deployed artifacts rather than just merged code.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/AGENT_STACK_SETUP.md` |
| 2 | `standards/DELIVERY_MATRIX.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two standards docs that define the end-to-end delivery layer for WRs and the setup for the agent stack. This introduces `deliver:*` labels, post-merge workflows, and a clear failure handoff so shipped artifacts are produced after merge.

- **New Features**
  - Added `standards/DELIVERY_MATRIX.md` mapping WR outputs to delivery paths, including labels like `deliver:api`, `deliver:cli`, `deliver:docs`, `deliver:mcp`, and more.
  - Standardized a post-merge GitHub Actions pattern that triggers on labels, runs delivery, and comments success/failure back on the originating issue.
  - Documented detail playbooks for complex targets (e.g., MCP servers, PDFs, video demos).
  - Extended the WR template with a “Delivery targets” checklist and a one-sentence “definition of done”.
  - Added `standards/AGENT_STACK_SETUP.md` with a minimal setup guide for the bot account, required secrets/variables, repo permissions, and Augment Code installation.

- **Migration**
  - Create a bot account and add repo secrets: `BOT_GITHUB_TOKEN`, `OPENROUTER_API_KEY`; add repo variable `BOT_USERNAME`; enable write permissions and PR approvals for Actions.
  - Install the Augment Code GitHub App for automatic PR reviews.
  - Adopt the WR template delivery checklist and wire delivery workflows per the matrix.

<sup>Written for commit f4efc1e4c8173338a7abf38d3dfebb2939768ebb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

