### PR TITLE
fix: recover stuck WR PR label flow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -408,6 +408,22 @@ labels:
     color: "0e8a16"
     description: "WR task completed with findings documented"
 
+  - name: "wr:retrigger-attempts-1"
+    color: "fef2c0"
+    description: "WR PR auto-healer retry attempt 1"
+
+  - name: "wr:retrigger-attempts-2"
+    color: "f9d71c"
+    description: "WR PR auto-healer retry attempt 2"
+
+  - name: "wr:retrigger-attempts-3"
+    color: "d93f0b"
+    description: "WR PR auto-healer retry attempt 3"
+
+  - name: wr-stuck
+    color: "b60205"
+    description: "WR auto-healer escalation tracking"
+
   # -- Research Engine Orchestrator --------------------------------------------
   - name: research-engine
     color: "6f42c1"

--- a/.github/workflows/wr-pr-creation.yml
+++ b/.github/workflows/wr-pr-creation.yml
@@ -249,6 +249,7 @@ jobs:
     env:
       ISSUE_NUMBER: ${{ needs.detect-completion.outputs.issue_number }}
       ISSUE_TITLE: ${{ needs.detect-completion.outputs.issue_title }}
+      ISSUE_BODY: ${{ needs.detect-completion.outputs.issue_body }}
       JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
     steps:
       - name: Checkout repository
@@ -372,16 +373,53 @@ jobs:
 
           echo "WR_FILE=${WR_FILE}" >> $GITHUB_ENV
 
-          # Copy template
-          cp wr/WR_TEMPLATE.md "${WR_FILE}"
+          # Copy the repo's canonical WR template. Keep fallbacks so this
+          # workflow does not get stuck if the template layout changes again.
+          TEMPLATE_FILE=""
+          for candidate in wr/WR_TEMPLATE_FULL.md wr/WR_TEMPLATE_BASIC.md WR_TEMPLATE_FULL.md WR_TEMPLATE_BASIC.md; do
+            if [[ -f "$candidate" ]]; then
+              TEMPLATE_FILE="$candidate"
+              break
+            fi
+          done
 
-          # Replace placeholders with actual values
-          sed -i "s#{REPO_NAME}#midnghtsapphire/revvel-standards#g" "${WR_FILE}"
-          sed -i "s#{REPO_URL}#https://github.com/midnghtsapphire/revvel-standards#g" "${WR_FILE}"
-          sed -i "s#{CREATED_DATE}#$(date -u +%Y-%m-%d)#g" "${WR_FILE}"
-          sed -i "s#{UPDATED_DATE}#$(date -u +%Y-%m-%d)#g" "${WR_FILE}"
-          sed -i "s#{RESEARCH_DATE}#$(date -u +%Y-%m-%d)#g" "${WR_FILE}"
-          sed -i "s#{PRIMARY_LANGUAGE}#JavaScript#g" "${WR_FILE}"
+          if [[ -z "$TEMPLATE_FILE" ]]; then
+            echo "::error::No WR template found. Expected wr/WR_TEMPLATE_FULL.md or wr/WR_TEMPLATE_BASIC.md."
+            exit 1
+          fi
+
+          echo "Using WR template: ${TEMPLATE_FILE}"
+          cp "${TEMPLATE_FILE}" "${WR_FILE}"
+
+          # Replace placeholders with actual values without depending on sed
+          # delimiter escaping for issue titles/bodies.
+          export WR_FILE ISSUE_TITLE ISSUE_BODY
+          python3 - <<'PY'
+          import datetime
+          import os
+          import pathlib
+          import re
+
+          wr_file = pathlib.Path(os.environ["WR_FILE"])
+          title = os.environ.get("ISSUE_TITLE", "")
+          body = os.environ.get("ISSUE_BODY", "")
+          clean_title = re.sub(r"^\[WR\]\s*", "", title, flags=re.IGNORECASE).strip() or title
+          today = datetime.datetime.utcnow().strftime("%Y-%m-%d")
+          replacements = {
+              "{REPO_NAME}": "midnghtsapphire/revvel-standards",
+              "{REPO_URL}": "https://github.com/midnghtsapphire/revvel-standards",
+              "{CREATED_DATE}": today,
+              "{UPDATED_DATE}": today,
+              "{RESEARCH_DATE}": today,
+              "{PRIMARY_LANGUAGE}": "JavaScript",
+              "{TITLE}": clean_title,
+              "{DESCRIPTION}": body,
+          }
+          text = wr_file.read_text(encoding="utf8")
+          for key, value in replacements.items():
+              text = text.replace(key, value)
+          wr_file.write_text(text, encoding="utf8")
+          PY
 
           # Insert issue information at the top
           cat > temp_header.md <<EOF
