### PR TITLE
feat(automation): PR lifecycle — auto-move labels & badges through full PR process

### DIFF
--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -131,7 +131,9 @@ jobs:
                 break;
 
               case 'ready_for_review':
-                await remove(...ALL);
+                await remove('awaiting-approval', 'approved',
+                             'changes-requested', 'review-started',
+                             'ready-to-merge', 'needs-action');
                 await add('awaiting-review');
                 break;
 

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -121,8 +121,7 @@ jobs:
                 break;
 
               case 'converted_to_draft':
-                await remove('awaiting-review', 'awaiting-approval',
-                             'approved', 'checks-passing', 'ready-to-merge');
+                await remove(...ALL);
                 break;
 
               case 'opened':

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -1,116 +1,350 @@
-name: PR Lifecycle Automation
+# PR Lifecycle Automation
+#
+# Automatically moves PRs through every state by reacting to real GitHub events.
+#
+# STATE MACHINE:
+#   PR opened (draft)          → no label (draft badge implicit via GitHub UI)
+#   PR opened (ready)          → awaiting-review
+#   PR converted to draft      → strips awaiting-review / approved / ready-to-merge
+#   PR marked ready for review → awaiting-review
+#   Review approved            → approved; if checks-passing already → ready-to-merge
+#   Review changes_requested   → changes-requested + needs-action
+#   Review comment only        → review-started (non-destructive)
+#   PR synchronised (push)     → reset approval; re-add awaiting-review
+#   All check suites pass      → checks-passing; if approved → ready-to-merge
+#   Any check suite fails      → checks-failing + needs-action
+#   PR merged / closed         → all lifecycle labels removed
+#
+# Labels used (all defined in .github/labels.yml):
+#   awaiting-review · awaiting-approval · approved · changes-requested
+#   review-started  · checks-failing   · checks-passing · ready-to-merge
+#   needs-action
+
+name: PR Lifecycle
 
 on:
   pull_request:
     types:
       - opened
-      - ready_for_review
       - reopened
+      - ready_for_review
+      - converted_to_draft
+      - review_requested
+      - synchronize
+      - closed
   pull_request_review:
     types: [submitted]
   check_suite:
+    types: [completed]
+  workflow_run:
+    workflows: ["*"]
     types: [completed]
 
 permissions:
   pull-requests: write
   issues: write
+  checks: read
   contents: read
 
-jobs:
-  # ─── PR OPENED / READY FOR REVIEW ─────────────────────────────
-  on-ready:
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false &&
-      (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'reopened')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request.number;
-            const action = context.payload.action;
-            // Remove stale lifecycle labels from prior state
-            // CI labels (checks-passing/checks-failing) are only stripped on reopened (stale CI) — not on ready_for_review (CI results still valid)
-            const staleLabels = ['approved', 'needs-action', 'ready-to-merge', 'lifecycle:stuck'];
-            if (action === 'reopened') {
-              staleLabels.push('checks-failing', 'checks-passing');
-            }
-            for (const label of staleLabels) {
-              try { await github.rest.issues.removeLabel({ owner, repo, issue_number: pr, name: label }); } catch(e) {}
-            }
-            await github.rest.issues.addLabels({ owner, repo, issue_number: pr, labels: ['awaiting-review'] });
-            await github.rest.issues.createComment({ owner, repo, issue_number: pr, body: '👀 **Status: Waiting for Review** — This PR is ready for review. A reviewer has been requested.' });
+env:
+  LIFECYCLE_LABELS: >-
+    awaiting-review awaiting-approval approved changes-requested
+    review-started checks-failing checks-passing ready-to-merge needs-action
 
-  # ─── REVIEW SUBMITTED ──────────────────────────────────────────
-  on-review:
-    if: github.event_name == 'pull_request_review'
+jobs:
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Job 1 — Pull Request events
+  # ─────────────────────────────────────────────────────────────────────
+  pr-state:
+    name: PR State — ${{ github.event.action }}
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
     steps:
