### PR TITLE
🔒 [security] Add API Key authentication to sensitive endpoints

### DIFF
--- a/.github/workflows/verify-security-fix.yml
+++ b/.github/workflows/verify-security-fix.yml
@@ -1,0 +1,23 @@
+name: Verify Security Fix
+
+on:
+  pull_request:
+    paths:
+      - "penny-sovereign-yield-scout/**"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          pip install -r penny-sovereign-yield-scout/requirements.txt
+          pip install -r penny-sovereign-yield-scout/requirements-dev.txt
+      - name: Run tests
+        run: |
+          python3 -m pytest penny-sovereign-yield-scout/tests/test_auto_compounder_api.py

--- a/penny-sovereign-yield-scout/.env.example
+++ b/penny-sovereign-yield-scout/.env.example
@@ -30,4 +30,5 @@ VERIFIABLE_LOG_DIR=./logs
 
 # ─── Wallet (NEVER commit real values) ────────────────────────────────────────
 COMPOUND_WALLET_ADDRESS=0xYourWalletAddressHere
+COMPOUND_API_KEY=your_api_key_here
 COMPOUND_PRIVATE_KEY=NEVER_COMMIT_YOUR_REAL_PRIVATE_KEY

--- a/penny-sovereign-yield-scout/tests/test_auto_compounder_api.py
+++ b/penny-sovereign-yield-scout/tests/test_auto_compounder_api.py
@@ -22,6 +22,13 @@ from auto_compounder_api import (
 
 client = TestClient(app)
 
+VALID_API_KEY = "test-key-123"
+AUTH_HEADER = {"X-API-Key": VALID_API_KEY}
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch):
+    monkeypatch.setenv("COMPOUND_API_KEY", VALID_API_KEY)
+
 @pytest.fixture(autouse=True)
 def reset_state():
     """Reset the global state before each test."""
@@ -103,7 +110,7 @@ def test_compound_execute():
         "chain": "arbitrum"
     }
 
-    response = client.post("/compound", json=req_data)
+    response = client.post("/compound", json=req_data, headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
 
@@ -133,7 +140,7 @@ def test_compound_skip():
         "chain": "arbitrum"
     }
 
-    response = client.post("/compound", json=req_data)
+    response = client.post("/compound", json=req_data, headers=AUTH_HEADER)
     assert response.status_code == 200
     data = response.json()
 
@@ -152,23 +159,23 @@ def test_history_and_positions():
     _positions["0x222:poolB"] = {"wallet": "0x222", "protocol": "B"}
 
     # Test history all
-    res = client.get("/history")
+    res = client.get("/history", headers=AUTH_HEADER)
     assert res.status_code == 200
     assert res.json()["total"] == 2
 
     # Test history filter
-    res = client.get("/history?wallet=0x111")
+    res = client.get("/history?wallet=0x111", headers=AUTH_HEADER)
     assert res.status_code == 200
     assert res.json()["total"] == 1
     assert res.json()["records"][0]["protocol"] == "A"
 
     # Test positions all
-    res = client.get("/positions")
+    res = client.get("/positions", headers=AUTH_HEADER)
     assert res.status_code == 200
     assert res.json()["total"] == 2
 
     # Test positions filter
-    res = client.get("/positions?wallet=0x222")
+    res = client.get("/positions?wallet=0x222", headers=AUTH_HEADER)
     assert res.status_code == 200
     assert res.json()["total"] == 1
     assert res.json()["positions"][0]["protocol"] == "B"
@@ -202,7 +209,7 @@ def test_audit_verify_empty():
     if LOG_FILE.exists():
         LOG_FILE.unlink()
 
-    res = client.get("/audit/verify")
+    res = client.get("/audit/verify", headers=AUTH_HEADER)
     assert res.status_code == 200
     assert res.json()["verified"] is True
     assert res.json()["entries"] == 0
@@ -218,10 +225,10 @@ def test_audit_verify_with_logs():
         "chain": "arbitrum"
     }
 
-    client.post("/compound", json=req_data)
-    client.post("/compound", json=req_data)
+    client.post("/compound", json=req_data, headers=AUTH_HEADER)
+    client.post("/compound", json=req_data, headers=AUTH_HEADER)
 
-    res = client.get("/audit/verify")
+    res = client.get("/audit/verify", headers=AUTH_HEADER)
     assert res.status_code == 200
     data = res.json()
     assert data["verified"] is True
@@ -238,7 +245,7 @@ def test_audit_verify_with_logs():
     with open(LOG_FILE, "w") as f:
         f.writelines(lines)
 
-    res = client.get("/audit/verify")
+    res = client.get("/audit/verify", headers=AUTH_HEADER)
     assert res.status_code == 200
     data = res.json()
     assert data["verified"] is False
@@ -381,3 +388,23 @@ def test_eth_price_endpoint(monkeypatch):
     data = res.json()
     assert data["price"] == 3000.0
     assert data["source"] == "coingecko"
+
+# --- Security Tests ---
+
+def test_unauthorized_access():
+    # No header
+    res = client.post("/compound", json={})
+    assert res.status_code == 403
+
+    res = client.get("/history")
+    assert res.status_code == 403
+
+    # Invalid key
+    res = client.get("/positions", headers={"X-API-Key": "wrong-key"})
+    assert res.status_code == 403
+
+def test_server_not_configured(monkeypatch):
+    monkeypatch.delenv("COMPOUND_API_KEY", raising=False)
+    res = client.get("/audit/verify", headers=AUTH_HEADER)
+    assert res.status_code == 500
+    assert "API authentication not configured" in res.json()["detail"]

