### PR TITLE
Add OpenRouter Agent workflow for issue handling

### DIFF
--- a/workflows/openrouter-agent
+++ b/workflows/openrouter-agent
@@ -1,0 +1,106 @@
+name: OpenRouter Agent
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  openrouter-agent:
+    name: Respond via OpenRouter
+    runs-on: ubuntu-latest
+
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@openrouter-agent')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@openrouter-agent')) ||
+      (github.event_name == 'issues' && github.event.action == 'opened')
+
+    steps:
+      - name: Build prompt context
+        id: context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+          ISSUE_BODY: ${{ github.event.issue.body || github.event.pull_request.body }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          USER_PROMPT=$(echo "$COMMENT_BODY" | sed 's/@openrouter-agent//g' | xargs)
+
+          if [ "$EVENT_NAME" = "issues" ]; then
+            SYSTEM_MSG="You are a helpful GitHub assistant for the revvel-standards repository. A new issue was just opened. Provide a concise summary and suggest next steps or relevant standards."
+            PROMPT="Issue title: $ISSUE_TITLE\n\nIssue body:\n$ISSUE_BODY"
+          else
+            SYSTEM_MSG="You are a helpful GitHub assistant for the revvel-standards repository. Answer the user's question clearly and concisely. Reference relevant standards or patterns when applicable."
+            PROMPT="Context — Issue/PR: $ISSUE_TITLE\n\nUser ($SENDER) asked: $USER_PROMPT"
+          fi
+
+          SYSTEM_ESCAPED=$(echo "$SYSTEM_MSG" | jq -Rs .)
+          PROMPT_ESCAPED=$(echo "$PROMPT" | jq -Rs .)
+
+          echo "system=$SYSTEM_ESCAPED" >> $GITHUB_OUTPUT
+          echo "prompt=$PROMPT_ESCAPED" >> $GITHUB_OUTPUT
+
+      - name: Call OpenRouter API
+        id: ai
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          SYSTEM=${{ steps.context.outputs.system }}
+          PROMPT=${{ steps.context.outputs.prompt }}
+
+          PAYLOAD=$(jq -n \
+            --argjson system "$SYSTEM" \
+            --argjson prompt "$PROMPT" \
+            '{
+              model: "anthropic/claude-3.5-sonnet",
+              max_tokens: 1024,
+              messages: [
+                { role: "system", content: $system },
+                { role: "user", content: $prompt }
+              ]
+            }')
+
+          RESPONSE=$(curl -sf https://openrouter.ai/api/v1/chat/completions \
+            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -H "HTTP-Referer: https://github.com/midnghtsapphire/revvel-standards" \
+            -H "X-Title: revvel-standards OpenRouter Agent" \
+            -d "$PAYLOAD")
+
+          if [ $? -ne 0 ]; then
+            echo "reply=⚠️ OpenRouter API call failed. Check your \`OPENROUTER_API_KEY\` secret." >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          REPLY=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // "⚠️ No response returned."')
+          echo "reply<<EOF" >> $GITHUB_OUTPUT
+          echo "$REPLY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post reply as comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY: ${{ steps.ai.outputs.reply }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          BODY=$(jq -n --arg body "> 🤖 **OpenRouter Agent**
+
+          $REPLY
+
+          ---
+          *Powered by [OpenRouter](https://openrouter.ai) · Model: \`anthropic/claude-3.5-sonnet\`*" \
+            '{ body: $body }')
+
+          gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+            --method POST \
+            --input - <<< "$BODY"


### PR DESCRIPTION
name: OpenRouter Agent

on:
  issue_comment:
    types: [created]
  issues:
    types: [opened]
  pull_request_review_comment:
    types: [created]

permissions:
  issues: write
  pull-requests: write
  contents: read

jobs:
  openrouter-agent:
    name: Respond via OpenRouter
    runs-on: ubuntu-latest

    if: |
      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@openrouter-agent')) ||
      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@openrouter-agent')) ||
      (github.event_name == 'issues' && github.event.action == 'opened')

    steps:
      - name: Build prompt context id: context env: EVENT_NAME: ${{ github.event_name }} ISSUE_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }} ISSUE_BODY: ${{ github.event.issue.body || github.event.pull_request.body }} COMMENT_BODY: ${{ github.event.comment.body }} SENDER: ${{ github.event.sender.login }} run: | USER_PROMPT=$(echo "$COMMENT_BODY" | sed 's/@openrouter-agent//g' | xargs)

          if [ "$EVENT_NAME" = "issues" ]; then
            SYSTEM_MSG="You are a helpful GitHub assistant for the revvel-standards repository. A new issue was just opened. Provide a concise summary and suggest next steps or relevant standards."
            PROMPT="Issue title: $ISSUE_TITLE\n\nIssue body:\n$ISSUE_BODY"
          else
            SYSTEM_MSG="You are a helpful GitHub assistant for the revvel-standards repository. Answer the user's question clearly and concisely. Reference relevant standards or patterns when applicable."
            PROMPT="Context — Issue/PR: $ISSUE_TITLE\n\nUser ($SENDER) asked: $USER_PROMPT"
          fi

          SYSTEM_ESCAPED=$(echo "$SYSTEM_MSG" | jq -Rs .)
          PROMPT_ESCAPED=$(echo "$PROMPT" | jq -Rs .)

          echo "system=$SYSTEM_ESCAPED" >> $GITHUB_OUTPUT
          echo "prompt=$PROMPT_ESCAPED" >> $GITHUB_OUTPUT

      - name: Call OpenRouter API
        id: ai
        env:
          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
        run: |
          SYSTEM=${{ steps.context.outputs.system }}
          PROMPT=${{ steps.context.outputs.prompt }}

          PAYLOAD=$(jq -n \
            --argjson system "$SYSTEM" \
            --argjson prompt "$PROMPT" \
            '{
              model: "anthropic/claude-3.5-sonnet",
              max_tokens: 1024,
              messages: [
                { role: "system", content: $system },
                { role: "user", content: $prompt }
              ]
            }')

          RESPONSE=$(curl -sf https://openrouter.ai/api/v1/chat/completions \
            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
            -H "Content-Type: application/json" \
            -H "HTTP-Referer: https://github.com/midnghtsapphire/revvel-standards" \
            -H "X-Title: revvel-standards OpenRouter Agent" \
            -d "$PAYLOAD")

          if [ $? -ne 0 ]; then
            echo "reply=⚠️ OpenRouter API call failed. Check your \`OPENROUTER_API_KEY\` secret." >> $GITHUB_OUTPUT
            exit 0
          fi

          REPLY=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // "⚠️ No response returned."')
          echo "reply<<EOF" >> $GITHUB_OUTPUT
          echo "$REPLY" >> $GITHUB_OUTPUT
          echo "EOF" >> $GITHUB_OUTPUT

      - name: Post reply as comment
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          REPLY: ${{ steps.ai.outputs.reply }}
          REPO: ${{ github.repository }}
          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
        run: |
          BODY=$(jq -n --arg body "> 🤖 **OpenRouter Agent**

          $REPLY

          ---
          *Powered by [OpenRouter](https://openrouter.ai) · Model: \`anthropic/claude-3.5-sonnet\`*" \
            '{ body: $body }')

          gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" \
            --method POST \
            --input - <<< "$BODY"

## Summary

<!-- One paragraph: what does this do? -->
Closes #<!-- issue number -->

## Changes

<!-- Bullet list of key changes -->
-

## Validation

<!-- One paragraph: how do you know this works? Link runs/screenshots/preview URLs. -->


## Checklist

<!-- These four are pre-checked because they apply to almost every PR. Uncheck any that this PR genuinely violates and explain in the Summary or Validation section above. -->
- [x] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

<!--
For reference (not user-facing — kept here for the PR-template-autocomplete workflow to inspect):
- Discoverability/docs: README, knowledge note, reference table, doc cross-links
- Ops/runbooks: REMINDERS.md, follow-up notes
- Testing: manual verification, CI passing, new tests
- Deferred items: list explicitly in Validation section above
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/midnghtsapphire/revvel-standards/pull/13426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a GitHub Actions workflow that integrates an AI-powered agent using OpenRouter's API to automatically respond to issues and comments. The workflow triggers when new issues are opened or when users mention `@openrouter-agent` in issue or PR comments, then uses the *Claude 3.5 Sonnet* model to generate contextual responses and post them as GitHub comments.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `workflows/openrouter-agent` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new event-triggered automation that calls an external LLM API using a repository secret and posts comments back to issues/PRs, which can create noisy or unintended public responses if misconfigured.
> 
> **Overview**
> Introduces a new GitHub Actions workflow (`workflows/openrouter-agent`) that auto-responds to newly opened issues and to issue/PR review comments that mention `@openrouter-agent`.
> 
> The job builds a prompt from issue/PR context, calls the OpenRouter chat completions API (Claude 3.5 Sonnet) using `OPENROUTER_API_KEY`, and posts the model output back as a GitHub comment via `gh api`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee79cfdecb024afb9f0debfb851e2bfb52b9bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that auto-replies to new issues and opt-in comments using OpenRouter. This helps triage and Q&A by posting a concise, formatted reply with model output.

- **New Features**
  - Triggers on new issues and on comments containing `@openrouter-agent` (issue comments or PR review comments).
  - Builds context from the issue/PR title/body and the user’s comment; strips the `@openrouter-agent` mention before sending.
  - Calls OpenRouter chat completions with `anthropic/claude-3.5-sonnet` and posts the reply as an issue/PR comment.
  - Adds guardrails: posts a friendly error if the OpenRouter request fails.
  - Uses restricted permissions: `issues`/`pull-requests` write, `contents` read.

- **Migration**
  - Add a repository secret `OPENROUTER_API_KEY`.
  - Use by mentioning `@openrouter-agent` in a comment; new issues receive an automatic summary without a mention.

<sup>Written for commit aee79cfdecb024afb9f0debfb851e2bfb52b9bd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