-      - uses: actions/github-script@v7
+      - name: Update lifecycle labels
+        uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request.number;
-            const state = context.payload.review.state;
-            const reviewer = context.payload.review.user.login;
+            const pr     = context.payload.pull_request;
+            const action = context.payload.action;
+            const owner  = context.repo.owner;
+            const repo   = context.repo.repo;
+            const num    = pr.number;
+
+            const ALL = [
+              'awaiting-review', 'awaiting-approval', 'approved',
+              'changes-requested', 'review-started', 'checks-failing',
+              'checks-passing', 'ready-to-merge', 'needs-action'
+            ];
+
+            // ─ helpers ────────────────────────────────────────────
+            const currentLabels = async () => (
+              await github.rest.issues.listLabelsOnIssue({
+                owner, repo, issue_number: num
+              })
+            ).data.map(l => l.name);
+
+            const add = async (...labels) => {
+              for (const l of labels) {
+                try {
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: num, labels: [l]
+                  });
+                  core.info(`  + ${l}`);
+                } catch (e) { core.warning(`add ${l}: ${e.message}`); }
+              }
+            };
+
+            const remove = async (...labels) => {
+              const cur = await currentLabels();
+              for (const l of labels) {
+                if (!cur.includes(l)) continue;
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: num, name: l
+                  });
+                  core.info(`  - ${l}`);
+                } catch (e) { core.warning(`remove ${l}: ${e.message}`); }
+              }
+            };
+
+            core.info(`PR #${num} event: ${action}`);
+
+            // ─ state machine ──────────────────────────────────────
+
+            switch (action) {
+
+              case 'closed':
+                await remove(...ALL);
+                break;
+
+              case 'converted_to_draft':
+                await remove('awaiting-review', 'awaiting-approval',
+                             'approved', 'checks-passing', 'ready-to-merge');
+                break;
+
+              case 'opened':
+              case 'reopened':
+                await remove(...ALL);
+                if (!pr.draft) await add('awaiting-review');
+                break;
+
+              case 'ready_for_review':
+                await remove(...ALL);
+                await add('awaiting-review');
+                break;
+
+              case 'synchronize': {
+                // New commits: drop approval state; keep CI labels
+                await remove('approved', 'ready-to-merge', 'review-started',
+                             'changes-requested');
+                const cur = await currentLabels();
+                if (!cur.includes('awaiting-review')) await add('awaiting-review');
+                break;
+              }
+
+              case 'review_requested': {
+                const cur = await currentLabels();
+                if (!cur.includes('awaiting-review')) await add('awaiting-review');
+                break;
+              }
+
+              default:
+                core.info(`No label change for action: ${action}`);
+            }
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Job 2 — Pull Request Review submitted
+  # ─────────────────────────────────────────────────────────────────────
+  review-state:
+    name: Review State — ${{ github.event.review.state }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_review'
+
+    steps:
+      - name: Update labels on review submission
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const review = context.payload.review;
+            const pr     = context.payload.pull_request;
+            const owner  = context.repo.owner;
+            const repo   = context.repo.repo;
+            const num    = pr.number;
+            const state  = review.state.toLowerCase();
+
+            core.info(`PR #${num} review state: ${state}`);
+
+            const currentLabels = async () => (
+              await github.rest.issues.listLabelsOnIssue({
+                owner, repo, issue_number: num
+              })
+            ).data.map(l => l.name);
+
+            const add = async (...labels) => {
+              for (const l of labels) {
+                try {
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: num, labels: [l]
+                  });
+                  core.info(`  + ${l}`);
+                } catch (e) { core.warning(`add ${l}: ${e.message}`); }
+              }
+            };
+
+            const remove = async (...labels) => {
+              const cur = await currentLabels();
+              for (const l of labels) {
+                if (!cur.includes(l)) continue;
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: num, name: l
+                  });
+                  core.info(`  - ${l}`);
+                } catch (e) { core.warning(`remove ${l}: ${e.message}`); }
+              }
+            };
+
+            if (state === 'commented') {
+              const cur = await currentLabels();
+              if (!cur.includes('review-started')) await add('review-started');
+              return;
+            }
 
             if (state === 'approved') {
-              for (const label of ['awaiting-review', 'needs-action']) {
-                try { await github.rest.issues.removeLabel({ owner, repo, issue_number: pr, name: label }); } catch(e) {}
-              }
-              await github.rest.issues.addLabels({ owner, repo, issue_number: pr, labels: ['approved'] });
-              const { data: labels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: pr });
-              const labelNames = labels.map(l => l.name);
-              if (labelNames.includes('checks-passing')) {
-                await github.rest.issues.addLabels({ owner, repo, issue_number: pr, labels: ['ready-to-merge'] });
-                await github.rest.issues.createComment({ owner, repo, issue_number: pr,
-                  body: `🚀 **Status: Ready to Merge** — @${reviewer} approved this PR and all checks pass. You may merge.` });
+              await remove('awaiting-review', 'awaiting-approval',
+                           'changes-requested', 'needs-action');
+              await add('approved');
+
+              // Gate: checks-passing already? → ready-to-merge
+              const cur = await currentLabels();
+              if (cur.includes('checks-passing')) {
+                await add('ready-to-merge');
+                core.info(`PR #${num} → ready-to-merge (approved + checks-passing)`);
               } else {
-                await github.rest.issues.createComment({ owner, repo, issue_number: pr,
-                  body: `✅ **Status: Approved** — @${reviewer} approved this PR. Waiting for CI checks to pass...` });
+                core.info(`PR #${num} approved — awaiting checks.`);
               }
-            } else if (state === 'changes_requested') {
-              for (const label of ['awaiting-review', 'approved', 'ready-to-merge']) {
-                try { await github.rest.issues.removeLabel({ owner, repo, issue_number: pr, name: label }); } catch(e) {}
-              }
-              await github.rest.issues.addLabels({ owner, repo, issue_number: pr, labels: ['needs-action'] });
-              await github.rest.issues.createComment({ owner, repo, issue_number: pr,
-                body: `🔄 **Status: Needs Action** — @${reviewer} requested changes. Please address the feedback and re-request review.` });
             }
