### PR TITLE
feat(agent-models): Better model profiles

### DIFF
--- a/.github/agent-models.yml
+++ b/.github/agent-models.yml
@@ -6,7 +6,31 @@
 # Use Claude Sonnet 4.6+ or GPT-5.5/GPT-5.1 class models
 
 profiles:
-  # Research: Perplexity for web-grounded research
+  # === OPENROUTER ORCHESTRATOR ===
+  # OpenRouter decides best model per task - recommended default
+  orchestrator:
+    description: "Let OpenRouter pick best model for the task - recommended for general use"
+    provider: openrouter
+    strategy: "auto"  # Let OpenRouter pick best model
+    primary: "openai/gpt-4o"
+    fallback: "anthropic/claude-sonnet-4-20250514"
+    max_tokens: 15000
+    temperature: 0.4
+
+  # === TASK-SPECIFIC PROFILES ===
+  
+  # Best coder - high reasoning for complex file edits
+  best_coder:
+    description: "Best available coder - Claude Sonnet 4 or GPT-4o for complex code"
+    provider: openrouter
+    # OpenRouter will use best reasoning model
+    primary: "anthropic/claude-sonnet-4-20250514"
+    fallback: "openai/gpt-4o"
+    max_tokens: 20000
+    temperature: 0.4
+    use_for: ["code", "file-edit", "refactor", "implement"]
+
+  # Best researcher - web-grounded with citations
   research:
     description: "Deep research using Perplexity Sonar for web-grounded answers"
     provider: perplexity
@@ -15,41 +39,27 @@ profiles:
     max_tokens: 10000
     temperature: 0.4
 
-  # Triage: Quick classification and routing
-  triage:
-    description: "Quick issue classification, label assignment, and routing"
-    provider: openrouter
-    primary: "openai/gpt-4o-mini"
-    fallback: "anthropic/claude-haiku-3.5"
-    max_tokens: 4000
-    temperature: 0.3
-
-  # code_patch: Coding agent - use direct LLM for file edits
-  code_patch:
-    description: "Writing and modifying code - use direct LLM for file edits"
-    provider: direct
-    primary: "anthropic/claude-sonnet-4-20250514"
-    fallback: "openai/gpt-4o"
-    max_tokens: 12000
-    temperature: 0.4
-
-  # jules: Jules coding agent (Google's CI Fixer)
-  jules:
-    description: "Jules coding agent with CI Fixer - PR creation and CI self-repair"
-    provider: google-jules
-    enabled: true
-    max_tokens: 15000
-
-  # review: Code review - direct LLM for quality checks
-  review:
-    description: "Reviewing code changes for quality, bugs, and best practices"
+  # Best reviewer - quality focused, lower temp
+  best_reviewer:
+    description: "Best available reviewer - GTP-4o or Claude for quality checks"
     provider: openrouter
     primary: "openai/gpt-4o"
     fallback: "anthropic/claude-sonnet-4-20250514"
     max_tokens: 8000
     temperature: 0.2
+    use_for: ["review", "pr-review", "code-review"]
 
-  # cheap_summary: Lightweight summarization
+  # Triage - quick classification, cheap
+  triage:
+    description: "Quick issue classification and routing - use cheap model"
+    provider: openrouter
+    primary: "openai/gpt-4o-mini"
+    fallback: "anthropic/claude-haiku-3.5"
+    max_tokens: 4000
+    temperature: 0.3
+    use_for: ["triage", "classify", "route", "label"]
+
+  # Cheap summary - lightweight tasks only
   cheap_summary:
     description: "Quick summaries and simple responses"
     provider: openrouter
@@ -57,13 +67,36 @@ profiles:
     fallback: "anthropic/claude-haiku-3.5"
     max_tokens: 2000
     temperature: 0.1
+    use_for: ["summarize", "simple", "quick"]
+
+  # Jules - Google's CI Fixer agent
+  jules:
+    description: "Jules coding agent with CI Fixer - PR creation and CI self-repair"
+    provider: google-jules
+    enabled: true
+    max_tokens: 15000
 
 #Orchestration flow:
+#  # Task-based routing:
+#  #   code/triage -> orchestrator (auto-select best model)
+#  #   file-edit/code -> best_coder (Claude Sonnet 4 or GPT-4o)
+#  #   research -> Perplexity Sonar (web-grounded)
+#  #   review -> best_reviewer (quality focus)
+#  #   simple/quick -> cheap_summary (gpt-4o-mini)
+#
 #  wr:research -> Perplexity (research + WR handoff)
 #  wr:jules -> Jules (PR creation + CI Fixer)
 #  wr:code -> Direct LLM (file edits)
 #  wr:checking -> GitHub Actions
 #  lifecycle:stuck -> Perplexity diagnosis + requeue
+
+# Model selection logic:
+# 1. Check use_for match in task context
+# 2. Fall back to orchestrator (auto-select)
+# 3. Specific profiles override auto
+
+# For GitHub Actions usage:
+#   - ${{ fromJson(inputs.model_profile || 'orchestrator') }}
 
 # Model selection helpers for GitHub Actions
 env:


### PR DESCRIPTION
Updated agent-models.yml with better profiles for OpenRouter orchestrator, best_coder, best_reviewer, research, triage, cheap_summary, and jules.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/midnghtsapphire/revvel-standards/pull/13412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR reorganizes and enhances the agent model profiles configuration by introducing an `orchestrator` profile that lets OpenRouter automatically select the best model for each task, and creating specialized profiles (`best_coder`, `best_reviewer`, `research`, `triage`, `cheap_summary`, `jules`) with clearer descriptions, appropriate provider settings, token limits, temperatures, and `use_for` context hints. The changes improve the structure by grouping profiles into OpenRouter orchestrator and task-specific categories, removing the deprecated `code_patch` and `review` profiles in favor of the new `best_coder` and `best_reviewer` variants, and adding more detailed orchestration flow documentation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/agent-models.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates model-profile configuration used by workflows, with no application logic changes; main risk is unintended workflow routing/model selection changes if consumers relied on removed/renamed profiles.
> 
> **Overview**
> Switches the agent model configuration to an **OpenRouter-first routing setup** by introducing an `orchestrator` profile (`strategy: auto`) and adding task-targeted profiles (`best_coder`, `best_reviewer`) alongside existing `research`, `triage`, and `cheap_summary`.
> 
> Removes the older `code_patch`/`review` entries and adds `use_for` tags plus updated inline guidance/comments to drive task-based profile selection (including GitHub Actions usage notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f391adfd49fd5123ab4e8155febf9b506ed1fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an OpenRouter-first routing setup with a new `orchestrator` profile and task-focused profiles to improve model selection and clarity. Removes `code_patch` and `review`, adds `use_for` tags, and sets sensible defaults and fallbacks.

- **New Features**
  - Added `orchestrator` (OpenRouter `strategy: auto`) with `openai/gpt-4o` primary and `anthropic/claude-sonnet-4-20250514` fallback.
  - Added `best_coder` and `best_reviewer` with `use_for` tags for code edits and reviews.
  - Clarified scopes and settings for `research` (Perplexity), `triage` (`gpt-4o-mini`), `cheap_summary` (`gpt-4o-mini`), and `jules`.

- **Migration**
  - Replace `code_patch` with `best_coder` and `review` with `best_reviewer`.
  - Default to `orchestrator` when no specific profile is required.
  - Update any workflow or tooling that referenced removed profile names.

<sup>Written for commit 83f391adfd49fd5123ab4e8155febf9b506ed1fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

