### PR TITLE
fix: stop WR PR comment retry loops

### DIFF
--- a/.github/workflows/wr-pr-creation.yml
+++ b/.github/workflows/wr-pr-creation.yml
@@ -34,6 +34,8 @@ jobs:
          startsWith(github.event.issue.title, '[ALERT]')))
     outputs:
       should_create_pr: ${{ steps.check.outputs.should_create_pr }}
+      should_notify_skip: ${{ steps.check.outputs.should_notify_skip }}
+      skip_reason: ${{ steps.check.outputs.skip_reason }}
       issue_number: ${{ steps.check.outputs.issue_number }}
       issue_title: ${{ steps.check.outputs.issue_title }}
       issue_body: ${{ steps.check.outputs.issue_body }}
@@ -44,9 +46,32 @@ jobs:
         with:
           script: |
             const issueNumber = context.payload.issue?.number || context.payload.inputs?.issue_number;
+            function skip(reason, { notify = context.eventName !== 'issue_comment' } = {}) {
+              core.info(`Skipping WR PR creation: ${reason}`);
+              core.setOutput('should_create_pr', 'false');
+              core.setOutput('should_notify_skip', notify ? 'true' : 'false');
+              core.setOutput('skip_reason', reason);
+            }
+
             if (!issueNumber) {
               core.notice('No issue number found');
-              core.setOutput('should_create_pr', 'false');
+              skip('no_issue_number', { notify: false });
+              return;
+            }
+
+            const commentBody = context.payload.comment?.body || '';
+            const commentAuthor = context.payload.comment?.user?.login || '';
+            const operationalCommentMarkers = [
+              'WR PR Creation Failed',
+              'WR PR Creation: Skipped',
+              'WR PR Created!',
+            ];
+            const isOperationalBotComment =
+              context.eventName === 'issue_comment' &&
+              commentAuthor === 'github-actions[bot]' &&
+              operationalCommentMarkers.some(marker => commentBody.includes(marker));
+            if (isOperationalBotComment) {
+              skip('operational_bot_comment', { notify: false });
               return;
             }
 
@@ -74,7 +99,7 @@ jobs:
               ['basic wr', 'wr', 'work request'].includes(normalizedIssueType);
             if (!isWR) {
               core.info(`Issue #${issueNumber} is not a WR issue`);
-              core.setOutput('should_create_pr', 'false');
+              skip('not_wr_issue');
               return;
             }
 
@@ -82,7 +107,7 @@ jobs:
             // by the job-level `if:` already).
             if (issue.user && issue.user.login === 'github-actions[bot]') {
               core.info(`Issue #${issueNumber} is bot-created; skipping.`);
-              core.setOutput('should_create_pr', 'false');
+              skip('bot_created_issue');
               return;
             }
 
@@ -157,7 +182,7 @@ jobs:
 
             if (existingPR) {
               core.info(`WR-skeleton PR already exists for issue #${issueNumber}: ${existingPR.html_url}`);
-              core.setOutput('should_create_pr', 'false');
+              skip('existing_wr_pr');
               return;
             }
 
@@ -193,6 +218,8 @@ jobs:
             core.info(`Current labels: ${Array.from(labelSet).join(', ')}`);
 
             core.setOutput('should_create_pr', shouldCreate ? 'true' : 'false');
+            core.setOutput('should_notify_skip', shouldCreate || context.eventName === 'issue_comment' ? 'false' : 'true');
+            core.setOutput('skip_reason', shouldCreate ? '' : 'trigger_not_ready');
             core.setOutput('issue_number', String(issueNumber));
             core.setOutput('issue_title', title);
             core.setOutput('issue_body', body);
@@ -200,7 +227,7 @@ jobs:
   notify-skip:
     name: Notify if PR creation was skipped
     needs: detect-completion
-    if: needs.detect-completion.outputs.should_create_pr != 'true'
+    if: needs.detect-completion.outputs.should_create_pr != 'true' && needs.detect-completion.outputs.should_notify_skip == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Post skip notification

