### PR TITLE
Schedule email-error intake (every 30m) + add /theprofessor

### DIFF
--- a/.github/workflows/email-error-intake.yml
+++ b/.github/workflows/email-error-intake.yml
@@ -4,15 +4,19 @@ name: Email Error Intake
 # so the existing route -> research -> fix -> heal pipeline can handle them.
 # See docs/process/EMAIL_ERROR_INTAKE.md.
 #
-# Rollout: manual + dry-run first. Run it once with dry_run=true to confirm it
-# connects and catches the right mail (it creates nothing). Once verified, run
-# with dry_run=false, then a schedule can be enabled.
+# Rollout: scheduled every 30 min (live) + manual. The scheduled run files real
+# issues (capped, labeled needs-triage). It no-ops cleanly if the ERROR_INBOX_*
+# secrets are not set, so it is safe to enable before the inbox is configured.
+# Tip: run it once manually with dry_run=true first to confirm it connects.
 #
 # Required repo secrets:
 #   ERROR_INBOX_ADDRESS       inbox to read (e.g. you@gmail.com)
 #   ERROR_INBOX_APP_PASSWORD  Gmail App Password (not the login password)
 
 on:
+  schedule:
+    # Every 30 minutes — read the inbox and open issues for new error emails.
+    - cron: '*/30 * * * *'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/persona-comment-trigger.yml
+++ b/.github/workflows/persona-comment-trigger.yml
@@ -30,7 +30,8 @@ jobs:
     # Skip bot comments (avoid loops) and only run when a persona trigger is present.
     if: >-
       github.event.comment.user.type != 'Bot' &&
-      (contains(github.event.comment.body, '/professor') ||
+      (contains(github.event.comment.body, '/theprofessor') ||
+       contains(github.event.comment.body, '/professor') ||
        contains(github.event.comment.body, '/oaudrey') ||
        contains(github.event.comment.body, '/mindmappr') ||
        contains(github.event.comment.body, '/openrouter') ||

--- a/docs/process/SYSTEM_MAP.md
+++ b/docs/process/SYSTEM_MAP.md
@@ -121,9 +121,10 @@ security findings, a11y/SEO gaps).
 ## The agents (personas)
 
 `scripts/openrouter-personas.js` defines named lanes, summonable from a PR/issue
-comment with a **leading slash** (`/professor`, `/oaudrey`, `/mindmappr`,
-`/openrouter`, or `/persona <name>`). Do **not** use `@professor` — GitHub reads
-`@name` as a mention of the real user account with that username and emails them:
+comment with a **leading slash** (`/professor` or `/theprofessor`, `/oaudrey`,
+`/mindmappr`, `/openrouter`, or `/persona <name>`). Do **not** use `@professor` —
+GitHub reads `@name` as a mention of the real user account with that username and
+emails them:
 
 - **The Professor** — deep research via no-key Perplexity (free).
 - **oAudrey** — primary orchestrator / triage.

--- a/scripts/openrouter-personas.js
+++ b/scripts/openrouter-personas.js
@@ -138,9 +138,20 @@ const PERSONA_REGISTRY = {
   },
 };
 
