### PR TITLE
Add OpenRouter Agent workflow for issue and PR comments

### DIFF
--- a/workflows/open-router-agent.yml
+++ b/workflows/open-router-agent.yml
@@ -1,0 +1,106 @@
+name: OpenRouter Agent
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  openrouter-agent:
+    name: Respond via OpenRouter
+    runs-on: ubuntu-latest
+
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@openrouter-agent')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@openrouter-agent')) ||
+      (github.event_name == 'issues' && github.event.action == 'opened')
+
+    steps:
+      - name: Build prompt context
+        id: context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+          ISSUE_BODY: ${{ github.event.issue.body || github.event.pull_request.body }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          USER_PROMPT=$(echo "$COMMENT_BODY" | sed 's/@openrouter-agent//g' | xargs)
+
+          if [ "$EVENT_NAME" = "issues" ]; then
+            SYSTEM_MSG="You are a helpful GitHub assistant for the revvel-standards repository. A new issue was just opened. Provide a concise summary and suggest next steps or relevant standards."
+            PROMPT="Issue title: $ISSUE_TITLE\n\nIssue body:\n$ISSUE_BODY"
+          else
+            SYSTEM_MSG="You are a helpful GitHub assistant for the revvel-standards repository. Answer the user's question clearly and concisely. Reference relevant standards or patterns when applicable."
+            PROMPT="Context — Issue/PR: $ISSUE_TITLE\n\nUser ($SENDER) asked: $USER_PROMPT"
+          fi
+
+          SYSTEM_ESCAPED=$(echo "$SYSTEM_MSG" | jq -Rs .)
+          PROMPT_ESCAPED=$(echo "$PROMPT" | jq -Rs .)
+
+          echo "system=$SYSTEM_ESCAPED" >> $GITHUB_OUTPUT
+          echo "prompt=$PROMPT_ESCAPED" >> $GITHUB_OUTPUT
+
+      - name: Call OpenRouter API
+        id: ai
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          SYSTEM=${{ steps.context.outputs.system }}
+          PROMPT=${{ steps.context.outputs.prompt }}
+
+          PAYLOAD=$(jq -n \
+            --argjson system "$SYSTEM" \
+            --argjson prompt "$PROMPT" \
+            '{
+              model: "anthropic/claude-3.5-sonnet",
+              max_tokens: 1024,
+              messages: [
+                { role: "system", content: $system },
+                { role: "user", content: $prompt }
+              ]
+            }')
+
+          RESPONSE=$(curl -sf https://openrouter.ai/api/v1/chat/completions \
+            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+            -H "Content-Type: application/json" \
+            -H "HTTP-Referer: https://github.com/midnghtsapphire/revvel-standards" \
+            -H "X-Title: revvel-standards OpenRouter Agent" \
+            -d "$PAYLOAD")
+
+          if [ $? -ne 0 ]; then
+            echo "reply=⚠️ OpenRouter API call failed. Check your \`OPENROUTER_API_KEY\` secret." >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          REPLY=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // "⚠️ No response returned."')
+          echo "reply<<EOF" >> $GITHUB_OUTPUT
+          echo "$REPLY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Post reply as comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY: ${{ steps.ai.outputs.reply }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          BODY=$(jq -n --arg body "> 🤖 **OpenRouter Agent**
+
+          $REPLY
+
+          ---
+          *Powered by [OpenRouter](https://openrouter.ai) · Model: \`anthropic/claude-3.5-sonnet\`*" \
+            '{ body: $body }')
+
+          gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+            --method POST \
+            --input - <<< "$BODY"


### PR DESCRIPTION
## Summary

<!-- One paragraph: what does this do? -->
Closes #<!-- issue number -->

## Changes

<!-- Bullet list of key changes -->
-

## Validation

<!-- One paragraph: how do you know this works? Link runs/screenshots/preview URLs. -->


## Checklist

<!-- These four are pre-checked because they apply to almost every PR. Uncheck any that this PR genuinely violates and explain in the Summary or Validation section above. -->
- [x] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

<!--
For reference (not user-facing — kept here for the PR-template-autocomplete workflow to inspect):
- Discoverability/docs: README, knowledge note, reference table, doc cross-links
- Ops/runbooks: REMINDERS.md, follow-up notes
- Testing: manual verification, CI passing, new tests
- Deferred items: list explicitly in Validation section above
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automated GitHub workflow that can post AI-generated comments on issues/PRs using a repository secret and an external API, so misconfiguration or prompt/permission issues could lead to noisy or unintended replies.
> 
> **Overview**
> Introduces a new GitHub Actions workflow (`workflows/open-router-agent.yml`) that triggers on new issues and on issue/PR review comments containing `@openrouter-agent`.
> 
> The job builds a prompt from the issue/PR context, calls the OpenRouter chat completions API (Claude 3.5 Sonnet) using `OPENROUTER_API_KEY`, and posts the model’s response back as a GitHub comment via `gh api` with write access to issues/PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58ccad2451a6cedd3aafae542489b11d3fb1b7bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a GitHub Actions workflow that integrates an AI agent powered by OpenRouter's API. The workflow automatically responds to issue and pull request comments when mentioned with `@openrouter-agent`, and provides automated summaries when new issues are opened. The agent uses Claude 3.5 Sonnet to generate contextual responses and posts them as GitHub comments.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `workflows/open-router-agent.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that auto-replies on new issues and on comments that mention `@openrouter-agent`, using `anthropic/claude-3.5-sonnet` via OpenRouter. It summarizes new issues and answers questions with brief, standards-aware replies.

- **New Features**
  - New workflow `workflows/open-router-agent.yml` listening to issues opened, issue comments, and PR review comments.
  - Replies only when a comment includes `@openrouter-agent`; always replies on newly opened issues with a summary and next steps.
  - Builds minimal context (title/body and cleaned user prompt), calls OpenRouter, and posts the reply back to the thread.

- **Migration**
  - Add repo secret `OPENROUTER_API_KEY`.
  - Optionally adjust the model (`anthropic/claude-3.5-sonnet`), system prompts, or headers in the workflow.

<sup>Written for commit 58ccad2451a6cedd3aafae542489b11d3fb1b7bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