@@ -412,7 +450,7 @@ jobs:
           mv temp_header.md "${WR_FILE}"
 
           # Read Output Type from issue body and skip app scaffolding if it's a PDF/doc
-          OUTPUT_TYPE=$(echo "${{ env.ISSUE_BODY }}" | grep -A 2 "### Output Type" | tail -n 1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -d '\r')
+          OUTPUT_TYPE=$(printf '%s\n' "$ISSUE_BODY" | awk '/^### Output Type/{getline; while ($0 == "") getline; print; exit}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -d '\r')
 
           if [[ "$OUTPUT_TYPE" == "sellable-pdf" || "$OUTPUT_TYPE" == "technical-documentation" || "$OUTPUT_TYPE" == "project-management-doc" ]]; then
             echo "Output Type is $OUTPUT_TYPE — stripping app deployment scaffolding from WR document."
@@ -639,16 +677,36 @@ jobs:
               labels: ['in-review'],
             });
 
-            // Remove wr:complete if present (since we're now in refinement phase)
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                name: 'wr:complete',
-              });
-            } catch (error) {
-              // Label might not exist, ignore
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+
+            // Remove completion and auto-healer labels once the PR exists so
+            // the issue no longer appears stuck after recovery.
+            const labelsToRemove = currentLabels
+              .map(label => label.name)
+              .filter(name =>
+                name === 'wr:complete' ||
+                name === 'lifecycle:stuck' ||
+                name === 'wr-stuck' ||
+                name.startsWith('wr:retrigger-attempts-')
+              );
+
+            for (const name of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name,
+                });
+                core.info(`Removed recovered WR label: ${name}`);
+              } catch (error) {
+                core.notice(`Could not remove label "${name}": ${error.message}`);
+              }
             }
       - name: Handle workflow failure
         if: failure()

--- a/.github/workflows/wr-pr-creation.yml
+++ b/.github/workflows/wr-pr-creation.yml
@@ -450,7 +450,7 @@ jobs:
             echo "" >> temp_header.md
           fi
 
-          # Append the rest of the template (skip first few lines to avoid duplication)
+          OUTPUT_TYPE=$(printf '%s\n' "$ISSUE_BODY" | awk '/^### Output Type$/ { found=1; next } found && NF { print; exit }' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -d '\r')
           tail -n +10 "${WR_FILE}" >> temp_header.md
 
           mv temp_header.md "${WR_FILE}"

--- a/tests/work-request-form-sync.test.js
+++ b/tests/work-request-form-sync.test.js
@@ -221,6 +221,43 @@ test('WR PR creation mirrors deep research labels onto the generated PR', () => 
   );
 });
 
