### PR TITLE
fix(promptfoo): harden CI workflow and fix model IDs

### DIFF
--- a/docs/Master_Inventory/CODE_REVIEW_STANDARD.md
+++ b/docs/Master_Inventory/CODE_REVIEW_STANDARD.md
@@ -50,7 +50,7 @@ providers:
 
 **Fallback: Claude 4.5 Sonnet**
 ```yaml
-  - id: anthropic/claude-sonnet-4-5-20255112
+  - id: anthropic/claude-3.7-sonnet
 ```
 
 **GitHub Action:** https://github.com/promptfoo/promptfoo-action

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -22,7 +22,7 @@ providers:
       temperature: 0
 
 # Fallback: Claude 4.5 Sonnet
-  - id: anthropic/claude-sonnet-4-5-20255112
+  - id: anthropic/claude-3.7-sonnet
     config:
       api_key: ${OPENROUTER_API_KEY}
 ```

--- a/skills/testing-agent/SKILL.md
+++ b/skills/testing-agent/SKILL.md
@@ -116,7 +116,7 @@ providers:
       max_tokens: 2048
 
 # Fallback: Claude 4.5 Sonnet
-  - id: anthropic/claude-sonnet-4-5-20255112
+  - id: anthropic/claude-3.7-sonnet
 
 prompts:
   - label: "Standard invocation"

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -129,7 +129,7 @@ providers:
       max_tokens: 2048
 
 # Fallback: Claude 4.5 Sonnet
-  - id: anthropic/claude-sonnet-4-5-20255112
+  - id: anthropic/claude-3.7-sonnet
 
 prompts:
   - label: "Standard invocation"

--- a/templates/cicd/prompt-eval.yml
+++ b/templates/cicd/prompt-eval.yml
@@ -65,11 +65,27 @@ jobs:
 
       - name: Run PromptFoo Evaluation
         if: env.OPENROUTER_API_KEY != '' && steps.configs.outputs.configs != ''
+        env:
+          CONFIGS: ${{ steps.configs.outputs.configs }}
         run: |
-          for config in ${{ steps.configs.outputs.configs }}; do
+          # Safe iteration over configs - write to separate files then merge
+          RESULTS_DIR="promptfoo-results"
+          mkdir -p "$RESULTS_DIR"
+          index=1
+          for config in $CONFIGS; do
             echo "Running: $config"
-            promptfoo eval -c "$config" --no-cache --randomize -o results.json || true
+            promptfoo eval -c "$config" --no-cache -o "$RESULTS_DIR/results-$index.json" || true
+            index=$((index + 1))
           done
+          # Merge results if multiple files exist
+          if [ "$index" -gt 2 ]; then
+            echo "[]" > results.json
+            for f in "$RESULTS_DIR"/*.json; do
+              [ -f "$f" ] && jq -s '.[0] + .[1]' results.json "$f" > tmp.json && mv tmp.json results.json
+            done
+          elif [ -f "$RESULTS_DIR/results-1.json" ]; then
+            cp "$RESULTS_DIR/results-1.json" results.json
+          fi
 
       - name: Run PromptFoo (no API key fallback)
         if: env.OPENROUTER_API_KEY == ''
@@ -89,5 +105,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: promptfoo-results
-          path: results.json
+          path: |
+            results.json
+            promptfoo-results/
+          if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
## Summary
Fix PromptFoo CI workflow and model ID issues from PR13350

## Changes
- Fix unsafe shell interpolation via env var
- Fix results.json overwrite in loop - use per-config files + merge
- Remove invalid --randomize flag
- Fix upload-artifact if-no-files-found: ignore
- Fix invalid model ID: claude-sonnet-4-5-20255112 → claude-3.7-sonnet

## Files
- templates/cicd/prompt-eval.yml
- docs/Master_Inventory/CODE_REVIEW_STANDARD.md
- skills/code-review/SKILL.md
- skills/testing-agent/SKILL.md
- skills/testing/SKILL.md

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the PromptFoo CI workflow by fixing several security and reliability issues from PR13350. The changes address **unsafe shell interpolation** by using environment variables, prevent **results file overwrites** by generating per-config result files and merging them, remove an invalid `--randomize` flag, and fix the artifact upload configuration. Additionally, it corrects an invalid model ID across multiple documentation files (changing `claude-sonnet-4-5-20255112` to `claude-3.7-sonnet`).

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `templates/cicd/prompt-eval.yml` |
| 2 | `docs/Master_Inventory/CODE_REVIEW_STANDARD.md` |
| 3 | `skills/code-review/SKILL.md` |
| 4 | `skills/testing-agent/SKILL.md` |
| 5 | `skills/testing/SKILL.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PromptFoo GitHub Actions workflow; errors in the shell loop or result-merging could cause CI to silently miss failures or produce incorrect aggregated results. Changes are localized to CI/docs and don’t affect runtime application code.
> 
> **Overview**
> Fixes PromptFoo model configuration references by replacing an invalid Claude Sonnet 4.5 model ID with `anthropic/claude-3.7-sonnet` across the code review/testing docs and skill templates.
> 
> Hardens the `prompt-eval` CI workflow by avoiding direct output interpolation (passes configs via `env`), writing per-config result files and merging them into `results.json`, removing the `--randomize` flag, and making artifact upload resilient via `if-no-files-found: ignore` while also uploading the per-run results directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 814f919b9845fa6fc00162c229925ea7ebea77a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the PromptFoo CI workflow and fixes invalid model IDs. Prevents unsafe shell expansion, result overwrites, and artifact upload issues; updates docs to use the correct `anthropic/claude-3.7-sonnet` model.

- **Bug Fixes**
  - Safely iterate configs using an env var; no direct shell interpolation.
  - Write per-config results and merge with `jq` to avoid overwriting `results.json`.
  - Remove invalid `--randomize` flag in `promptfoo eval`.
  - Upload both `results.json` and `promptfoo-results/`; set `if-no-files-found: ignore` in `actions/upload-artifact@v4`.
  - Replace `anthropic/claude-sonnet-4-5-20255112` with `anthropic/claude-3.7-sonnet` in docs and skills.

<sup>Written for commit 814f919b9845fa6fc00162c229925ea7ebea77a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

