### PR TITLE
Stop bot-issue spam at its two sources (Sentinel dedup + Watchdog comment-not-issue)

### DIFF
--- a/.github/workflows/secrets-sentinel.yml
+++ b/.github/workflows/secrets-sentinel.yml
@@ -123,14 +123,19 @@ jobs:
             const healSucceeded = process.env.HEAL_SUCCEEDED === 'true';
             const today = new Date().toISOString().split('T')[0];
 
-            // Avoid opening duplicate issues — check for an existing open one.
-            const { data: existing } = await github.rest.issues.listForRepo({
+            // Avoid opening duplicate issues — search across all open issues by
+            // title. The previous label-only filter missed duplicates created via
+            // the labels-not-provisioned fallback path (unlabeled issues), which
+            // is why dozens of identical sentinel issues piled up.
+            const { data: allOpen } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'secrets-missing',
               state: 'open',
-              per_page: 5,
+              per_page: 100,
             });
+            const existing = allOpen.filter(
+              (i) => !i.pull_request && i.title.startsWith('🔐 Secrets Sentinel')
+            );
 
             const body = [
               '## 🔐 Secrets Sentinel — Missing Credentials Detected',

--- a/.github/workflows/stuck-label-watchdog.yml
+++ b/.github/workflows/stuck-label-watchdog.yml
@@ -210,35 +210,25 @@ jobs:
                 continue;
               }
 
-              // awaiting-review for 24h+ → ping
+              // awaiting-review for 24h+ → label the PR + comment ON THE PR.
+              // No more new "agent repair" ISSUES for time-based stale states —
+              // they piled up one-per-PR (#13934/35/36/41 etc.) and just added
+              // noise that the agent processor (billing-blocked) never closed.
+              // Logical-conflict cases below still file repair issues.
               if (labelNames.includes('awaiting-review') && age > 24 * HOUR) {
                 if (!labelNames.includes('lifecycle:stuck')) {
                   await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['lifecycle:stuck'] });
-                  const repairIssue = await openAgentRepairIssue(
-                    pr,
-                    'awaiting-review-over-24h',
-                    '`awaiting-review` for 24+ hours',
-                    'Added `lifecycle:stuck` to make the stale review state visible.',
-                    'Review the PR, request the missing reviewer action, or patch automation if a review should already have been requested/submitted.'
-                  );
                   await github.rest.issues.createComment({ owner, repo, issue_number: prNumber,
-                    body: `⏰ **Watchdog:** This PR has been \`awaiting-review\` for 24+ hours. Routed follow-up to agent repair issue #${repairIssue.number}.` });
+                    body: `⏰ **Watchdog:** This PR has been \`awaiting-review\` for 24+ hours. Marked \`lifecycle:stuck\`.` });
                 }
               }
 
-              // checks-failing for 12h+ → ping
+              // checks-failing for 12h+ → label the PR + comment ON THE PR (no new issue).
               if (labelNames.includes('checks-failing') && age > 12 * HOUR) {
                 if (!labelNames.includes('lifecycle:stuck')) {
                   await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['lifecycle:stuck'] });
-                  const repairIssue = await openAgentRepairIssue(
-                    pr,
-                    'checks-failing-over-12h',
-                    '`checks-failing` for 12+ hours',
-                    'Added `lifecycle:stuck` to make the stale CI failure visible.',
-                    'Read the failing check logs, identify the root cause, and patch the PR or workflow so the PR can merge.'
-                  );
                   await github.rest.issues.createComment({ owner, repo, issue_number: prNumber,
-                    body: `⏰ **Watchdog:** CI has been failing for 12+ hours. Routed follow-up to agent repair issue #${repairIssue.number}.` });
+                    body: `⏰ **Watchdog:** CI has been failing for 12+ hours. Marked \`lifecycle:stuck\`.` });
                 }
               }
 


### PR DESCRIPTION
## Summary

Stops the two sources that fill your backlog with bot self-spam — without removing the underlying alerts.

### The two bugs

**1. `secrets-sentinel.yml`** has dedup logic, but it filtered by `labels: 'secrets-missing'` with `per_page: 5`. The workflow's *own* fallback path creates issues **without labels** when the label isn't provisioned — so every later run searched only labeled issues, missed all the unlabeled duplicates, and filed another. That's why **64 identical "Secrets Missing" issues** piled up.
**Fix:** search all open issues by title prefix; one canonical sentinel issue gets *updated* instead.

**2. `stuck-label-watchdog.yml`** opened a brand-new "agent repair issue" for each PR that was `awaiting-review > 24h` or `checks-failing > 12h`. While the agent processor (`agent-fallback`) was billing-blocked, those repair issues were never resolved — they just stacked up (#13934/35/36/41 and 10+ more).
**Fix:** for time-based stale states, label the PR `lifecycle:stuck` and **comment on the PR** instead of opening a new issue. Logical-conflict cases (`approved` + `needs-action`, `checks-passing` + `checks-failing`, etc.) still file repair issues — they're rare and worth tracking.

### Effect
- Stops ~60+ "Secrets Sentinel" duplicates/week at the source.
- Stops ~14+ "Watchdog repair" duplicates/week at the source.
- Existing duplicate noise can then be bulk-closed in one pass (next step).
- The architecture still alerts you — just once per condition, on the PR itself.

### Test plan
- [x] Both workflows parse and pass YAML validation.
- [x] `openAgentRepairIssue` still defined and used for the kept (logical-conflict) cases.
- [ ] After merge: confirm the next sentinel/watchdog run comments on existing issues / on the PR rather than opening new ones.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes two GitHub workflow bugs that were creating duplicate bot-generated issues. The `secrets-sentinel.yml` workflow was creating dozens of duplicate "Secrets Missing" issues because it only searched for labeled issues when checking for duplicates, but unlabeled issues were being created when labels weren't provisioned. The fix searches all open issues by title prefix instead. The `stuck-label-watchdog.yml` workflow was opening a new repair issue for every PR stuck in `awaiting-review` or `checks-failing` states, creating 14+ duplicates per week. The fix now labels the PR as `lifecycle:stuck` and comments directly on the PR instead of opening new issues for these time-based stale states, while still filing repair issues for genuine logical conflicts.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/secrets-sentinel.yml` |
| 2 | `.github/workflows/stuck-label-watchdog.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents bot self-spam by deduping Secrets Sentinel issues and switching Watchdog stale-state alerts to PR comments with `lifecycle:stuck`. Alerts still fire, but we update one existing issue or the PR instead of opening new ones.

- **Bug Fixes**
  - `secrets-sentinel.yml`: search all open issues by title prefix (not labels) and update a single canonical issue to stop unlabeled duplicates.
  - `stuck-label-watchdog.yml`: for `awaiting-review > 24h` and `checks-failing > 12h`, add `lifecycle:stuck` and comment on the PR; only logical-conflict states still open a repair issue.

<sup>Written for commit 68a73a27a87772e9c87a2f1eb369d8df77628a31. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13948?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