+test('WR PR creation uses an existing template and clears recovered stuck labels', () => {
+  const wrPrCreation = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-pr-creation.yml'),
+    'utf8'
+  );
+  const labelsYaml = fs.readFileSync(path.join(REPO_ROOT, '.github', 'labels.yml'), 'utf8');
+
+  assert(
+    fs.statSync(path.join(REPO_ROOT, 'wr', 'WR_TEMPLATE_FULL.md')).isFile(),
+    'Canonical full WR template must exist'
+  );
+  assert(
+    wrPrCreation.includes('wr/WR_TEMPLATE_FULL.md') &&
+      wrPrCreation.includes('wr/WR_TEMPLATE_BASIC.md'),
+    'WR PR creation must use existing WR template paths'
+  );
+  assert(
+    wrPrCreation.includes('ISSUE_BODY: ${{ needs.detect-completion.outputs.issue_body }}'),
+    'WR PR creation must pass the issue body into document generation'
+  );
+  assert(
+    wrPrCreation.includes("name.startsWith('wr:retrigger-attempts-')") &&
+      wrPrCreation.includes("name === 'lifecycle:stuck'") &&
+      wrPrCreation.includes("name === 'wr-stuck'"),
+    'WR PR creation must clear auto-healer stuck labels after a PR is created'
+  );
+
+  for (const label of [
+    'wr:retrigger-attempts-1',
+    'wr:retrigger-attempts-2',
+    'wr:retrigger-attempts-3',
+    'wr-stuck',
+  ]) {
+    assertLabelDefinition(labelsYaml, label);
+  }
+});
+
 test('Work Request Output Type options match wr-auto-classify DROPDOWN_FIELDS', () => {
   const tmplPath = path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', '00-work-request.yml');
   const tmpl = fs.readFileSync(tmplPath, 'utf8');

--- a/tests/workflow-yaml-validation.test.js
+++ b/tests/workflow-yaml-validation.test.js
@@ -214,6 +214,7 @@ test('wr-pr-creation.yml github-script blocks compile after workflow expression 
   const namesToCompile = new Set([
     'Check if PR should be created',
     'Apply labels to PR',
+    'Update issue labels',
   ]);
 
   for (const step of steps) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the stuck WR auto-healer path that was failing to create a WR PR for #13634 because `wr-pr-creation.yml` referenced a missing `wr/WR_TEMPLATE.md` file. Related to #13634; this intentionally does not close the WR issue because the requested product bundle still needs a follow-up implementation PR after the control-plane recovery is merged.

## Changes

- Select an existing WR template (`wr/WR_TEMPLATE_FULL.md` with safe fallbacks) instead of the missing `wr/WR_TEMPLATE.md`.
- Pass the issue body into WR document generation so Output Type parsing is not blank.
- Clear recovered WR auto-healer labels (`wr:retrigger-attempts-*`, `wr-stuck`, `lifecycle:stuck`, `wr:complete`) once a PR is successfully created.
- Add canonical labels for WR retry/escalation states and regression coverage for the workflow contract.

## Validation

- `node tests/work-request-form-sync.test.js && node tests/workflow-yaml-validation.test.js && node tests/stuck-wr-detector.test.js`
- Result: passing (`389 passed, 0 failed` in workflow YAML validation; `6 passed, 0 failed` in stuck-WR detector tests).

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — intentionally unchecked; this is a control-plane fix related to #13634, not the product-bundle delivery.
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9c5b7b7-e9ae-402d-8086-19bbf2700b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9c5b7b7-e9ae-402d-8086-19bbf2700b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a stuck Work Request (WR) auto-healer workflow that was failing because it referenced a missing template file. The changes include: using an existing template file (`wr/WR_TEMPLATE_FULL.md`) with safe fallbacks, passing the issue body into WR document generation to prevent blank output type parsing, clearing auto-healer recovery labels (`wr:retrigger-attempts-*`, `wr-stuck`, `lifecycle:stuck`, `wr:complete`) after a PR is successfully created, and adding canonical label definitions for WR retry and escalation states. Test coverage is added to validate the workflow contract and ensure the template paths exist.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/labels.yml` |
| 2 | `tests/work-request-form-sync.test.js` |
| 3 | `tests/workflow-yaml-validation.test.js` |
| 4 | `.github/workflows/wr-pr-creation.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the WR auto-healer so it creates PRs again and clears “stuck” labels after recovery. Expands template fallbacks (now includes root-level `WR_TEMPLATE_*`) and safely injects issue title/body to generate correct docs.

- **Bug Fixes**
  - Selects an existing WR template with safe fallbacks (includes root `WR_TEMPLATE_FULL.md`/`WR_TEMPLATE_BASIC.md`); fails fast if none are found.
  - Generates WR docs with Python-based placeholder replacement using `ISSUE_TITLE` and `ISSUE_BODY` to avoid sed escaping and fix Output Type parsing.
  - Adds a label-cleanup step to remove recovery/stuck labels after PR creation (`wr:retrigger-attempts-*`, `wr-stuck`, `lifecycle:stuck`, `wr:complete`) and ensures all labels are fetched before removal.
  - Defines canonical retry/escalation labels in `.github/labels.yml` and extends tests to cover template paths, env wiring, label cleanup, PR/step compilation.

<sup>Written for commit 3135ce2f8808b804efe1e339a216bf9467feb71c. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13644?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

