### PR TITLE
Fix peter-evans CPR warning (drop misplaced persist-credentials)

### DIFF
--- a/.github/workflows/agent-fallback.yml
+++ b/.github/workflows/agent-fallback.yml
@@ -314,7 +314,6 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          persist-credentials: false
           branch: agent-fallback/issue-${{ steps.issue.outputs.issue_number }}
           base: main
           title: "[${{ steps.result.outputs.agent }}] ${{ steps.issue.outputs.issue_title }}"


### PR DESCRIPTION
## Summary

Fixes the `Unexpected input(s) 'persist-credentials'` warning on every `agent-fallback` run.

`peter-evans/create-pull-request@v6` doesn't accept `persist-credentials` — that input belongs to `actions/checkout`. It was misplaced on the CPR step at `agent-fallback.yml:317`; the action ignored it and warned every run. Removed.

The two *correct* usages of `persist-credentials: false` on `actions/checkout` earlier in the file are unchanged.

## Test plan
- [x] Workflow parses.
- [x] No remaining `persist-credentials` on CPR steps repo-wide.
- [ ] Next agent-fallback run: warning gone.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes a misplaced `persist-credentials` parameter from a `peter-evans/create-pull-request` action call that was causing warnings on every agent-fallback workflow run. The parameter belongs to `actions/checkout` and was incorrectly placed on the create-pull-request step, causing the action to ignore it and emit warnings.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/agent-fallback.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove a misplaced `persist-credentials: false` from the `peter-evans/create-pull-request@v6` step to stop the "Unexpected input(s) 'persist-credentials'" warning on every `agent-fallback` run. Correct `persist-credentials` usages on `actions/checkout` remain unchanged.

<sup>Written for commit d3f4e471ce550e58ed19d31a9ec3a5d0f788330c. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13958?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

