### PR TITLE
Persona executor v1 — action comments file real work (not just replies)

### DIFF
--- a/scripts/persona-comment-runner.js
+++ b/scripts/persona-comment-runner.js
@@ -8,11 +8,17 @@
  *   - "@professor <task>"  / "@oaudrey ..." / "@mindmappr ..." / "@openrouter ..."
  *   - "/persona <name> <task>"
  *
- * Parses the trigger, instantiates the persona via scripts/openrouter-personas.js
- * (eager mode), and posts the reply back to the thread with gh. No-ops cleanly
- * when the comment contains no persona trigger.
+ * Two modes:
+ *   - ADVISORY (a question): instantiates the persona and posts a text reply.
+ *   - EXECUTION (an action verb like build/implement/create/fix/ship): instead of
+ *     talking, the persona files a real Work Request issue and triggers the
+ *     working coder (openrouter-coder) — so the persona DOES instead of describes.
+ *
+ * No-ops cleanly when the comment contains no persona trigger.
  *
  * 2026-05-21 (Claude): created for the comment-trigger persona lane.
+ * 2026-05-22 (Claude): added EXECUTION mode so action comments produce a real
+ * artifact (a Work Request that the pipeline implements), not just a reply.
  *
  * Env: COMMENT_BODY, ISSUE_NUMBER, REPO (owner/repo), OPENROUTER_API_KEY, GH_TOKEN
  */
@@ -21,11 +27,19 @@ const fs = require("fs");
 const { execFileSync } = require("child_process");
 const { instantiate, getPersonas } = require("./openrouter-personas");
 