--- a/tests/workflow-yaml-validation.test.js
+++ b/tests/workflow-yaml-validation.test.js
@@ -258,6 +258,41 @@ test('wr-pr-creation.yml uses existing WR templates and preserves issue body', (
   }
 });
 
+test('wr-pr-creation.yml suppresses operational issue_comment retry loops', () => {
+  const filePath = path.join(WORKFLOWS_DIR, 'wr-pr-creation.yml');
+  const doc = yaml.parse(fs.readFileSync(filePath, 'utf8'));
+  const detectJob = doc.jobs['detect-completion'];
+  const notifyJob = doc.jobs['notify-skip'];
+  const checkStep = detectJob.steps.find((step) => step.name === 'Check if PR should be created');
+
+  if (!detectJob.outputs?.should_notify_skip || !detectJob.outputs?.skip_reason) {
+    throw new Error('detect-completion must expose skip notification outputs');
+  }
+  if (!checkStep) {
+    throw new Error('Check if PR should be created step not found');
+  }
+
+  const script = checkStep.with?.script || '';
+  const requiredSnippets = [
+    'operationalCommentMarkers',
+    'WR PR Creation Failed',
+    'WR PR Creation: Skipped',
+    'WR PR Created!',
+    'operational_bot_comment',
+    "context.eventName !== 'issue_comment'",
+  ];
+  for (const snippet of requiredSnippets) {
+    if (!script.includes(snippet)) {
+      throw new Error(`WR PR detection must suppress retry loops; missing ${snippet}`);
+    }
+  }
+
+  const notifyIf = String(notifyJob.if || '');
+  if (!notifyIf.includes("needs.detect-completion.outputs.should_notify_skip == 'true'")) {
+    throw new Error('notify-skip job must honor should_notify_skip');
+  }
+});
+
 test('stuck-wr-detector.yml routes exhausted WR retries to agent fallback and OpenRouter', () => {
   const filePath = path.join(WORKFLOWS_DIR, 'stuck-wr-detector.yml');
   const doc = yaml.parse(fs.readFileSync(filePath, 'utf8'));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardens the WR PR creation workflow so bot-authored operational comments do not retrigger PR creation and skipped comment-triggered runs do not post another skip comment. Related to #13630.

## Changes

- Add skip metadata outputs to `detect-completion`.
- Ignore `github-actions[bot]` operational comments for WR PR failed/skipped/created notifications.
- Gate the skip notification job behind `should_notify_skip` so ordinary `issue_comment` skips stay silent.
- Add workflow validation coverage for the retry-loop guard.

## Validation

- `node tests/workflow-yaml-validation.test.js` — 395 passed, 0 failed
- `node tests/research-engine.test.js && node tests/stuck-wr-detector.test.js` — focused tests passed

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge (not used: this is process hardening related to #13630; the WR implementation PR already links that issue)
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-336d98df-5fcd-43c2-b06e-bb01bc5b4396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-336d98df-5fcd-43c2-b06e-bb01bc5b4396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR prevents infinite retry loops in the WR (Work Request) PR creation workflow by filtering out bot-authored operational comments (like "WR PR Creation Failed", "WR PR Creation: Skipped", "WR PR Created!") so they don't retrigger the workflow. It adds `should_notify_skip` and `skip_reason` metadata outputs to the `detect-completion` job, gates the skip notification behind a condition to prevent redundant comments, and includes test coverage to validate the retry-loop guard logic.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tests/workflow-yaml-validation.test.js` |
| 2 | `.github/workflows/wr-pr-creation.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops comment-triggered retry loops in the WR PR creation workflow. Ignores operational comments from `github-actions[bot]` and only posts skip notices when needed.

- **Bug Fixes**
  - Added `should_notify_skip` and `skip_reason` outputs to `detect-completion`, and gated `notify-skip` on `should_notify_skip`.
  - Filtered operational bot comments ("WR PR Creation Failed", "WR PR Creation: Skipped", "WR PR Created!") so they don’t retrigger the workflow.
  - Added workflow YAML validation to enforce the retry-loop guard.

<sup>Written for commit 99b04bf28fa2bb099819fdbc768a877b4136291f. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13659?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

