### PR TITLE
Enforce the law: SEO+a11y gate + research-to-build approval gate

### DIFF
--- a/.github/workflows/openrouter-coder.yml
+++ b/.github/workflows/openrouter-coder.yml
@@ -27,7 +27,7 @@ jobs:
        !startsWith(github.event.issue.title, '[FAILURE]') &&
        !startsWith(github.event.issue.title, '[ALERT]') &&
        (github.event.label.name == 'wr:code' ||
-        github.event.label.name == 'wr:research-complete')) ||
+        github.event.label.name == 'spec-approved')) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.user.login != 'github-actions[bot]' &&
        !startsWith(github.event.issue.title, '[FAILURE]') &&

--- a/.github/workflows/seo-a11y-guard.yml
+++ b/.github/workflows/seo-a11y-guard.yml
@@ -1,0 +1,32 @@
+name: SEO + A11y Guard
+
+# Fails any product PR that ships obvious SEO/a11y debt:
+#   - <img>/<Image> missing alt or with empty alt
+#   - junk image filenames (IMG_1234.jpg, screenshot, etc.)
+#   - page/layout files missing a <meta name="description">
+# Override with the `allow-seo-debt` label. See scripts/seo-a11y-guard.js
+# and docs/SEO_STANDARDS.md (refresh quarterly — Google + schema.org evolve).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Scan changed app files for SEO / a11y debt
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          ALLOW_SEO_DEBT: ${{ contains(github.event.pull_request.labels.*.name, 'allow-seo-debt') }}
+        run: node scripts/seo-a11y-guard.js