+// Verbs that mean "do the thing" rather than "tell me about it".
+const ACTION_VERBS = ["build", "implement", "create", "fix", "ship", "make", "add"];
+
+function detectAction(task) {
+  const m = (task || "").match(/^\s*(build|implement|create|fix|ship|make|add)\b/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
 /**
  * Parse a persona trigger out of a comment body.
  *
  * @param {string} body - The comment body.
- * @returns {{handle: string, task: string} | null} Parsed command, or null.
+ * @returns {{handle: string, task: string, action: (string|null)} | null}
  */
 function parsePersonaCommand(body) {
   if (!body || typeof body !== "string") return null;
@@ -36,8 +50,8 @@ function parsePersonaCommand(body) {
   if (slash) {
     const handle = slash[1].toLowerCase();
     if (handles.includes(handle)) {
-      const task = (slash[2] || "").trim();
-      return { handle, task: task || body.trim() };
+      const rest = (slash[2] || "").trim();
+      return { handle, task: rest || body.trim(), action: detectAction(rest) };
     }
   }
 
@@ -45,8 +59,8 @@ function parsePersonaCommand(body) {
   for (const handle of handles) {
     const mention = new RegExp(`@${handle}\\b`, "i");
     if (mention.test(body)) {
-      const task = body.replace(mention, "").trim();
-      return { handle, task: task || body.trim() };
+      const rest = body.replace(mention, "").trim();
+      return { handle, task: rest || body.trim(), action: detectAction(rest) };
     }
   }
 
@@ -63,6 +77,34 @@ function postComment(repo, issueNumber, markdown) {
   );
 }
 
+/**
+ * EXECUTION mode: file a real Work Request issue and trigger the working coder.
+ * Returns the new issue number (or the raw gh output if it can't be parsed).
+ */
+function openWorkRequest({ repo, handle, action, task, requestedOn }) {
+  const title = `[WR] ${task}`.slice(0, 120);
+  const body = [
+    `Filed by the **${handle}** persona (action: \`${action}\`) from a comment on #${requestedOn}.`,
+    "",
+    "## Request",
+    "",
+    task,
+    "",
+    "_Routed into the build pipeline via labels (`wr:code` → openrouter-coder)._",
+    "_The coder will implement this and open a pull request._",
+  ].join("\n");
+  const tmpFile = "/tmp/persona-workrequest.md";
+  fs.writeFileSync(tmpFile, body);
+  const out = execFileSync(
+    "gh",
+    ["issue", "create", "--repo", repo, "--title", title, "--body-file", tmpFile,
+     "--label", "work-request", "--label", "openrouter", "--label", "wr:code"],
+    { encoding: "utf8" }
+  );
+  const m = out.match(/\/issues\/(\d+)/);
+  return m ? m[1] : out.trim();
+}
+
 async function main() {
   const body = process.env.COMMENT_BODY || "";
   const repo = process.env.REPO;
@@ -75,6 +117,26 @@ async function main() {
   }
   if (!repo || !issueNumber) {
     throw new Error("Missing REPO or ISSUE_NUMBER");
+  }
+
+  // EXECUTION mode: an action verb means "do it", so file real work instead of replying.
+  if (command.action) {
+    const num = openWorkRequest({
+      repo,
+      handle: command.handle,
+      action: command.action,
+      task: command.task,
+      requestedOn: issueNumber,
+    });
+    postComment(
+      repo,
+      issueNumber,
+      `🛠️ **${command.handle}** filed this as Work Request #${num} and triggered the build pipeline ` +
+        `(\`wr:code\` → openrouter-coder), which will open an implementation PR. ` +
+        `This is real work, not a comment.\n\n_Action: \`${command.action}\`._`
+    );
+    console.log(`✅ ${command.handle} filed Work Request #${num} for issue #${issueNumber}`);
+    return;
   }
 
   const task =

--- a/tests/persona-comment-runner.test.js
+++ b/tests/persona-comment-runner.test.js
@@ -59,5 +59,17 @@ test("returns null when there is no persona trigger", () => {
   assert.strictEqual(parsePersonaCommand(null), null);
 });
 
+test("detects an action verb (execution mode)", () => {
+  assert.strictEqual(parsePersonaCommand("@oaudrey build a CSV exporter").action, "build");
+  assert.strictEqual(parsePersonaCommand("@openrouter implement X").action, "implement");
+  assert.strictEqual(parsePersonaCommand("/persona oaudrey create a landing page").action, "create");
+  assert.strictEqual(parsePersonaCommand("@OAUDREY Fix the parser").action, "fix");
+});
+
+test("a question is advisory (no action)", () => {
+  assert.strictEqual(parsePersonaCommand("@professor what is the TAM?").action, null);
+  assert.strictEqual(parsePersonaCommand("@oaudrey how should we route this?").action, null);
+});
+
 console.log(`\nTest Summary: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Makes the personas **do** instead of **describe** — the first real "executor," reusing the one piece that already works (the OpenRouter coder).

Until now, a persona comment was a one-shot text reply with no tools — so the 9000 skills / oAudrey's "assignments" never actually ran. This adds **EXECUTION mode**:

- A comment with an **action verb** — `@oaudrey build X`, `implement`, `create`, `fix`, `ship`, `make`, `add` — now **files a real Work Request issue** labeled `work-request` + `openrouter` + `wr:code`, which **triggers `openrouter-coder`** to implement it and open a PR.
- A comment that's a **question** still gets the advisory text reply as before.

So "talk" becomes "a real work item the doer-pipeline picks up," using proven machinery rather than a from-scratch agent.

## Scope / honesty

- This is **v1**: it routes action comments into the existing implement pipeline (the thing that genuinely produces PRs). It is **not** a full tool-use agent that loads the 9000 skills — that's a bigger build, and this is the foundational, safe first step.
- The filed issue goes through the normal review gates before anything merges.

## Test plan

- [x] Parser unit-tested (8/8): action verbs detected; questions stay advisory; non-personas ignored.
- [ ] Live: comment `@oaudrey build a tiny hello-world script` → a `[WR]` issue is filed with `wr:code` → openrouter-coder opens a PR.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR transforms persona comments from passive text replies into active work executors. When a user mentions a persona (like `@oaudrey`) with an **action verb** (`build`, `implement`, `create`, `fix`, `ship`, `make`, `add`), the system now files a real Work Request issue that triggers the existing `openrouter-coder` pipeline to produce an actual PR. Questions without action verbs continue to receive advisory text replies as before. This is the first step toward making personas execute real work rather than just describe what should be done.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tests/persona-comment-runner.test.js` |
| 2 | `scripts/persona-comment-runner.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persona comments now execute work. Action verbs (e.g., `@oaudrey build X`) create a Work Request that triggers `openrouter-coder` to open a PR; questions still get advisory replies.

- **New Features**
  - Detects action verbs: build, implement, create, fix, ship, make, add.
  - On action, files a `[WR]` issue with `work-request`, `openrouter`, `wr:code` and comments back with the issue number to route to `openrouter-coder`.
  - Questions stay in advisory mode; comments without persona triggers no-op.
  - Added parser tests for action detection and questions.

<sup>Written for commit 96c9f2674e7d481b5cb48eea71da493c7ba6eddf. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13730?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new automation path that creates labeled GitHub issues and comments via `gh`, which could generate unintended work items if action-verb detection misfires or is abused. Core logic change is small but affects repo workflow/CI routing.
> 
> **Overview**
> Persona comment triggers now support an **EXECUTION mode**: when a persona mention or `/persona` command starts with an action verb (`build`, `implement`, `create`, `fix`, `ship`, `make`, `add`), the runner files a new `[WR]` GitHub issue labeled `work-request`, `openrouter`, and `wr:code`, then comments back on the originating thread with the created issue number.
> 
> Non-action prompts (e.g., questions) remain **ADVISORY mode**, continuing to instantiate the persona and post a text reply; tests were expanded to cover action detection vs. advisory behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96c9f2674e7d481b5cb48eea71da493c7ba6eddf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->