### PR TITLE
Add Definition of Done — testable-live, Vercel link in README (even APIs)

### DIFF
--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -1,0 +1,37 @@
+# Definition of Done — the law
+
+Curt rules. Don't negotiate them. If a deliverable breaks one, it is **not done.**
+
+## 1. Done = TESTABLE-LIVE
+- **Every deliverable ships a live Vercel deployment.** No live URL = not done.
+- **Put the live URL in the README** under `## Live Deployment`. Every app, every repo.
+- **Even an API, CLI, or MCP server gets a web interface to test it.** A minimal
+  playground/console that exercises it live. If a human can't click it and watch
+  it work, it isn't done. No headless deliverables.
+
+## 2. Don't ship scaffolding
+- No `TODO`, `FIXME`, "coming soon", placeholder, lorem ipsum, empty handlers, or
+  default framework boilerplate in shipped product code.
+- The build passes. Every screen and flow works end to end. Finish it in detail.
+
+## 3. Reuse, don't rebuild
+- Check `docs/APP_REGISTRY.md` first. Reuse existing apps/modules that fit.
+- Saturated type (≥3 similar apps) → start from the closest template, swap only
+  the domain logic. Don't rebuild what already exists.
+
+## 4. Don't destroy
+- Never overwrite or delete a working app. Make minimal diffs to existing code.
+- Replacing/removing existing work needs the `allow-destroy` label (owner sign-off).
+
+## 5. Get approval to reimagine
+- Reinventing an existing app: **propose → owner approves → build.** Reuse alone
+  does not need approval; a rewrite does.
+
+## 6. Scope
+- **One iteration, done in full.** No "overhaul", no "30-day", no "long", no "big".
+  Minimal scope, complete. Just build it.
+
+---
+
+_Enforced by: No-Destroy Guard (#4), Completeness Gate (#2), App Registry (#3),
+Approve-to-Reimagine gate (#5). Ship-to-market deploys + records the live URL (#1)._

--- a/products/life-insurance-lead-engine/build/README.md
+++ b/products/life-insurance-lead-engine/build/README.md
@@ -15,6 +15,15 @@ Open http://localhost:3000
 npm run build && npm start
 ```
 
-## Deploy
+## Live Deployment
 
-Click "Deploy to Vercel" or run `vercel --prod`.
+<!-- live-deployment -->
+**Live:** _not deployed yet — set this once the Vercel project is created._
+
+**To deploy (≈2 min, no secrets needed — uses the free public NPPES API):**
+1. Vercel → Add New… → Project → import `midnghtsapphire/revvel-standards`.
+2. **Root Directory** = `products/life-insurance-lead-engine/build`.
+3. Framework auto-detects **Next.js**. No environment variables.
+4. **Deploy** → paste the live URL into the **Live:** line above.
+
+Per `docs/DEFINITION_OF_DONE.md`: not done until the live URL is here.


### PR DESCRIPTION
## Summary

Encodes the standard you just set: **a deliverable isn't done until it's testable live.**

`docs/DEFINITION_OF_DONE.md` — a curt, forceful one-pager (the kind you said actually works):
1. **Done = testable-live** — every deliverable ships a **live Vercel deployment**, the **URL goes in the README**, and **even an API/CLI/MCP gets a web interface to test it.** No live URL = not done. No headless deliverables.
2. **No scaffolding** — no TODO/placeholder/boilerplate; build passes; flows work end to end.
3. **Reuse, don't rebuild** — check the App Registry first.
4. **Don't destroy** — minimal diffs; `allow-destroy` label to replace existing work.
5. **Approval to reimagine** — propose → you approve → build.
6. **Scope** — one iteration, done in full; no "overhaul"/"long"/"30-day".

Also adds the concrete **`## Live Deployment`** section to the lead-engine README (with the exact deploy steps + a `<!-- live-deployment -->` slot for the URL).

This is the through-line for everything this session — and it's the rule that stops "scaffolding instead of the whole thing."

## Next (enforcement)
- Wire `ship-to-market.yml` to **write the captured live URL into the README** automatically (it currently only comments it), and to give APIs a test interface. That makes rule #1 self-enforcing.

## Test plan
- [x] Doc + README section render.
- [ ] You confirm the wording, then I wire the ship-to-market README-write step.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR establishes a **Definition of Done** policy that mandates every deliverable must be testable live with a deployed Vercel URL documented in the README. The new policy document (`DEFINITION_OF_DONE.md`) codifies six core rules: requiring live deployments for all deliverables (including web interfaces for APIs/CLIs), prohibiting scaffolding and placeholder code, encouraging reuse from the App Registry, preventing destructive changes without approval, requiring sign-off for reimplementation, and enforcing complete single-iteration scope. The lead-engine README is updated to include a concrete **Live Deployment** section with step-by-step Vercel deployment instructions and a placeholder for the live URL, demonstrating the new standard in practice.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/DEFINITION_OF_DONE.md` |
| 2 | `products/life-insurance-lead-engine/build/README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets “Done = testable-live” as the standard: every deliverable must have a live Vercel deployment with the URL in the README, including APIs/CLIs with a minimal web test UI. Adds a one-page Definition of Done and updates the lead-engine README with a Live Deployment section and deploy steps.

- **New Features**
  - Added `docs/DEFINITION_OF_DONE.md` defining: testable-live, README live URL, web UI for APIs/CLI/MCP, no scaffolding, reuse-first, no-destroy (`allow-destroy`), approval to reimagine, single-iteration scope.
  - Updated `products/life-insurance-lead-engine/build/README.md` with `## Live Deployment`, a `<!-- live-deployment -->` slot, and Vercel deploy steps.

<sup>Written for commit 298b8c21e569cbcaf0daa52effd367275b5dfe46. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13918?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