--- a/.github/workflows/spec-approval-gate.yml
+++ b/.github/workflows/spec-approval-gate.yml
@@ -1,0 +1,62 @@
+name: Spec Approval Gate
+
+# Two-phase pipeline:
+#   research-engine → applies wr:research-complete  (Phase A finished)
+#   THIS gate      → applies needs-spec-approval + posts a "ready for owner approval" comment
+#   owner          → adds the `spec-approved` label
+#   openrouter-coder fires (Phase B starts)
+#
+# Encodes the law: a bad spec wastes an entire iteration's PRs. The owner
+# approves the spec FIRST, then the coder fans out builds. See
+# docs/DEFINITION_OF_DONE.md.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  gate:
+    if: github.event.label.name == 'wr:research-complete'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+            const labelNames = (context.payload.issue.labels || []).map((l) => l.name);
+
+            // Idempotent: don't re-post if already gated or already approved.
+            if (labelNames.includes('spec-approved') || labelNames.includes('needs-spec-approval')) {
+              core.info('Already gated or approved — nothing to do.');
+              return;
+            }
+
+            try {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number, labels: ['needs-spec-approval'],
+              });
+            } catch (e) {
+              core.warning(`Could not add needs-spec-approval label: ${e.message}`);
+            }
+
+            const body = [
+              '🔬 **Research complete — spec is ready for your approval.**',
+              '',
+              'Per the two-phase pipeline (`docs/DEFINITION_OF_DONE.md`), the coder',
+              'does NOT auto-fire on `wr:research-complete` anymore. A bad spec wastes',
+              'a whole iteration of PRs.',
+              '',
+              '**Owner action:**',
+              '- Read the research / spec above.',
+              '- If it\'s right → add the **`spec-approved`** label. The coder will start',
+              '  building (fan-out PRs for app / cli / api / pdf / etc. as scoped).',
+              '- If it needs changes → comment what to fix; do **not** add `spec-approved`.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            core.notice(`Posted spec-approval gate notice on issue #${issue_number}`);

--- a/scripts/seo-a11y-guard.js
+++ b/scripts/seo-a11y-guard.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * SEO + A11y Guard
+ *
+ * Fails a PR that ships obvious SEO/a11y debt in a product app:
+ *   - <img> / <Image> tags missing an alt attribute (or empty alt with no role)
+ *   - junk image filenames (IMG_1234.jpg, DSC_0042.png, Screenshot 1.png, etc.)
+ *     — descriptive, hyphenated filenames help both SEO and accessibility.
+ *   - page/layout files missing a meta description tag.
+ *
+ * Override with the `allow-seo-debt` label when shipping intentional gaps.
+ * SEO standards evolve (Google updates, schema.org); the patterns here are
+ * conservative and stable. Review docs/SEO_STANDARDS.md quarterly.
+ *
+ * Env:
+ *   BASE_SHA          PR base sha (e.g. github.event.pull_request.base.sha)
+ *   ALLOW_SEO_DEBT    'true' when the PR carries the allow-seo-debt label
+ *   PROTECTED         protected path prefixes (default: products/,apps/,sites/,src/)
+ */
+
+const fs = require("fs");
+const { execFileSync } = require("child_process");
+
+const DEFAULT_PROTECTED = "products/,apps/,sites/,src/";
+const APP_FILE_RE = /\.(html|jsx|tsx)$/i;
+const PAGE_FILE_RE = /\b(page|layout|index)\.(html|jsx|tsx)$/i;
+
+// Junk filenames that hurt SEO and signal sloppy a11y work.
+const JUNK_FILENAME_RE = new RegExp(
+  [
+    "IMG[_-]?\\d+",
+    "DSC[_-]?\\d+",
+    "screen[\\s_-]?shot",
+    "screenshot[\\s_-]?\\d*",
+    "pasted[\\s_-]?image",
+    "^image\\.",
+    "^photo\\.",
+    "^untitled",
+    "^\\d+\\.(png|jpe?g|gif|webp|svg)$",
+  ].join("|"),
+  "i"
+);
+
+/**
+ * @param {{path:string, content:string}[]} files
+ * @param {{protectedPrefixes?:string[], allowDebt?:boolean}} opts
+ * @returns {{fail:boolean, violations:Array<{file:string,kind:string,detail:string}>}}
+ */
+function evaluateSeoA11y(files, opts = {}) {
+  const protectedPrefixes = opts.protectedPrefixes || ["products/", "apps/", "sites/", "src/"];
+  if (opts.allowDebt) return { fail: false, violations: [] };
+
+  const isProtected = (p) => protectedPrefixes.some((pre) => pre && p.startsWith(pre));
+  const violations = [];
+
+  for (const f of files) {
+    if (!isProtected(f.path) || !APP_FILE_RE.test(f.path)) continue;
+    const content = String(f.content || "");
+
+    const imgRe = /<(img|Image)\b[^>]*>/gi;
+    let m;
+    while ((m = imgRe.exec(content)) !== null) {
+      const tag = m[0];
+      const altMatch = tag.match(/\balt\s*=\s*(?:"([^"]*)"|'([^']*)'|\{`([^`]*)`\}|\{["']([^"']*)["']\})/);
+      if (!altMatch) {
+        violations.push({ file: f.path, kind: "missing-alt", detail: tag.slice(0, 120) });
+      } else {
+        const alt = (altMatch[1] ?? altMatch[2] ?? altMatch[3] ?? altMatch[4] ?? "").trim();
+        if (!alt) violations.push({ file: f.path, kind: "empty-alt", detail: tag.slice(0, 120) });
+      }
+      const srcMatch = tag.match(/\bsrc\s*=\s*(?:"([^"]*)"|'([^']*)'|\{["']([^"']*)["']\})/);
+      if (srcMatch) {
+        const src = (srcMatch[1] ?? srcMatch[2] ?? srcMatch[3] ?? "").trim();
+        const filename = src.split("/").pop() || "";
+        if (filename && JUNK_FILENAME_RE.test(filename)) {
+          violations.push({ file: f.path, kind: "junk-filename", detail: filename });
+        }
+      }
+    }
+
+    if (PAGE_FILE_RE.test(f.path)) {
+      const hasDesc = /\b(description\s*[:=]|meta\s+name=["']description["'])/i.test(content);
+      if (!hasDesc) violations.push({ file: f.path, kind: "missing-meta-description", detail: "" });
+    }
+  }
+  return { fail: violations.length > 0, violations };
+}
+
+function readChangedFiles(baseSha) {
+  const out = execFileSync("git", ["diff", "--name-only", `${baseSha}...HEAD`], { encoding: "utf8" });
+  return out
+    .split("\n")
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .filter((p) => APP_FILE_RE.test(p) && fs.existsSync(p))
+    .map((p) => ({ path: p, content: fs.readFileSync(p, "utf8") }));
+}
+
+function main() {
+  const baseSha = process.env.BASE_SHA;
+  if (!baseSha) {
+    console.log("::warning::BASE_SHA not set — SEO/a11y guard skipped.");
+    return 0;
+  }
+  const allowDebt = (process.env.ALLOW_SEO_DEBT || "").toLowerCase() === "true";
+  const protectedPrefixes = (process.env.PROTECTED || DEFAULT_PROTECTED).split(",").map((s) => s.trim()).filter(Boolean);
+
+  const files = readChangedFiles(baseSha);
+  const { fail, violations } = evaluateSeoA11y(files, { protectedPrefixes, allowDebt });
+
+  if (allowDebt) {
+    console.log("`allow-seo-debt` label present — SEO/a11y guard intentionally skipped.");
+    return 0;
+  }
+  if (fail) {
+    console.log(`❌ SEO/A11y Guard: ${violations.length} violation(s).\n`);
+    for (const v of violations) {
+      console.log(`  - [${v.kind}] ${v.file}${v.detail ? `  → ${v.detail}` : ""}`);
+    }
+    console.log(
+      "\nFix by adding meaningful `alt` text (helps disabled users AND SEO), renaming junk filenames" +
+        " to descriptive-hyphenated ones (e.g. `life-insurance-leads-zip-90210.png`), and adding a" +
+        " <meta name=\"description\"> to page/layout files.\n" +
+        "If intentional, add the `allow-seo-debt` label and re-run."
+    );
+    return 1;
+  }
+  console.log(`✅ SEO/A11y Guard passed (${files.length} app file(s) scanned).`);
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exit(main());
+  } catch (e) {
+    console.error("seo-a11y-guard error:", e.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { evaluateSeoA11y };

--- a/tests/seo-a11y-guard.test.js
+++ b/tests/seo-a11y-guard.test.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+"use strict";
+
+/** Unit tests for scripts/seo-a11y-guard.js — pure detection logic. */
+
+const assert = require("assert");
+const { evaluateSeoA11y } = require("../scripts/seo-a11y-guard");
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); console.log(`PASS: ${name}`); passed++; }
+  catch (e) { console.log(`FAIL: ${name}\n    ${e.stack || e.message}`); failed++; }
+}
+
+const opts = { protectedPrefixes: ["products/"], allowDebt: false };
+
+test("flags <img> missing alt", () => {
+  const r = evaluateSeoA11y(
+    [{ path: "products/x/src/app/page.tsx", content: '<img src="/hero.png" />' }],
+    opts
+  );
+  assert.strictEqual(r.fail, true);
+  assert.ok(r.violations.some((v) => v.kind === "missing-alt"));
+});
+
+test("flags empty alt", () => {
+  const r = evaluateSeoA11y(
+    [{ path: "products/x/src/app/page.tsx", content: '<img src="/h.png" alt="" />' }],
+    opts
+  );
+  assert.ok(r.violations.some((v) => v.kind === "empty-alt"));
+});
+
+test("flags junk filename even with alt", () => {
+  const r = evaluateSeoA11y(
+    [{ path: "products/x/src/app/page.tsx", content: '<img src="/IMG_1234.jpg" alt="leads" />' }],
+    opts
+  );
+  assert.ok(r.violations.some((v) => v.kind === "junk-filename"));
+});
+
+test("passes good alt + descriptive filename", () => {
+  const r = evaluateSeoA11y(
+    [{
+      path: "products/x/src/app/page.tsx",
+      content:
+        'export default function P(){ return <main><meta name="description" content="x"/><img src="/life-insurance-zip-90210.png" alt="Life insurance lead by zip" /></main> }',
+    }],
+    opts
+  );
+  assert.strictEqual(r.fail, false, `expected pass, got ${JSON.stringify(r.violations)}`);
+});
+
+test("flags page file missing meta description", () => {
+  const r = evaluateSeoA11y(
+    [{ path: "products/x/src/app/page.tsx", content: "export default function P(){ return <main/> }" }],
+    opts
+  );
+  assert.ok(r.violations.some((v) => v.kind === "missing-meta-description"));
+});
+
+test("ignores files outside protected paths", () => {
+  const r = evaluateSeoA11y(
+    [{ path: "docs/old.md", content: '<img src="/IMG_1.jpg">' }],
+    opts
+  );
+  assert.strictEqual(r.fail, false);
+});
+
+test("allow-seo-debt override passes", () => {
+  const r = evaluateSeoA11y(
+    [{ path: "products/x/src/app/page.tsx", content: '<img src="/IMG_1.jpg">' }],
+    { ...opts, allowDebt: true }
+  );
+  assert.strictEqual(r.fail, false);
+});
+
+console.log(`\nTest Summary: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Two enforcement gates that make the Definition of Done **actually binding** — no more "hoped-for" standards.

### 1. SEO + A11y Guard
`scripts/seo-a11y-guard.js` + `seo-a11y-guard.yml` — fails any product PR that ships obvious SEO/a11y debt:
- `<img>` / `<Image>` missing an `alt` attribute (or empty alt)
- **Junk image filenames** — `IMG_1234.jpg`, `DSC_0042.png`, `Screenshot 1.png`, `image.png`, `1.png` etc.
- Page/layout files missing a `<meta name="description">`

Override with the `allow-seo-debt` label. **Alt-text helps both disabled users AND SEO** — same text, two beneficiaries. **7/7 unit tests.** SEO patterns are conservative + stable; refresh `docs/SEO_STANDARDS.md` quarterly as Google evolves.

### 2. Research-to-Build Approval Gate
Encodes your **two-phase pipeline** so a bad spec can't burn a whole iteration:

| Phase | Before | After |
| --- | --- | --- |
| Research finishes | coder auto-fires on `wr:research-complete` | gate labels the issue **`needs-spec-approval`** + posts a comment asking the owner to approve |
| Owner approves | (no checkpoint) | owner adds **`spec-approved`** label |
| Build fan-out | `wr:research-complete` triggered coder | `spec-approved` triggers coder (app / cli / api / pdf / etc.) |

Two small changes: 1 line in `openrouter-coder.yml` (label trigger) + new `spec-approval-gate.yml` that announces the gate.

### Effect
- Bad alt-text / junk filenames / missing meta = PR blocked at the gate, not after deploy.
- Bad spec = stopped at the spec stage, not after the coder spends tokens on 5 wrong PRs.

### Test plan
- [x] 7/7 SEO/a11y unit tests; `node --check` clean; all three workflows parse.
- [x] Coder trigger swapped (`wr:research-complete` → `spec-approved`).
- [ ] First live PR exercises the SEO/a11y gate; first real research WR exercises the approval gate.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces two enforcement gates to make the Definition of Done binding. First, it adds an **SEO and accessibility guard** that fails PRs shipping images without proper `alt` attributes, junk image filenames (like `IMG_1234.jpg` or `Screenshot 1.png`), or page files missing meta descriptions. Second, it implements a **research-to-build approval gate** that changes the workflow trigger from `wr:research-complete` to `spec-approved`, requiring explicit owner approval of specifications before the coder begins building. The SEO/a11y guard can be bypassed with an `allow-seo-debt` label, and includes comprehensive unit tests (7/7 passing).

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/spec-approval-gate.yml` |
| 2 | `.github/workflows/openrouter-coder.yml` |
| 3 | `scripts/seo-a11y-guard.js` |
| 4 | `tests/seo-a11y-guard.test.js` |
| 5 | `.github/workflows/seo-a11y-guard.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two enforcement gates: an SEO + accessibility PR guard and a spec-approval gate for the research-to-build pipeline. This blocks obvious SEO/a11y debt and starts builds only after the spec is approved.

- **New Features**
  - SEO + A11y Guard: blocks PRs with missing `alt` on `<img>/<Image>`, junk image filenames (e.g., `IMG_1234.jpg`, `screenshot.png`), and missing `<meta name="description">` in page/layout files; override with the `allow-seo-debt` label.
  - Spec Approval Gate: when `wr:research-complete` is applied, adds `needs-spec-approval` and posts a notice; builds now fan out only after the owner adds `spec-approved`.

- **Migration**
  - Builds trigger on `spec-approved` (not `wr:research-complete`).
  - To intentionally ship SEO/a11y gaps, add the `allow-seo-debt` label.

<sup>Written for commit cbbe525d09722d893ec7e4a5af140e133e5e0947. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13957?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