+// Extra summon aliases that resolve to a canonical persona. Kept OUT of
+// PERSONA_REGISTRY so fleet iteration never double-runs the same persona.
+const PERSONA_ALIASES = {
+  theprofessor: "professor",
+};
+
 /** @returns {Object} The full persona registry. */
 function getPersonas() {
   return PERSONA_REGISTRY;
+}
+
+/** @returns {string[]} All summonable handles, including aliases. */
+function getPersonaHandles() {
+  return [...Object.keys(PERSONA_REGISTRY), ...Object.keys(PERSONA_ALIASES)];
 }
 
 /**
@@ -153,7 +164,8 @@ function getPersona(handle) {
   if (!handle || typeof handle !== "string") {
     throw new Error("Persona handle is required");
   }
-  const key = handle.trim().toLowerCase().replace(/^@/, "");
+  const raw = handle.trim().toLowerCase().replace(/^@/, "");
+  const key = PERSONA_ALIASES[raw] || raw;
   const persona = PERSONA_REGISTRY[key];
   if (!persona) {
     const available = Object.keys(PERSONA_REGISTRY).join(", ");
@@ -301,8 +313,10 @@ async function instantiateFleet(handles, options = {}) {
 
 module.exports = {
   PERSONA_REGISTRY,
+  PERSONA_ALIASES,
   INSTANTIATION_MODES,
   getPersonas,
+  getPersonaHandles,
   getPersona,
   normalizeMode,
   buildMessages,

--- a/scripts/persona-comment-runner.js
+++ b/scripts/persona-comment-runner.js
@@ -32,7 +32,7 @@
 
 const fs = require("fs");
 const { execFileSync } = require("child_process");
-const { instantiate, getPersonas } = require("./openrouter-personas");
+const { instantiate, getPersonaHandles } = require("./openrouter-personas");
 
 // Verbs that mean "do the thing" rather than "tell me about it".
 const ACTION_VERBS = ["build", "implement", "create", "fix", "ship", "make", "add"];
@@ -54,7 +54,7 @@ function detectAction(task) {
  */
 function parsePersonaCommand(body) {
   if (!body || typeof body !== "string") return null;
-  const handles = Object.keys(getPersonas()); // openrouter, oaudrey, mindmappr, professor
+  const handles = getPersonaHandles(); // openrouter, oaudrey, mindmappr, professor, theprofessor
 
   // "/persona <name> <task...>"
   const slash = body.match(/\/persona\s+([a-z0-9_-]+)\s*([\s\S]*)/i);

--- a/tests/persona-comment-runner.test.js
+++ b/tests/persona-comment-runner.test.js
@@ -35,6 +35,12 @@ test("parses other persona shortcuts", () => {
   assert.strictEqual(parsePersonaCommand("/openrouter route this").handle, "openrouter");
 });
 
+test("/theprofessor alias resolves to The Professor", () => {
+  const cmd = parsePersonaCommand("/theprofessor research the OSINT market");
+  assert.strictEqual(cmd.handle, "theprofessor");
+  assert.strictEqual(cmd.task, "research the OSINT market");
+});
+
 test("parses the /persona <name> <task> form", () => {
   const cmd = parsePersonaCommand("/persona professor research the OSINT market");
   assert.strictEqual(cmd.handle, "professor");


### PR DESCRIPTION
## Summary

Two things you asked for:

### 1. Scheduled the email-error intake (24/7)
`email-error-intake.yml` now runs on a **30-minute cron** (`*/30 * * * *`) in addition to manual. Scheduled runs are **live** (file real issues) but stay safe:
- **No-op if the `ERROR_INBOX_*` secrets aren't set** — safe to enable before the inbox is wired.
- Capped per run + labeled `needs-triage` so nothing floods the repo or auto-codes without review.

> Tip: run it once manually with `dry_run=true` to confirm it connects to your inbox before trusting the schedule.

### 2. Added `/theprofessor`
You can now summon the Professor as **`/theprofessor`** (or still `/professor`, or `/persona theprofessor`). It's an **alias** that resolves to the same persona — kept out of the registry so fleet runs don't double-fire. Still a **slash**, so it never pings the real `@professor` user.

## Test plan

- [x] `getPersona('theprofessor')` → "The Professor"; handles list includes it.
- [x] Parser tests 10/10 (`/theprofessor` resolves; `@name` still ignored).
- [x] Both workflows parse; email workflow has the `schedule` cron; trigger filter includes `/theprofessor`.
- [ ] Live: a manual `dry_run=true` run connects to the inbox; then the cron files real issues.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds two features: (1) schedules the email error intake workflow to run automatically every 30 minutes instead of only manually, with safeguards to no-op if secrets aren't configured, and (2) introduces `/theprofessor` as an alias for the existing professor persona, ensuring it resolves to the same persona without causing duplicate runs in fleet operations.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/openrouter-personas.js` |
| 2 | `tests/persona-comment-runner.test.js` |
| 3 | `scripts/persona-comment-runner.js` |
| 4 | `.github/workflows/persona-comment-trigger.yml` |
| 5 | `docs/process/SYSTEM_MAP.md` |
| 6 | `.github/workflows/email-error-intake.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Schedules the email error intake to run every 30 minutes and adds `/theprofessor` as an alias for the Professor persona to make summoning clearer and safer.

- **New Features**
  - Email error intake now runs on a 30-minute cron (live) in addition to manual. Runs are capped, labeled `needs-triage`, and no-op if `ERROR_INBOX_*` secrets are unset.
  - Added `/theprofessor` (and `/persona theprofessor`) as an alias for the `professor` persona without double-running. Updated trigger filter, parser, docs, and tests. Avoid using `@professor`.

- **Migration**
  - Set `ERROR_INBOX_ADDRESS` and `ERROR_INBOX_APP_PASSWORD` repo secrets.
  - Run the workflow once with `dry_run=true` to verify inbox access; the schedule will then create real issues.

<sup>Written for commit b2da56469b4171b191eba6fa0ab1f12811c8d432. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13751?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a new scheduled GitHub Action that can automatically create issues from an inbox, which could increase noise if misconfigured despite caps/no-op safeguards. Persona changes are small but touch comment-trigger parsing and workflow filters.
> 
> **Overview**
> **Automates email error intake on a cron.** `email-error-intake.yml` now runs every 30 minutes (in addition to manual dispatch), intended to file real, capped issues for new error emails while remaining safe to enable before `ERROR_INBOX_*` secrets are configured.
> 
> **Adds a new persona summon alias.** Introduces `/theprofessor` as an alias of `/professor` by adding alias resolution in `openrouter-personas.js`, updating the comment-trigger workflow filter and parser to accept the new handle, and extending docs/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2da56469b4171b191eba6fa0ab1f12811c8d432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->