### PR TITLE
fix: Auto-add wr:new on issue opened

### DIFF
--- a/.github/workflows/api-rate-limit-handler.yml
+++ b/.github/workflows/api-rate-limit-handler.yml
@@ -38,28 +38,20 @@ jobs:
           EXISTING=$(gh search issues --repo ${{ github.repository }} \
             --state open --json number \
             -q ".[] | select(.title | contains(\"${{ inputs.failed_workflow }}\") and contains(title, \"API rate limit\")) | .number" 2>/dev/null || echo "")
-
-          BODY=$(cat <<EOF
-          ## Rate Limit Hit
-
-          **Failed Workflow:** ${{ inputs.failed_workflow }}
-          **Agent:** ${{ inputs.agent_used }}
-          **Error:** ${{ inputs.error_message }}
-          **When:** ${{ github.event.workflow_run.run_started_at }}
-
-          ## Required Action
-          - [ ] Re-run with different agent (OpenRouter fallback)
-          - [ ] Or wait and re-run later
-
-          ## Label
-          /label automation-failure,rate-limit-failure
-          EOF
-          )
           
           if [[ -z "$EXISTING" ]]; then
             gh issue create \
               --title "[RATE LIMIT] ${{ inputs.failed_workflow }} - API rate limit hit" \
-              --body "$BODY" \
+              --body "## Rate Limit Hit
+
+**Failed Workflow:** ${{ inputs.failed_workflow }}
+**Agent:** ${{ inputs.agent_used }}
+**Error:** ${{ inputs.error_message }}
+**When:** ${{ github.event.workflow_run.run_started_at }}
+
+## Required Action
+- [ ] Re-run with different agent (OpenRouter fallback)
+- [ ] Or wait and re-run later" \
               --label "automation-failure,needs-human"
           else
             echo "Duplicate WR #${EXISTING} already exists"

--- a/.github/workflows/commit-queue-monitor.yml
+++ b/.github/workflows/commit-queue-monitor.yml
@@ -16,7 +16,7 @@ jobs:
   monitor:
     runs-on: ubuntu-latest
     env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Evaluate commit queue backlog
         uses: actions/github-script@v8

--- a/.github/workflows/issue-state-machine.yml
+++ b/.github/workflows/issue-state-machine.yml
@@ -101,19 +101,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-    if: github.event_name == 'issues' && github.event.action == 'opened' &&
-      !contains(github.event.issue.labels.*.name, 'wr:')
+    if: github.event_name == 'issues' && github.event.action == 'opened'
     steps:
-      - name: Add initial label
+      - name: Add wr:new label
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              labels: ['wr:new']
-            });
+            const labels = context.payload.issue.labels.map(l => l.name);
+            if (!labels.some(l => l.startsWith('wr:'))) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels: ['wr:new']
+              });
+              console.log('Added wr:new label');
+            } else {
+              console.log('Issue already has wr:* label:', labels.filter(l => l.startsWith('wr:')));
+            }
     timeout-minutes: 15
   transition-state:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes automation not auto-labeling new issues.

### Changes

1. **Remove restrictive condition** - Was checking in YAML condition, now checks in JavaScript
2. **Check label in script** - Will add wr:new if no existing wr:* label
3. **Also includes**: 13 WR labels + workflow YAML fixes from previous work

### To test

1. Create new issue in GitHub UI
2. Should auto-get wr:new label
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/midnghtsapphire/revvel-standards/pull/13446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes the GitHub issue auto-labeling automation by moving the check for existing `wr:*` labels from the YAML workflow condition into the JavaScript logic. The change ensures that newly created issues are automatically tagged with the `wr:new` label only if they don't already have a workflow-related label. Additionally, the PR includes minor cleanup changes such as formatting adjustments and simplification of issue creation logic in related workflow files.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/issue-state-machine.yml` |
| 2 | `.github/workflows/commit-queue-monitor.yml` |
| 3 | `.github/workflows/api-rate-limit-handler.yml` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `.github/workflows/api-rate-limit-handler.yml` | This file contains refactoring of issue body creation (from heredoc to inline string) which is unrelated to the main purpose of fixing wr:new label auto-addition |
| `.github/workflows/commit-queue-monitor.yml` | This file only contains an indentation formatting change that is unrelated to the issue auto-labeling fix |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-adds the `wr:new` label to newly opened issues by checking labels in the script instead of a restrictive YAML condition. Also cleans up workflow YAML and updates the rate-limit handler message and labels.

- **Bug Fixes**
  - issue-state-machine: Check for existing `wr:*` in JavaScript; add `wr:new` only if none found.
  - api-rate-limit-handler: Inline issue body and set labels via `--label` (`automation-failure,needs-human`).
  - commit-queue-monitor: Fix env indentation for `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.

<sup>Written for commit 304338eee70c4e622b7c1341b7e4545f87e998d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow conditions/scripts and issue/label creation behavior, with no application runtime impact.
> 
> **Overview**
> Ensures newly opened issues get `wr:new` reliably by running the `set-initial-state` job on every `issues.opened` event and moving the “no existing `wr:*` label” check into the `github-script` step.
> 
> Also simplifies the API rate-limit handler’s issue body construction and updates the created issue’s labels, and fixes a YAML indentation issue for `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` in `commit-queue-monitor.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304338eee70c4e622b7c1341b7e4545f87e998d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->