### PR TITLE
Add email-error intake (turn error emails into auto-handled issues)

### DIFF
--- a/.github/workflows/email-error-intake.yml
+++ b/.github/workflows/email-error-intake.yml
@@ -1,0 +1,52 @@
+name: Email Error Intake
+
+# Reads UNREAD "error" emails from an inbox and opens one GitHub issue per error,
+# so the existing route -> research -> fix -> heal pipeline can handle them.
+# See docs/process/EMAIL_ERROR_INTAKE.md.
+#
+# Rollout: manual + dry-run first. Run it once with dry_run=true to confirm it
+# connects and catches the right mail (it creates nothing). Once verified, run
+# with dry_run=false, then a schedule can be enabled.
+#
+# Required repo secrets:
+#   ERROR_INBOX_ADDRESS       inbox to read (e.g. you@gmail.com)
+#   ERROR_INBOX_APP_PASSWORD  Gmail App Password (not the login password)
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log what would be filed without creating issues'
+        type: boolean
+        default: true
+      max_issues:
+        description: 'Max issues to open this run'
+        type: string
+        default: '5'
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: email-error-intake
+  cancel-in-progress: false
+
+jobs:
+  intake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Read inbox and open issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ERROR_INBOX_ADDRESS: ${{ secrets.ERROR_INBOX_ADDRESS }}
+          ERROR_INBOX_APP_PASSWORD: ${{ secrets.ERROR_INBOX_APP_PASSWORD }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          MAX_ISSUES: ${{ inputs.max_issues }}
+        run: python3 scripts/email_error_intake.py

--- a/scripts/email_error_intake.py
+++ b/scripts/email_error_intake.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Email Error Intake.
+
+Reads UNREAD "error" emails from an inbox over IMAP and opens one GitHub issue
+per error, so the existing route -> research -> fix -> heal pipeline can handle
+them. Read-only on the inbox: it marks processed error mails as read; it never
+sends, moves, or deletes anything.
+
+Safety:
+  - Exits cleanly (no failure) if the inbox secrets are not set.
+  - DRY_RUN=true logs what it WOULD file and changes nothing (recommended first run).
+  - Only acts on mails whose subject matches an error keyword (and, if an allow
+    list is set, whose sender matches). Non-matching mail is left untouched.
+  - Caps issues per run (MAX_ISSUES) and labels them `needs-triage` so a human /
+    oAudrey reviews before any auto-coding.
+
+Environment:
+  ERROR_INBOX_ADDRESS       inbox to read, e.g. you@gmail.com   (required)
+  ERROR_INBOX_APP_PASSWORD  Gmail App Password (NOT your login) (required)
+  IMAP_HOST                 default: imap.gmail.com
+  REPO                      owner/repo for gh issue create
+  GH_TOKEN                  token for gh (provided by Actions)
+  ERROR_SUBJECT_KEYWORDS    comma list; default below
+  ERROR_SENDERS             optional comma list of allowed sender substrings
+  MAX_ISSUES                cap per run; default 5
+  DRY_RUN                   'true' to log without creating issues / marking read
+"""
+
+import email
+import imaplib
+import json
+import os
+import ssl
+import subprocess
+import tempfile
+from email.header import decode_header
+
+DEFAULT_KEYWORDS = "error,failed,failure,alert,exception,timeout,down,5xx,crash"
+
+
+def env(key, default=""):
+    return os.environ.get(key, default)
+
+
+def decode_mime(value):
+    if not value:
+        return ""
+    out = ""
+    for text, enc in decode_header(value):
+        if isinstance(text, bytes):
+            out += text.decode(enc or "utf-8", "replace")
+        else:
+            out += text
+    return out.strip()
+
+
+def is_error_mail(subject, sender, keywords, senders):
+    """An error mail = subject hits a keyword AND (no sender allow list OR sender matches)."""
+    s = (subject or "").lower()
+    keyword_hit = any(k and k in s for k in keywords)
+    sender_ok = (not senders) or any(x and x in (sender or "").lower() for x in senders)
+    return keyword_hit and sender_ok
+
+
+def extract_text(msg):
+    if msg.is_multipart():
+        for part in msg.walk():
+            disp = str(part.get("Content-Disposition", ""))
+            if part.get_content_type() == "text/plain" and "attachment" not in disp:
+                payload = part.get_payload(decode=True)
+                if payload:
+                    return payload.decode(part.get_content_charset() or "utf-8", "replace")
+        return ""
+    payload = msg.get_payload(decode=True)
+    if payload:
+        return payload.decode(msg.get_content_charset() or "utf-8", "replace")
+    return str(msg.get_payload())
+
+
+def already_filed(repo, marker):
+    """Best-effort dedupe: has an issue already been filed for this Message-ID?"""
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "list", "--repo", repo, "--search", marker,
+             "--state", "all", "--json", "number"],
+            capture_output=True, text=True, check=False,
+        )
+        return len(json.loads(result.stdout or "[]")) > 0
+    except Exception:
+        return False
+
+
+def create_issue(repo, title, body):
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as tf:
+        tf.write(body)
+        path = tf.name
+    result = subprocess.run(
+        ["gh", "issue", "create", "--repo", repo, "--title", title,
+         "--body-file", path,
+         "--label", "work-request", "--label", "agent-fallback",
+         "--label", "openrouter", "--label", "needs-triage"],
+        capture_output=True, text=True, check=False,
+    )
+    print(result.stdout.strip() or result.stderr.strip())
+
+
+def main():
+    addr = env("ERROR_INBOX_ADDRESS")
+    pw = env("ERROR_INBOX_APP_PASSWORD")
+    if not addr or not pw:
+        print("::warning::ERROR_INBOX_ADDRESS / ERROR_INBOX_APP_PASSWORD not set — "
+              "skipping email intake (no failure).")
+        return 0
+
+    repo = env("REPO")
+    host = env("IMAP_HOST", "imap.gmail.com")
+    keywords = [k.strip().lower() for k in env("ERROR_SUBJECT_KEYWORDS", DEFAULT_KEYWORDS).split(",") if k.strip()]
+    senders = [x.strip() for x in env("ERROR_SENDERS", "").split(",") if x.strip()]
+    try:
+        max_issues = max(1, int(env("MAX_ISSUES", "5") or "5"))
+    except ValueError:
+        max_issues = 5
+    dry_run = env("DRY_RUN", "").lower() == "true"
+
+    box = imaplib.IMAP4_SSL(host, ssl_context=ssl.create_default_context())
+    box.login(addr, pw)
+    box.select("INBOX")
+    typ, data = box.search(None, "UNSEEN")
+    ids = data[0].split() if (typ == "OK" and data and data[0]) else []
+    print(f"{len(ids)} unread message(s); DRY_RUN={dry_run}.")
+
+    created = 0
+    for num in ids:
+        if created >= max_issues:
+            print(f"Reached MAX_ISSUES={max_issues}; stopping.")
+            break
+        typ, msgdata = box.fetch(num, "(RFC822)")
+        if typ != "OK" or not msgdata or not msgdata[0]:
+            continue
+        msg = email.message_from_bytes(msgdata[0][1])
+        subject = decode_mime(msg.get("Subject"))
+        sender = decode_mime(msg.get("From"))
+        if not is_error_mail(subject, sender, keywords, senders):
+            continue  # leave non-error mail untouched (still unread)
+
+        msgid = (msg.get("Message-ID") or "").strip()
+        marker = f"email-error-intake:{msgid}"
+        title = (f"[email-error] {subject or '(no subject)'}")[:120]
+        body = (
+            "Auto-filed from an error email by `email_error_intake.py`.\n\n"
+            f"- **From:** {sender}\n"
+            f"- **Date:** {decode_mime(msg.get('Date'))}\n"
+            f"- **Message-ID:** `{msgid}`\n\n"
+            "### Excerpt\n\n```\n"
+            f"{extract_text(msg)[:1500]}\n"
+            "```\n\n"
+            f"<!-- {marker} -->\n"
+        )
+
+        if dry_run:
+            print(f"[dry-run] would open issue: {title}")
+            continue
+        if msgid and already_filed(repo, marker):
+            print(f"Already filed for {msgid}; marking read.")
+        else:
+            create_issue(repo, title, body)
+            created += 1
+        box.store(num, "+FLAGS", "\\Seen")
+
+    box.logout()
+    print(f"Done. Opened {created} issue(s) this run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the email→issue bridge so the agent pipeline can handle errors that land in your inbox. (Companion to the doc in #13726.)

- **`scripts/email_error_intake.py`** — reads UNREAD "error" mail over IMAP (Python stdlib only, no new deps), filters by subject keyword (+ optional sender allowlist), and opens **one labeled GitHub issue per error** (`work-request`, `agent-fallback`, `openrouter`, `needs-triage`) with Message-ID dedupe. The existing route → research → fix → heal pipeline takes it from there.
- **`.github/workflows/email-error-intake.yml`** — manual trigger, **dry-run-first**.

## Read-only + safe by design

- Read-only on the inbox: marks processed error mail as read; **never sends, moves, or deletes**.
- Exits cleanly (no failure) if the inbox secrets aren't set.
- Caps issues per run; labels `needs-triage` so you/oAudrey review before any auto-coding.
- Non-error mail (newsletters, etc.) is left untouched.

## How to turn it on

1. Confirm two repo secrets exist: **`ERROR_INBOX_ADDRESS`** (e.g. `you@gmail.com`) and **`ERROR_INBOX_APP_PASSWORD`** (a Gmail App Password). If your secrets are named differently, tell me and I'll match them.
2. Run the workflow manually with **dry_run = true** → it logs what it *would* file, creates nothing. Confirm it connected and caught the right emails.
3. Run with **dry_run = false** to file real issues. Once you trust it, I'll add a schedule (cron) for 24/7.

## Test plan

- [x] `python3 -m py_compile` passes; filter logic verified (error → yes, newsletter → no, sender allowlist respected).
- [x] Workflow parses and passes the repo's workflow-YAML validator.
- [ ] Manual dry-run connects to the inbox and lists candidate errors.
- [ ] Live run opens correctly-labeled issues; pipeline picks them up.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds an automated email-to-GitHub-issue bridge that monitors an inbox for error emails and converts them into labeled GitHub issues for the agent pipeline to handle. The implementation includes a Python script (`email_error_intake.py`) that reads unread emails via IMAP, filters them by subject keywords and optional sender allowlist, creates deduplicated GitHub issues with appropriate labels (`work-request`, `agent-fallback`, `openrouter`, `needs-triage`), and marks processed emails as read. A GitHub Actions workflow (`email-error-intake.yml`) provides manual triggering with dry-run capability for safe rollout. The system is designed to be read-only on the inbox (never sends, moves, or deletes), caps issues per run, and gracefully exits if inbox credentials aren't configured.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/email_error_intake.py` |
| 2 | `.github/workflows/email-error-intake.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turn error emails into auto-filed GitHub issues so the agent pipeline can triage and fix them. Adds a safe, dry-runnable IMAP intake with guardrails and no new dependencies.

- **New Features**
  - Added `scripts/email_error_intake.py`: reads UNSEEN mail via IMAP (stdlib only), filters by subject keywords (+ optional sender allowlist), dedupes by Message-ID, opens one issue per error with labels (`work-request`, `agent-fallback`, `openrouter`, `needs-triage`), and marks processed mail as read (never moves/deletes).
  - Added `.github/workflows/email-error-intake.yml`: manual trigger with `dry_run` (default true) and `max_issues`; exits cleanly if inbox secrets are missing; uses `gh` to file issues; concurrency-safe.

- **Migration**
  - Add repo secrets: `ERROR_INBOX_ADDRESS` and `ERROR_INBOX_APP_PASSWORD`.
  - Run the workflow with `dry_run = true` to verify connection and candidates.
  - Run with `dry_run = false` to create issues; add a schedule later if desired.

<sup>Written for commit 341ca8d215b33ff2c5ad151d5954c61e01b8f593. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13729?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Action that accesses an external IMAP inbox and can auto-create GitHub issues; misconfiguration could spam issues or mark emails as read despite guardrails like dry-run and issue caps.
> 
> **Overview**
> Introduces an *email→issue intake* automation: a new `Email Error Intake` GitHub Action can be manually run (default **dry-run**) to scan an IMAP inbox for unread emails whose subject matches configurable error keywords (optionally restricted by sender), then open labeled GitHub issues with an excerpt and Message-ID marker for dedupe.
> 
> Adds `scripts/email_error_intake.py` (stdlib-only) to connect via IMAP using repo secrets, cap filings via `MAX_ISSUES`, and mark only processed error emails as read; the workflow wires required env/secrets and ensures single-run concurrency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 341ca8d215b33ff2c5ad151d5954c61e01b8f593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->