### PR TITLE
Reuse-first WR for a new insurance lead app

### DIFF
--- a/wr/issues/issue-new-insurance-lead-app-reuse-first.md
+++ b/wr/issues/issue-new-insurance-lead-app-reuse-first.md
@@ -1,0 +1,81 @@
+# WR: New Insurance Lead App (reuse-first build)
+
+**Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)
+**Created:** 2026-05-25
+**Output Type:** `production-app` → `deliver:app` (landing + lead pipeline)
+**Revenue target (monthly USD):** $5,000 _(placeholder — owner to confirm; required by CONTRACT Rule 4)_
+**WR Status:** 🟡 Spec ready — awaiting owner go
+
+---
+
+## Goal
+
+Build a **new** life-insurance lead-generation app (not a reimagining of
+GodsofInsurance — that stays untouched). Same Blue-Ocean thesis: source exclusive,
+fresh leads from **public-record life events** (marriage licenses, new home
+purchases, business filings, birth/death records, new driver's licenses), package
+them as exclusive batches, and support agents with an AI phone/quote layer.
+
+**Non-negotiable build rule:** this is a **reuse-first** build. Pull the existing
+code listed below — do **not** rebuild functionality the repo already has. New
+code is only for the genuine gaps. Ship it **complete** (Completeness Gate), don't
+overwrite anything (No-Destroy Guard).
+
+---
+
+## ♻️ Reuse manifest (REQUIRED — pull these, do not rebuild)
+
+### Reuse as-is
+| Capability | Source file(s) |
+| --- | --- |
+| Lead capture form/flow | `products/life-insurance-lead-engine/build/src/components/LeadGenerator/LeadGenerator.tsx` |
+| Lead de-duplication (logic + UI) | `products/life-insurance-lead-engine/build/src/components/Dedupe/Dedupe.tsx`, `.../build/src/utils/dedupe.ts` |
+| Lead data parsing | `products/life-insurance-lead-engine/build/src/utils/parser.ts` |
+| Email / newsletter capture | `products/life-insurance-lead-engine/build/src/components/Newsletter.tsx` |
+| Monetization block | `products/life-insurance-lead-engine/build/src/components/AffiliateMarketing.tsx` |
+| Accessibility panel | `products/life-insurance-lead-engine/build/src/components/AccessibilityControls.tsx` |
+
+### Adapt (foundation exists — extend it)
+| Capability | Reuse from | Adapt into |
+| --- | --- | --- |
+| Public-records scraping (the Blue Ocean) | `reesereviews/vine-marketplace/lib/amazon-parser.js`, `gmail-reader.js`, `facebook-poster.js` | county/marriage-license/home-purchase record scrapers |
+| AI features (phone answering, quotes) | `src/lib/model-router.js`, `src/lib/model-routing-modes.js`, `products/music-video-creator/src/lib/orchestrator.ts`, `.../openrouter-config.ts`, `products/prompt-generation-app/lib/prompt-generator.js` | AI phone-answer agent + quote-explanation flow |
+
+### Build net-new (no reusable code in repo)
+- Public-records source connectors (use the adapted scraper pattern above)
+- Multi-carrier quote comparison
+- Twilio/voice integration for AI phone answering
+- Billing/checkout + agent auth
+
+> Reuse coverage at start ≈ **40–50%**. The builder must reference each file above
+> in its plan and justify any case where it chooses to rebuild instead of reuse.
+
+---
+
+## Definition of Done (Completeness Gate — must pass before `status: done`)
+
+- App **builds and runs** (`npm install && npm run build`), no errors.
+- Every flow implemented end-to-end: capture → dedupe → package → deliver. **No
+  TODO/placeholder/"coming soon"/empty handlers** in shipped product code.
+- Landing page real (not default Next.js boilerplate); deploys on Vercel.
+- Reused modules wired in and working (not re-stubbed copies).
+- Net-new gaps either implemented or written to a Procurement BOM if blocked on a
+  missing API/credential (don't fail silently).
+
+---
+
+## Guardrails
+
+- **New build is approved** (it's net-new, not a reimagining). Reimagining any
+  *existing* app still requires owner approval (propose → approve → build).
+- **No-Destroy:** never overwrite/delete existing apps or the reused source files.
+- **Research:** standard research defaults apply (market, BOM, competitors,
+  compliance — TCPA/FCRA/CAN-SPAM/source ToS are critical for public-records data).
+
+---
+
+## Pipeline
+
+Route through revvel-standards: research-engine → coder (reuse-first per the
+manifest) → full review jury (OpenRouter code review + Jules + Semgrep + CodeQL) →
+draft PR for owner approval → ship.


### PR DESCRIPTION
## Summary

The build spec that makes **"reuse, don't rebuild"** actually happen for a **new** insurance lead app. It is *not* a reimagining of GodsofInsurance — that stays untouched. New build, but it's **required** to harvest existing repo code.

The WR bakes in a **reuse manifest**:
- **Reuse as-is:** `LeadGenerator`, `Dedupe` (+ `dedupe.ts`), `parser.ts`, `Newsletter`, `AffiliateMarketing`, `AccessibilityControls` — all from `life-insurance-lead-engine`.
- **Adapt:** `vine-marketplace/lib` scrapers → public-records scraping (the Blue Ocean); `model-router` / `orchestrator` / `prompt-generator` → AI phone + quote logic.
- **Build net-new only the real gaps:** public-records connectors, multi-carrier quotes, Twilio voice, billing/auth.

Plus a **completeness Definition of Done** (no scaffolding, builds & runs, all flows wired) and the guardrails (no-destroy, approval for reimaginings). Reuse coverage ≈ **40–50%** at start.

## How to use it
- This is the spec. When you're ready (and billing's restored), file it as a `[WR]` issue and it routes through research-engine → coder (reuse-first) → review jury → draft PR for your approval. I can file that issue for you on the word go.

## Test plan
- [x] Reuse paths verified against an actual repo scan.
- [ ] Owner confirms the revenue target + scope, then file as a live WR.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a work request (WR) specification for building a new life-insurance lead-generation app using a **reuse-first** approach. The spec mandates harvesting 40-50% of functionality from existing repository code (such as `LeadGenerator`, `Dedupe`, parsers, and AI routing components from `life-insurance-lead-engine` and `vine-marketplace`) rather than rebuilding from scratch. It includes a detailed reuse manifest that identifies which components should be reused as-is, which should be adapted for new use cases (like public-records scraping and AI phone/quote logic), and which gaps require net-new development (multi-carrier quotes, Twilio voice integration, billing/auth). The document also establishes a completeness gate requiring fully functional end-to-end flows with no placeholders, plus guardrails preventing destruction of existing code and requiring research compliance for TCPA/FCRA regulations.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `wr/issues/issue-new-insurance-lead-app-reuse-first.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reuse-first WR spec for a new life-insurance lead app, outlining what to reuse, adapt, and build new. Includes a Definition of Done, guardrails, and pipeline to ship a complete app while reusing ~40–50% of existing code and keeping GodsofInsurance unchanged.

<sup>Written for commit 893075d5a000bfea884679c99e2f4d049257f6a5. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13917?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