--- a/penny-sovereign-yield-scout/tools/auto_compounder_api.py
+++ b/penny-sovereign-yield-scout/tools/auto_compounder_api.py
@@ -29,7 +29,8 @@ from typing import Optional
 
 import requests
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Depends, Security
+from fastapi.security import APIKeyHeader
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
@@ -56,6 +57,31 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# ─── Security setup ────────────────────────────────────────────────────────────
+
+API_KEY_NAME = "X-API-Key"
+api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=False)
+
+def validate_api_key(api_key: str = Security(api_key_header)) -> str:
+    """
+    Validate the request API key against COMPOUND_API_KEY env var.
+    Returns the key if valid, else raises 403 Forbidden.
+    """
+    expected_key = os.getenv("COMPOUND_API_KEY")
+    if not expected_key:
+        # If no key is configured, we reject all sensitive requests for safety
+        raise HTTPException(
+            status_code=500,
+            detail="API authentication not configured on server"
+        )
+    if api_key != expected_key:
+        raise HTTPException(
+            status_code=403,
+            detail="Could not validate credentials"
+        )
+    return api_key
+
 
 DEFILLAMA_BASE = os.getenv("DEFILLAMA_BASE_URL", "https://yields.llama.fi")
 LOG_DIR = Path(os.getenv("VERIFIABLE_LOG_DIR", "./logs"))
@@ -280,7 +306,7 @@ def eth_price(force_refresh: bool = Query(default=False, description="Bypass the
     return fetch_eth_price_usd(force_refresh=force_refresh)
 
 
-@app.post("/compound", response_model=CompoundResponse, tags=["Compounding"])
+@app.post("/compound", response_model=CompoundResponse, tags=["Compounding"], dependencies=[Depends(validate_api_key)])
 def trigger_compound(req: CompoundRequest) -> CompoundResponse:
     """
     Trigger an auto-compound action for a yield position.
@@ -363,7 +389,7 @@ def trigger_compound(req: CompoundRequest) -> CompoundResponse:
     )
 
 
-@app.get("/history", tags=["Compounding"])
+@app.get("/history", tags=["Compounding"], dependencies=[Depends(validate_api_key)])
 def get_history(
     wallet: Optional[str] = Query(default=None, description="Filter by wallet address"),
     limit: int = Query(default=50, le=500),
@@ -378,7 +404,7 @@ def get_history(
     }
 
 
-@app.get("/positions", tags=["Positions"])
+@app.get("/positions", tags=["Positions"], dependencies=[Depends(validate_api_key)])
 def list_positions(wallet: Optional[str] = Query(default=None)) -> dict:
     """List all tracked positions, optionally filtered by wallet."""
     positions = list(_positions.values())
@@ -417,7 +443,7 @@ def optimal_compound_interval(
     }
 
 
-@app.get("/audit/verify", tags=["Audit"])
+@app.get("/audit/verify", tags=["Audit"], dependencies=[Depends(validate_api_key)])
 def verify_audit_log() -> dict:
     """Verify the integrity of the audit chain log."""
     if not LOG_FILE.exists():


### PR DESCRIPTION
🎯 **What:** Added API key authentication to sensitive endpoints in the auto-compounder API.
⚠️ **Risk:** These endpoints (especially `/compound`) trigger financial transactions and were previously publicly accessible, allowing anyone to trigger compounding or view history/positions.
🛡️ **Solution:** Implemented a FastAPI dependency `validate_api_key` that checks for an `X-API-Key` header against a `COMPOUND_API_KEY` environment variable. Applied this to `/compound`, `/history`, `/positions`, and `/audit/verify`.

---
*PR created automatically by Jules for task [12468273422513415292](https://jules.google.com/task/12468273422513415292) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds API key authentication to protect sensitive financial endpoints in the auto-compounder API. Previously, critical endpoints like `/compound` (which triggers financial transactions), `/history`, `/positions`, and `/audit/verify` were publicly accessible. The solution implements a `validate_api_key` FastAPI dependency that validates requests against an `X-API-Key` header using a `COMPOUND_API_KEY` environment variable. All affected endpoints now require authentication, and comprehensive tests verify both authorized and unauthorized access scenarios.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `penny-sovereign-yield-scout/tools/auto_compounder_api.py` |
| 2 | `penny-sovereign-yield-scout/tests/test_auto_compounder_api.py` |
| 3 | `penny-sovereign-yield-scout/.env.example` |
| 4 | `.github/workflows/verify-security-fix.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds API key authentication to sensitive auto-compounder endpoints to block unauthorized compounding and data access. Implements `X-API-Key` validation and updates tests and CI.

- **New Features**
  - Added `validate_api_key` that checks `X-API-Key` against `COMPOUND_API_KEY`; applied to `/compound`, `/history`, `/positions`, `/audit/verify`.
  - Added security tests (unauthorized and misconfigured server) and updated existing tests to use auth headers.
  - Added GitHub Actions workflow to run the API test suite.
  - Added `COMPOUND_API_KEY` to `.env.example`.

- **Migration**
  - Set `COMPOUND_API_KEY` on the server.
  - Send header `X-API-Key: <your key>` to access protected endpoints.
  - Server returns 500 if not configured, 403 if the key is missing or invalid.

<sup>Written for commit efe6aae834542b287433f7a126f33e0561abe4d9. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13880?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

