### PR TITLE
fix(all): Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to all workflows

### DIFF
--- a/.github/workflows/agent-dispatcher.yml
+++ b/.github/workflows/agent-dispatcher.yml
@@ -33,6 +33,8 @@ env:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     timeout-minutes: 30
     steps:
       - name: Determine agent to dispatch

--- a/.github/workflows/commit-queue-monitor.yml
+++ b/.github/workflows/commit-queue-monitor.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   monitor:
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Evaluate commit queue backlog
         uses: actions/github-script@v8

--- a/.github/workflows/issue-state-machine.yml
+++ b/.github/workflows/issue-state-machine.yml
@@ -32,6 +32,8 @@ env:
 jobs:
   enforce-singular-lifecycle:
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     if: github.event_name == 'issues'
     steps:
       - name: Check current labels
@@ -101,6 +103,8 @@ jobs:
     timeout-minutes: 15
   set-initial-state:
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     if: github.event_name == 'issues' && github.event.action == 'opened' &&
       !contains(github.event.issue.labels.*.name, 'wr:')
     steps:
@@ -117,6 +121,8 @@ jobs:
     timeout-minutes: 15
   transition-state:
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.target_state
     steps:
       - name: Transition state
@@ -197,6 +203,8 @@ jobs:
     timeout-minutes: 15
   close-completed:
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     if: github.event_name == 'issues' && github.event.action == 'closed' &&
       contains(github.event.issue.labels.*.name, 'wr:')
     steps:

--- a/.github/workflows/jules-coding-agent.yml
+++ b/.github/workflows/jules-coding-agent.yml
@@ -30,6 +30,8 @@ env:
 jobs:
   jules-code:
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     timeout-minutes: 45
     if: >-
       (github.event_name == 'workflow_dispatch') ||
@@ -108,6 +110,8 @@ jobs:
   ci-fix:
     name: CI Fixer
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     timeout-minutes: 30
     if: >-
       github.event_name == 'pull_request' &&

--- a/.github/workflows/perplexity-research-agent.yml
+++ b/.github/workflows/perplexity-research-agent.yml
@@ -28,6 +28,8 @@ env:
 jobs:
   research:
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     timeout-minutes: 20
     if: >-
       (github.event_name == 'workflow_dispatch') ||

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -32,6 +32,8 @@ jobs:
   pr-state:
     name: PR State — ${{ github.event.action }}
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     if: github.event_name == 'pull_request'
     steps:
       - name: Update lifecycle labels
@@ -143,6 +145,8 @@ jobs:
   review-state:
     name: Review State — ${{ github.event.review.state }}
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     if: github.event_name == 'pull_request_review'
     steps:
       - name: Update labels on review submission
@@ -232,6 +236,8 @@ jobs:
     name: Check State — ${{ github.event.check_suite.conclusion ||
       github.event.workflow_run.conclusion }}
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     if: github.event_name == 'check_suite' || github.event_name == 'workflow_run'
     steps:
       - name: Find open PRs for this SHA and update check labels

--- a/.github/workflows/priority-router.yml
+++ b/.github/workflows/priority-router.yml
@@ -38,6 +38,8 @@ jobs:
   route-priority:
     name: Route priority
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Route priority for issues and PRs
         uses: actions/github-script@v8

--- a/.github/workflows/ship-quality.yml
+++ b/.github/workflows/ship-quality.yml
@@ -15,6 +15,8 @@ jobs:
   scan:
     name: Ship Quality Check
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout PR

--- a/.github/workflows/ship-to-market.yml
+++ b/.github/workflows/ship-to-market.yml
@@ -26,6 +26,8 @@ jobs:
   gate:
     name: 🔒 Merge Gate
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true)
@@ -91,6 +93,8 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run_api == 'true'
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -150,6 +154,8 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run_app == 'true'
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -206,6 +212,8 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run_pdf == 'true'
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v4
       - name: Install pandoc + LaTeX
@@ -252,6 +260,8 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run_cli == 'true'
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -291,6 +301,8 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run_docker == 'true'
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3
@@ -321,6 +333,8 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run_mcp == 'true'
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -381,6 +395,8 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run_docs == 'true'
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     permissions:
       contents: write
       pages: write
@@ -427,6 +443,8 @@ jobs:
     needs: gate
     if: needs.gate.outputs.run_video == 'true'
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -482,6 +500,8 @@ jobs:
       - deliver-video
     if: always()
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Check for failures
         id: check

--- a/.github/workflows/stuck-check-watchdog.yml
+++ b/.github/workflows/stuck-check-watchdog.yml
@@ -27,6 +27,8 @@ env:
 jobs:
   find-stuck-issues:
     runs-on: ubuntu-latest
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     timeout-minutes: 30
     steps:
       - name: Fetch stuck issues


### PR DESCRIPTION
## Summary
Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to all remaining workflows that were missing it.

## Why
Fixes Node.js 20 deprecation warning across all GitHub Actions. All jobs now run on Node.js 24.

## Changes
- 10 workflow files updated with env var

## Rollback
`git revert HEAD`

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` environment variable to all remaining GitHub Actions workflows to resolve Node.js 20 deprecation warnings and ensure all jobs run on Node.js 24. The change is applied uniformly across 10 workflow files, adding the environment variable at the job level in each workflow.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/agent-dispatcher.yml` |
| 2 | `.github/workflows/commit-queue-monitor.yml` |
| 3 | `.github/workflows/stuck-check-watchdog.yml` |
| 4 | `.github/workflows/perplexity-research-agent.yml` |
| 5 | `.github/workflows/priority-router.yml` |
| 6 | `.github/workflows/ship-quality.yml` |
| 7 | `.github/workflows/issue-state-machine.yml` |
| 8 | `.github/workflows/jules-coding-agent.yml` |
| 9 | `.github/workflows/pr-lifecycle.yml` |
| 10 | `.github/workflows/ship-to-market.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadly touches many GitHub Actions workflows; while the change is just an env var, incorrect YAML indentation could prevent workflows/jobs from running and would only be caught at runtime.
> 
> **Overview**
> Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24="true"` to remaining GitHub Actions workflows/jobs so `actions/github-script` (and other JS actions) run on Node.js 24 and stop emitting Node 20 deprecation warnings.
> 
> This is applied across dispatch/agent, issue & PR lifecycle automation, routing/monitoring jobs, and ship/delivery pipelines (including per-job additions in `ship-to-market.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8128a9c827879fcb916c9f31bfbbce510730840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to remaining GitHub Actions workflows so JavaScript actions run on Node.js 24 and Node 20 deprecation warnings are removed.

- **Bug Fixes**
  - Set the env var at the job level in 10 workflows.

<sup>Written for commit b8128a9c827879fcb916c9f31bfbbce510730840. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/midnghtsapphire/revvel-standards/pull/13409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->