### PR TITLE
Sanitize persona replies so bot comments never @-ping a real user

### DIFF
--- a/scripts/persona-comment-runner.js
+++ b/scripts/persona-comment-runner.js
@@ -78,9 +78,20 @@ function parsePersonaCommand(body) {
   return null;
 }
 
+/**
+ * Neutralize @mentions in any text a bot posts, so a persona reply can never
+ * notify a real GitHub user (the persona's LLM output sometimes writes "@Name").
+ * Inserts a zero-width space after the "@": it still renders as "@name" but is
+ * no longer a valid mention, so GitHub sends no notification. Leaves emails
+ * (foo@bar) effectively unchanged in appearance.
+ */
+function sanitizeMentions(text) {
+  return String(text == null ? "" : text).replace(/@(?=[A-Za-z0-9_-])/g, "@​");
+}
+
 function postComment(repo, issueNumber, markdown) {
   const tmpFile = "/tmp/persona-comment-reply.md";
-  fs.writeFileSync(tmpFile, markdown);
+  fs.writeFileSync(tmpFile, sanitizeMentions(markdown));
   execFileSync(
     "gh",
     ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", tmpFile],
@@ -170,4 +181,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { parsePersonaCommand };
+module.exports = { parsePersonaCommand, sanitizeMentions };

--- a/tests/persona-comment-runner.test.js
+++ b/tests/persona-comment-runner.test.js
@@ -7,7 +7,7 @@
  */
 
 const assert = require("assert");
-const { parsePersonaCommand } = require("../scripts/persona-comment-runner");
+const { parsePersonaCommand, sanitizeMentions } = require("../scripts/persona-comment-runner");
 
 let passed = 0;
 let failed = 0;
@@ -80,6 +80,14 @@ test("detects an action verb (execution mode)", () => {
 test("a question is advisory (no action)", () => {
   assert.strictEqual(parsePersonaCommand("/professor what is the TAM?").action, null);
   assert.strictEqual(parsePersonaCommand("/oaudrey how should we route this?").action, null);
+});
+
+test("sanitizeMentions defangs @mentions so a reply never pings a real user", () => {
+  const out = sanitizeMentions("cc @TheProfessor and @mindmappr please");
+  assert.ok(!/@[A-Za-z]/.test(out), "no bare @name should remain");
+  assert.ok(out.includes("@​TheProfessor"), "mention is defanged with a zero-width space");
+  // Visible text is unchanged once the zero-width space is stripped.
+  assert.strictEqual(out.replace(/​/g, ""), "cc @TheProfessor and @mindmappr please");
 });
 
 console.log(`\nTest Summary: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## Summary

Closes the *other half* of the "stop emailing the stranger" bug. The earlier fix stopped the `@name` **trigger** syntax — but a persona's **reply** (written by the LLM and posted by the bot) can still contain `@Name`. We saw this live: the oAudrey persona replied with `@TheProfessor`, `@MindMappr`, `@RadioChaser`, which would notify whoever owns those real GitHub handles.

## Fix
`postComment` now runs every bot comment through `sanitizeMentions()`, which inserts a zero-width space after each `@` (`@name`). It still **renders as `@name`** to readers, but is no longer a valid mention, so GitHub sends **no notification** — for any persona reply, status message, or execution-mode confirmation.

## Test plan
- [x] 11/11 parser/sanitizer tests (defangs `@mentions`; visible text unchanged once the zero-width char is stripped).
- [x] `node --check` clean.

> Note: like the rest of this batch, the required CI checks are currently billing-blocked — merge with the admin override once you're ready.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR prevents bot personas from accidentally notifying real GitHub users by sanitizing all `@mentions` in bot comments. When the LLM generates a reply containing `@Name`, the system now inserts a zero-width space after the `@` symbol, making it render normally but preventing GitHub from treating it as an actual mention. This fix applies to all bot-posted content including persona replies, status messages, and execution confirmations.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tests/persona-comment-runner.test.js` |
| 2 | `scripts/persona-comment-runner.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent bot-posted persona replies from pinging real GitHub users. All outgoing comments now sanitize `@mentions` so they look the same but do not trigger notifications.

- **Bug Fixes**
  - Added a sanitizer that inserts a zero‑width space after `@` to neutralize `@mentions`.
  - Applied the sanitizer in `postComment` for all bot comments.
  - Added tests to confirm mentions are defanged and visible text is unchanged.

<sup>Written for commit cae2c5f428e35c5781e8944f4230fa653e959d63. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13832?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

