### PR TITLE
fix(agent-dispatcher): Wire to actually trigger workflows

### DIFF
--- a/.github/workflows/agent-dispatcher.yml
+++ b/.github/workflows/agent-dispatcher.yml
@@ -120,15 +120,20 @@ jobs:
         run: |
           echo "Dispatching $AGENT for issue #$ISSUE_NUMBER..."
           
-          # The actual agent would be triggered here
-          # For now, add a comment with the prompt
-          
-          gh issue comment "$ISSUE_NUMBER" --body "
-// agent: $AGENT
-// status: dispatched
-
-${{ steps.prompt.outputs.prompt }}
-"
+          case "$AGENT" in
+            perplexity)
+              # Trigger Perplexity workflow
+              gh workflow run perplexity-research-agent.yml -f issue_number=$ISSUE_NUMBER
+              ;;
+            jules)
+              # Trigger Jules - uses your JULES_TOKEN
+              gh workflow run jules-coding-agent.yml -f issue_number=$ISSUE_NUMBER
+              ;;
+            openrouter)
+              # Trigger OpenRouter coder
+              gh workflow run openrouter-coder.yml -f issue_number=$ISSUE_NUMBER
+              ;;
+          esac
 
       - name: Update labels
         env:


### PR DESCRIPTION
## Summary
Wires the agent dispatcher to actually trigger the correct workflows:
- perplexity -> perplexity-research-agent.yml
- jules -> jules-coding-agent.yml
- openrouter -> openrouter-coder.yml

Uses JULES_TOKEN you already created.

## Why
The dispatcher was just commenting on issues with prompts. Now it actually triggers the workflows.

## Rollback
`git revert HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI automation behavior by switching from commenting to actually invoking other GitHub Actions workflows; misconfiguration or missing permissions/secrets could cause failed or unintended dispatches.
> 
> **Overview**
> The agent dispatcher workflow now **actually triggers downstream agent workflows** (Perplexity, Jules, OpenRouter) via `gh workflow run ... -f issue_number=...` instead of posting a comment with the prompt.
> 
> Dispatch behavior is selected via a `case` on the resolved `AGENT`, wiring each agent label to its corresponding workflow file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b92fe900e68f71e3b8d3400edc40ec4c43c0632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the agent dispatcher workflow to actually trigger the appropriate agent workflows (`perplexity-research-agent.yml`, `jules-coding-agent.yml`, or `openrouter-coder.yml`) based on the selected agent, instead of just posting a comment with the prompt on the issue. The dispatcher now uses a case statement to route to the correct workflow and passes the issue number as a workflow input.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/agent-dispatcher.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the agent dispatcher to run downstream workflows instead of commenting on issues. Routes each agent to its workflow and passes the issue number.

- **New Features**
  - `perplexity` → `perplexity-research-agent.yml`
  - `jules` → `jules-coding-agent.yml` (uses `JULES_TOKEN`)
  - `openrouter` → `openrouter-coder.yml`

<sup>Written for commit 6b92fe900e68f71e3b8d3400edc40ec4c43c0632. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/midnghtsapphire/revvel-standards/pull/13408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->