### PR TITLE
Change model from 'anthropic/claude-3.5-sonnet' to 'google/gemini 2.5…

### DIFF
--- a/workflows/openrouter-agent
+++ b/workflows/openrouter-agent
@@ -61,7 +61,7 @@ jobs:
             --argjson system "$SYSTEM" \
             --argjson prompt "$PROMPT" \
             '{
-              model: "anthropic/claude-3.5-sonnet",
+              model: "google/gemini 2.5 pro",
               max_tokens: 1024,
               messages: [
                 { role: "system", content: $system },
@@ -98,7 +98,7 @@ jobs:
           $REPLY
 
           ---
-          *Powered by [OpenRouter](https://openrouter.ai) · Model: \`anthropic/claude-3.5-sonnet\`*" \
+          *Powered by [OpenRouter](https://openrouter.ai) · Model: \`google/gemini 2.5 pro\`*" \
             '{ body: $body }')
 
           gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments" \


### PR DESCRIPTION
… pro'

## Summary

<!-- One paragraph: what does this do? -->
Closes #<!-- issue number -->

## Changes

<!-- Bullet list of key changes -->
-

## Validation

<!-- One paragraph: how do you know this works? Link runs/screenshots/preview URLs. -->


## Checklist

<!-- These four are pre-checked because they apply to almost every PR. Uncheck any that this PR genuinely violates and explain in the Summary or Validation section above. -->
- [x] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

<!--
For reference (not user-facing — kept here for the PR-template-autocomplete workflow to inspect):
- Discoverability/docs: README, knowledge note, reference table, doc cross-links
- Ops/runbooks: REMINDERS.md, follow-up notes
- Testing: manual verification, CI passing, new tests
- Deferred items: list explicitly in Validation section above
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the model identifier used in the OpenRouter request and the corresponding comment footer; no logic or permission changes.
> 
> **Overview**
> Updates the `openrouter-agent` GitHub Actions workflow to use the `google/gemini 2.5 pro` model instead of `anthropic/claude-3.5-sonnet` when calling OpenRouter.
> 
> Also updates the posted comment footer to reflect the new model name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 881ba9b3eba5b009f5b16cefaa102383b5580c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the `openrouter-agent` workflow to use `google/gemini 2.5 pro` instead of `anthropic/claude-3.5-sonnet` for OpenRouter requests. Updates the posted comment footer to show the new model name.

<sup>Written for commit 881ba9b3eba5b009f5b16cefaa102383b5580c5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