-            // Comments don't change label state — approved PRs stay approved
 
-  # ─── CHECKS PASS / FAIL ────────────────────────────────────────
-  on-checks:
-    if: github.event_name == 'check_suite'
+            if (state === 'changes_requested') {
+              await remove('awaiting-review', 'awaiting-approval',
+                           'approved', 'ready-to-merge');
+              await add('changes-requested', 'needs-action');
+            }
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Job 3 — Check suite / workflow_run completed
+  # ─────────────────────────────────────────────────────────────────────
+  check-state:
+    name: Check State — ${{ github.event.check_suite.conclusion || github.event.workflow_run.conclusion }}
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const suite = context.payload.check_suite;
-            const conclusion = suite.conclusion;
-            const prs = suite.pull_requests;
-            for (const pr of prs) {
-              const prNumber = pr.number;
-              try { await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: 'checks-failing' }); } catch(e) {}
-              try { await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: 'checks-passing' }); } catch(e) {}
+    if: github.event_name == 'check_suite' || github.event_name == 'workflow_run'
 
-              if (conclusion === 'failure' || conclusion === 'timed_out') {
-                await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['checks-failing'] });
-                try { await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: 'ready-to-merge' }); } catch(e) {}
-                await github.rest.issues.createComment({ owner, repo, issue_number: prNumber,
-                  body: `❌ **Status: Checks Failing** — One or more CI checks failed. Please review the [check results](${context.payload.repository.html_url}/commit/${suite.head_sha}/checks) and push a fix.` });
-              } else if (conclusion === 'success') {
-                await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['checks-passing'] });
-                const { data: labels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: prNumber });
-                const labelNames = labels.map(l => l.name);
-                if (labelNames.includes('approved')) {
-                  await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['ready-to-merge'] });
-                  await github.rest.issues.createComment({ owner, repo, issue_number: prNumber,
-                    body: '🚀 **Status: Ready to Merge** — All checks pass and the PR is approved. You may merge.' });
+    steps:
+      - name: Find open PRs for this SHA and update check labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            let headSha, conclusion;
+            if (context.eventName === 'check_suite') {
+              headSha    = context.payload.check_suite.head_sha;
+              conclusion = context.payload.check_suite.conclusion;
+            } else {
+              headSha    = context.payload.workflow_run.head_sha;
+              conclusion = context.payload.workflow_run.conclusion;
+            }
+
+            if (!conclusion) {
+              core.info('No conclusion yet — skipping.');
+              return;
+            }
+
+            // Find open PRs matching this head SHA
+            const { data: prs } = await github.rest.pulls.list({
+              owner, repo, state: 'open', per_page: 100
+            });
+            const targets = prs.filter(p => p.head.sha === headSha);
+
+            if (targets.length === 0) {
+              core.info(`No open PRs for SHA ${headSha.slice(0,7)}.`);
+              return;
+            }
+
+            for (const pr of targets) {
+              const num = pr.number;
+              core.info(`Updating PR #${num}`);
+
+              const currentLabels = async () => (
+                await github.rest.issues.listLabelsOnIssue({
+                  owner, repo, issue_number: num
+                })
+              ).data.map(l => l.name);
+
+              const add = async (...labels) => {
+                for (const l of labels) {
+                  try {
+                    await github.rest.issues.addLabels({
+                      owner, repo, issue_number: num, labels: [l]
+                    });
+                    core.info(`  PR #${num} + ${l}`);
+                  } catch (e) { core.warning(`add ${l}: ${e.message}`); }
                 }
+              };
+
+              const remove = async (...labels) => {
+                const cur = await currentLabels();
+                for (const l of labels) {
+                  if (!cur.includes(l)) continue;
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner, repo, issue_number: num, name: l
+                    });
+                    core.info(`  PR #${num} - ${l}`);
+                  } catch (e) { core.warning(`remove ${l}: ${e.message}`); }
+                }
+              };
+
+              // Aggregate all check suites for this SHA
+              let allPass = false;
+              try {
+                const { data: suites } = await github.rest.checks.listSuitesForRef({
+                  owner, repo, ref: headSha, per_page: 100
+                });
+                const done = suites.check_suites.filter(s => s.status === 'completed');
+                const pending = suites.check_suites.filter(s => s.status !== 'completed');
+
+                if (pending.length > 0) {
+                  core.info(`PR #${num}: ${pending.length} suite(s) still pending — skipping.`);
+                  continue;
+                }
+
+                const PASS = new Set(['success', 'neutral', 'skipped']);
+                allPass = done.length > 0 && done.every(s => PASS.has(s.conclusion));
+              } catch (e) {
+                core.warning(`Could not list check suites: ${e.message}`);
+                // Fall back to single-event conclusion
+                const PASS = new Set(['success', 'neutral', 'skipped']);
+                allPass = PASS.has(conclusion);
+              }
+
+              if (allPass) {
+                await remove('checks-failing', 'needs-action');
+                await add('checks-passing');
+
+                const cur = await currentLabels();
+                if (cur.includes('approved')) {
+                  await add('ready-to-merge');
+                  core.info(`PR #${num} → ready-to-merge`);
+                }
+              } else {
+                await remove('checks-passing', 'ready-to-merge');
+                await add('checks-failing', 'needs-action');
               }
             }

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -140,7 +140,7 @@ jobs:
               case 'synchronize': {
                 // New commits: drop approval state; keep CI labels
                 await remove('approved', 'ready-to-merge', 'review-started',
-                             'changes-requested');
+                             'changes-requested', 'needs-action');
                 const cur = await currentLabels();
                 if (!cur.includes('awaiting-review')) await add('awaiting-review');
                 break;


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pr-lifecycle.yml` — a fully event-driven workflow that automatically moves every PR through the correct label/badge state without any manual intervention.

## State Machine

| Event | Labels Added | Labels Removed |
|---|---|---|
| PR opened (ready) | `awaiting-review` | all lifecycle labels |
| PR opened (draft) | _(none)_ | all lifecycle labels |
| PR ready_for_review | `awaiting-review` | all lifecycle labels |
| PR converted_to_draft | _(none)_ | `awaiting-review` `approved` `checks-passing` `ready-to-merge` |
| PR synchronize (new push) | `awaiting-review` | `approved` `ready-to-merge` `changes-requested` |
| Review **approved** | `approved` | `awaiting-review` `awaiting-approval` `changes-requested` `needs-action` |
| Review **approved** + `checks-passing` | `approved` `ready-to-merge` | same as above |
| Review **changes_requested** | `changes-requested` `needs-action` | `awaiting-review` `awaiting-approval` `approved` `ready-to-merge` |
| Review **comment** | `review-started` | _(none, non-destructive)_ |
| All checks pass | `checks-passing` | `checks-failing` `needs-action` |
| All checks pass + `approved` | `checks-passing` `ready-to-merge` | same |
| Any check fails | `checks-failing` `needs-action` | `checks-passing` `ready-to-merge` |
| PR merged / closed | _(all lifecycle labels removed)_ | |

## Triggers

- `pull_request` — opened, reopened, ready_for_review, converted_to_draft, review_requested, synchronize, closed
- `pull_request_review` — submitted
- `check_suite` — completed
- `workflow_run` — completed (fallback for any workflow not in a check suite)

## Labels Used

All labels are pre-defined in `.github/labels.yml`:
`awaiting-review` · `awaiting-approval` · `approved` · `changes-requested` · `review-started` · `checks-failing` · `checks-passing` · `ready-to-merge` · `needs-action`

## Current PRs This Fixes

- **#13380** `checks-failing` (16 checks) → will auto-label correctly
- **#13379** `checks-failing` (54 checks) → will auto-label correctly  
- **#13355** `checks-failing` (8 checks) → will auto-label correctly
- **#13363** `awaiting-review` → will advance to `approved`/`ready-to-merge` automatically
- **#13345** draft → will stay clean until marked ready

## No Breaking Changes

This workflow co-exists with the existing `arsc-labels.yml`. It only manages the lifecycle label subset listed above and does not touch triage, priority, agent-routing, or any other labels.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/midnghtsapphire/revvel-standards/pull/13402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions automation that mutates PR labels based on reviews and CI results; mislabeling or missed events could affect merge readiness signalling across the repo.
> 
> **Overview**
> Replaces the prior simple PR-label workflow with a **three-job, event-driven state machine** that updates PR lifecycle labels across `pull_request`, `pull_request_review`, and CI completion events.
> 
> PR events now clear/reset lifecycle labels on close/draft transitions, ensure `awaiting-review` on ready/review-requested/sync, and drop approval-related labels on new commits. Review submission now sets `approved` or `changes-requested`/`needs-action`, and conditionally adds `ready-to-merge` when `checks-passing` is already present.
> 
> CI handling is expanded to react to both `check_suite` and `workflow_run`, find open PRs by head SHA, and **aggregate all check suites** to decide `checks-passing` vs `checks-failing` (and add/remove `ready-to-merge` accordingly), with added `checks: read` permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d808b90f791d8e55c55a09bcd6a886848b1831d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements a comprehensive event-driven GitHub Actions workflow that automatically manages PR lifecycle labels through every stage of the pull request process. The workflow acts as a state machine that responds to PR events (opened, draft conversion, synchronize), review submissions (approved, changes requested, comments), and CI check completions to apply and remove labels like `awaiting-review`, `approved`, `checks-passing`, `ready-to-merge`, `changes-requested`, and `needs-action` without manual intervention. The implementation replaces a simpler 116-line workflow with a robust 350-line state machine that handles complex scenarios such as aggregating multiple check suites, distinguishing draft vs ready states, and coordinating approval status with CI results to determine merge-readiness.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/pr-lifecycle.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an event‑driven workflow that auto-updates PR lifecycle labels across the full PR process, including aggregated CI results. It removes manual updates and surfaces `ready-to-merge` when a PR is approved and checks pass.

- **New Features**
  - Adds `.github/workflows/pr-lifecycle.yml`; triggers on `pull_request`, `pull_request_review`, `check_suite`, and `workflow_run`. Only manages lifecycle labels defined in `.github/labels.yml`.
  - PR state: ready → `awaiting-review`; draft/closed → clear; opened/reopened → reset; `review_requested` ensures `awaiting-review`; `synchronize` drops `approved`/`ready-to-merge`/`changes-requested`/`review-started`/`needs-action`, re-adds `awaiting-review`, and keeps CI labels.
  - Reviews: `approved` → `approved` (and `ready-to-merge` if `checks-passing`); `changes_requested` → `changes-requested` + `needs-action`; `commented` → `review-started` (non-destructive).
  - Checks: aggregates all suites for the PR’s head SHA; skips updates while any suites are pending; all pass (`success`/`neutral`/`skipped`) → `checks-passing` (and `ready-to-merge` if `approved`); any fail → `checks-failing` + `needs-action`; `workflow_run` updates labels by SHA as a fallback.

<sup>Written for commit 7d808b90f791d8e55c55a09bcd6a886848b1831d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

