### PR TITLE
Pause Mabl auto-triggers, replace with Keploy (eval kept per revvel-standards)

### DIFF
--- a/.github/workflows/credential-gatekeeper.yml
+++ b/.github/workflows/credential-gatekeeper.yml
@@ -98,12 +98,15 @@ jobs:
                 doppler_name: 'APP_ID',
                 also_requires: ['APP_PRIVATE_KEY'],
               },
+              // PAUSED 2026-05-27 with mabl.yml — uncomment block to re-enable.
+              /*
               {
                 keywords: ['mabl', 'e2e test', 'end-to-end test', 'browser test'],
                 secret: 'MABL_API_KEY',
                 description: 'mabl testing platform API key',
                 doppler_name: 'MABL_API_KEY',
               },
+              */
               {
                 keywords: ['gist', 'mirror', 'backup', 'durability'],
                 secret: 'MIRROR_GIST_TOKEN',

--- a/.github/workflows/jules-coding-agent.yml
+++ b/.github/workflows/jules-coding-agent.yml
@@ -24,7 +24,13 @@ permissions:
   issues: write
 
 env:
-  JULES_TOKEN: ${{ secrets.JULES_TOKEN }}
+  # Unified to JULES_API_KEY 2026-05-28 — every other Jules workflow already used
+  # JULES_API_KEY; only this file looked for JULES_TOKEN, which left the
+  # secret-persistence-guard chasing a key nobody else referenced (the "clog").
+  # Old name kept (commented) per the standards convention; uncomment only if
+  # you ever genuinely need a separate token credential.
+  # JULES_TOKEN: ${{ secrets.JULES_TOKEN }}
+  JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/mabl.yml
+++ b/.github/workflows/mabl.yml
@@ -1,14 +1,56 @@
 name: mabl Automated Tests
+
+# ── PAUSED 2026-05-27 — Mabl replaced by Keploy ───────────────────────────────
+# Kept (commented) so this can be re-enabled in one edit if Mabl is ever needed
+# again for cloud-managed E2E browser tests. Per revvel-standards convention:
+# every tool we evaluated gets a record of what it did + what we liked + what
+# we didn't, so future-us doesn't re-litigate the same decision.
+#
+# ── What this workflow did ────────────────────────────────────────────────────
+# - On push to main/release/** + every PR, installed @mablhq/mabl-cli and
+#   called `mabl tests run` against the Mabl cloud account.
+# - Test plans were configured in the Mabl dashboard (NOT in this repo); the
+#   CLI only TRIGGERS them. If no plans existed with matching labels, the CLI
+#   ran and nothing actually executed → silent no-op.
+# - Since MABL_API_KEY went missing it short-circuited at the key check
+#   ("⚠️ MABL_API_KEY secret is not set"), so it's been a full no-op recently.
+#
+# ── What we liked ─────────────────────────────────────────────────────────────
+# - Hands-off cloud-managed E2E (no Playwright code to maintain in-repo).
+# - Visual recorder + dataflow tests in the dashboard.
+# - Cross-browser without our own grid.
+#
+# ── What we didn't like ───────────────────────────────────────────────────────
+# - Test plans live in Mabl's dashboard, NOT in this repo → invisible to the
+#   pipeline, the agents, code review, and audit. Can't reuse or version-
+#   control the test logic from code.
+# - Required a paid MABL_API_KEY that kept expiring / going missing → cascade
+#   into the Secrets Sentinel spam.
+# - In practice, "we never saw it run much" — either no plans were configured,
+#   or it no-op'd silently when the key was absent.
+#
+# ── Replaced by ───────────────────────────────────────────────────────────────
+# - **Keploy** GitHub App (https://github.com/apps/keploy) — AI-generated,
+#   validated unit + API tests written directly into PRs. Code-level, visible,
+#   no external dashboard for test logic, no paid key needed for the basic tier.
+# - For genuine browser E2E (login flows, multi-step journeys), add Playwright
+#   in the affected app rather than a paid cloud runner.
+#
+# ── To re-enable Mabl ─────────────────────────────────────────────────────────
+# Uncomment the push: / pull_request: blocks below, set MABL_API_KEY in repo
+# secrets, and configure plans in the Mabl dashboard with matching labels.
+# ──────────────────────────────────────────────────────────────────────────────
+
 on:
-  push:
-    branches:
-      - main
-      - release/**
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+  # push:
+  #   branches:
+  #     - main
+  #     - release/**
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - synchronize
+  #     - reopened
   workflow_dispatch:
     inputs:
       app-url:

--- a/.github/workflows/secret-persistence-guard.yml
+++ b/.github/workflows/secret-persistence-guard.yml
@@ -113,7 +113,7 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_AGENT_TOKEN || secrets.DOPPLER_TOKEN || secrets.DOPPLER_LOCAL_TOKEN || secrets.DOPPLER_API_KEY || secrets.DOPPLER_AGENT_ODIC || secrets.DOPPLER_CIRCLECI_OIDC }}
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-          MABL_API_KEY: ${{ secrets.MABL_API_KEY }}
+          # MABL_API_KEY: ${{ secrets.MABL_API_KEY }}  # PAUSED 2026-05-27 with mabl.yml — uncomment to re-enable.
         run: |
           MISSING=()
 
@@ -140,7 +140,7 @@ jobs:
           check_secret "DOPPLER_TOKEN"
           check_secret "APP_ID"
           check_secret "APP_PRIVATE_KEY"
-          check_secret "MABL_API_KEY"
+          # check_secret "MABL_API_KEY"  # PAUSED 2026-05-27 with mabl.yml — uncomment to re-enable.
 
           # Save missing secrets (compact single-line JSON to avoid $GITHUB_OUTPUT multiline issues)
           if [ ${#MISSING[@]} -gt 0 ]; then

--- a/.github/workflows/secrets-health-check.yml
+++ b/.github/workflows/secrets-health-check.yml
@@ -22,7 +22,7 @@ jobs:
           RECURSE_ML_API_KEY: ${{ secrets.RECURSE_ML_API_KEY }}
           APP_ID: ${{ secrets.APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-          MABL_API_KEY: ${{ secrets.MABL_API_KEY }}
+          # MABL_API_KEY: ${{ secrets.MABL_API_KEY }}  # PAUSED 2026-05-27 with mabl.yml — uncomment to re-enable.
           MIRROR_GIST_ID: ${{ secrets.MIRROR_GIST_ID }}
           MIRROR_GIST_TOKEN: ${{ secrets.MIRROR_GIST_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
           check_secret "APP_ID"
           check_secret "APP_PRIVATE_KEY"
           # Other integrations
-          check_secret "MABL_API_KEY"
+          # check_secret "MABL_API_KEY"  # PAUSED 2026-05-27 with mabl.yml — uncomment to re-enable.
           check_secret "MIRROR_GIST_ID"
           check_secret "MIRROR_GIST_TOKEN"
           check_secret "VERCEL_TOKEN"

--- a/docs/API_LIMIT_AUTO_UPGRADE.md
+++ b/docs/API_LIMIT_AUTO_UPGRADE.md
@@ -1,0 +1,97 @@
+# API Limit → Auto-Upgrade Decision Standard
+
+When any SaaS/API tool we use (Keploy, OpenRouter, Jules, Mabl, Vercel,
+DigitalOcean, etc.) hits a quota / rate limit / "upgrade required" wall, this
+standard decides **what the pipeline does next** — without making someone hunt
+the dashboard.
+
+The same decision tree pitches well to enterprise/SaaS buyers ("here's how we
+govern tool spend across the fleet"), so every decision the system makes against
+this standard is logged into `docs/UPGRADE_LOG.md` so we can show the reasoning
+on demand.
+
+> Per the standards convention: **nothing is dropped — only commented**. When a
+> tool is downgraded or paused, the old config stays in-file with a header
+> explaining what we tried and what changed, so future-us can re-enable in one
+> edit and future-buyers can audit the decision.
+
+---
+
+## The decision tree
+
+Triggered when a workflow fails with a recognisable limit error
+(`rate limit`, `quota exceeded`, `upgrade required`, `429`, `payment required`).
+
+### Step 1 — find the upgrade cost
+Look up the next-tier cost from `docs/TOOL_COST_INDEX.md` (see template below).
+If the tool isn't in the index, file a **research WR** to populate it before
+deciding.
+
+### Step 2 — apply the cost gate
+
+| Next-tier cost | Path | Owner approval? |
+| --- | --- | --- |
+| **≤ $40 / month** | **Auto-implement** the upgrade (file an upgrade WR labeled `auto-upgrade-approved`; the openrouter-coder pipeline executes via the provider's API where possible, or files an actionable instruction issue if the upgrade requires a UI click). | **Not required** — the standard pre-approves spend below this threshold. Still logged. |
+| **$41 – $50 / month** | **Auto-implement** the upgrade, but file the WR labeled `owner-approval-recommended` so it shows up in the daily digest. Pipeline proceeds unless owner adds `block-upgrade` within 24h. | Soft (default-yes). |
+| **$51 – $99 / month** | **Research first.** Pipeline files a `[WR] Upgrade evaluation: <tool> <next-tier>` via the research-engine. The Professor produces a sourced cost/benefit packet (utilization, alternatives, ROI, contract terms). Owner approves with `spec-approved`; only then upgrade proceeds. | **Required.** |
+| **≥ $100 / month** | **Deep research + written justification.** Same as above plus: at least one named alternative considered, 30-day ROI projection, exit-cost analysis ("what does cancelling look like in 6 months?"). | **Required + signed off.** |
+
+### Step 3 — record the decision
+Every run writes one row to `docs/UPGRADE_LOG.md`:
+`date | tool | trigger | next-tier cost | decision | link to WR/PR`.
+
+---
+
+## Hard rules (don't ever break these)
+
+1. **Comment, don't delete.** When we downgrade or pause a tool, its config
+   stays in the relevant workflow with a header explaining the change. See
+   `mabl.yml` for the reference pattern.
+2. **Never silently upgrade above $40/mo.** Anything in tier 3/4 must surface
+   to the owner via an issue or daily digest *before* the spend lands.
+3. **Free tier first.** If the free tier covers ≥ 80% of need, stay on free
+   and budget the gap (e.g. queue jobs vs paying for headroom).
+4. **Single source of truth for cost.** All numbers come from
+   `docs/TOOL_COST_INDEX.md`. If a workflow needs to know a price, it reads
+   from there, not from inline literals.
+5. **Auditable for enterprise pitches.** `docs/UPGRADE_LOG.md` is the
+   evidence trail. Don't garbage-collect it.
+
+---
+
+## What this serves (the enterprise pitch angle)
+
+- A potential enterprise client asks: *"How do you govern your tool spend?"*
+- You point them at this file + `docs/UPGRADE_LOG.md`.
+- They see: tiered approval, free-tier-first, full audit trail, written
+  justifications for every paid upgrade above $50/mo, alternatives considered.
+- That's a more credible spend-control story than most early-stage companies
+  have.
+
+---
+
+## Tools in scope (initial — extend as we add)
+
+| Tool | Free tier sufficient? | Current cost | Next-tier cost | Decision band |
+| --- | --- | --- | --- | --- |
+| **Keploy** | yes (low volume) | $0 | est. $20–$40/seat | Tier 1 (auto-implement when hit) |
+| **OpenRouter** | usage-priced | varies | n/a (no fixed tier) | Tracks `vars.WR_MODEL`; per-call budget cap separate |
+| **Jules** | per Google's terms | per Google | n/a | Reviewed when limit hits |
+| **Vercel** | yes (hobby) | $0 | $20/mo (Pro) | Tier 1 |
+| **DigitalOcean** | usage-priced | varies | n/a | Budget cap separately |
+| **Mabl** | n/a (PAUSED) | $0 | — | See mabl.yml header |
+| **ImgBot** | yes (open-source) | $0 | n/a | Free indefinitely |
+| **CodeRabbit** | per their tier | varies | per tier | Review when hit |
+| **Bito** | per their tier | varies | per tier | Review when hit |
+
+Extend with `docs/TOOL_COST_INDEX.md` when adding a new SaaS to the pipeline.
+
+---
+
+## Implementation (planned next)
+
+A small workflow (`api-limit-auto-upgrade.yml`) listens for workflow failures
+with limit-error signatures, looks up the cost from `TOOL_COST_INDEX.md`, and
+files the right kind of issue per Step 2. This standard governs the behaviour;
+the workflow enforces it. Build is a follow-on — defining the standard first so
+we don't build the wrong shape.

--- a/docs/AUTOMATION_AUDIT.md
+++ b/docs/AUTOMATION_AUDIT.md
@@ -81,7 +81,7 @@ The revvel-standards repository has extensive automation infrastructure:
 #### Monitoring & Analytics
 33. ✅ `amplitude-events.yml` — Amplitude analytics events
 34. ✅ `amplitude-to-notion.yml` — Amplitude → Notion sync
-35. ✅ `mabl.yml` — Mabl test automation
+35. ⏸ `mabl.yml` — Mabl test automation (PAUSED 2026-05-27; replaced by Keploy. Auto-triggers commented; manual `workflow_dispatch` still works. See header notes in the workflow file for the full evaluation.)
 36. ✅ `workflow-health-dashboard.yml` — Workflow monitoring
 37. ✅ `proof-of-life.yml` — App health checks
 

--- a/docs/CREDENTIAL_AUTOMATION_ROADMAP.md
+++ b/docs/CREDENTIAL_AUTOMATION_ROADMAP.md
@@ -1,0 +1,123 @@
+# Credential Automation Roadmap
+
+**Goal (Manus-style):** the pipeline can **mint a new API token from a
+provider**, **store it as a GitHub secret**, and use it — with **no manual UI
+clicks**. When a tool needs a key the system asks for one and gets one.
+
+This file is the honest map: what's wired today, what's still manual, and what
+order to fill in the gaps.
+
+> Per the standards convention: nothing is dropped, only commented; every
+> decision logged in `docs/UPGRADE_LOG.md`; all numbers from
+> `docs/TOOL_COST_INDEX.md`; cost gates per `docs/API_LIMIT_AUTO_UPGRADE.md`.
+
+---
+
+## What's already wired (the easy half — restore + persist)
+
+| Layer | What it does | File |
+| --- | --- | --- |
+| **Sentinel** | Audits 5 critical secrets daily, files one tracked issue when something's missing (dedup by title — fix in #13948). | `secrets-sentinel.yml` |
+| **Secret Persistence Guard** | Hourly; alerts when secrets *disappear* from the repo. | `secret-persistence-guard.yml` |
+| **Credential Backup Harness** | Restores secrets from any of 8 sources (Doppler, JSON, SOPS, pass, Bitwarden, 1Password, Infisical, Vault). | `scripts/credential-backup-harness.js` |
+| **Gatekeeper Sync** | Pulls from a source and `gh secret set`s back into the repo. | `scripts/gatekeeper-sync.sh` |
+
+**Net:** once a secret exists *somewhere we own* (Doppler, JSON, 1Password,
+etc.), the pipeline can keep it in GitHub secrets indefinitely. That's the
+"backup → persistence → auto-restore" half.
+
+---
+
+## What's still manual (the hard half — auto-generate from a provider)
+
+| Step | Today | What Manus-style would do |
+| --- | --- | --- |
+| 1. Provider account exists | Manual | Same — accounts are still human-created |
+| 2. Generate a new API key | **Manual** (UI click on the provider's site) | Pipeline calls the provider's *admin/OAuth* endpoint to mint a new key |
+| 3. Store key in a backup source | Manual | Pipeline writes to Doppler / `CREDENTIAL_BACKUP_JSON` |
+| 4. Sync to GitHub secret | ✅ auto (gatekeeper-sync) | Same |
+| 5. Rotate on expiry | Manual reminder | Pipeline detects expiry → repeats steps 2–4 |
+
+**The blocker:** step 2 needs the provider's admin API to mint keys, and
+authenticating to *that* needs a higher-tier credential (an OAuth admin token).
+Chicken-and-egg until the first admin token is set up.
+
+---
+
+## Phased plan
+
+### Phase 1 — Make manual key insertion 1-step (DOABLE NOW)
+Today when you generate a key from a provider, you:
+1. Copy it.
+2. Open repo settings → secrets → new secret → name + paste → save.
+
+Build `scripts/secret-set.sh` that wraps `gh secret set` + writes to
+`CREDENTIAL_BACKUP_JSON` simultaneously so future restores work too:
+
+```bash
+./scripts/secret-set.sh JULES_API_KEY <pasted-key>
+# → writes to GitHub secrets AND to the backup JSON in one call
+```
+
+Tiny effort, big QoL win, no new permissions needed.
+
+### Phase 2 — Per-provider mint adapters (one provider at a time)
+For each SaaS where we want auto-mint, add a small adapter that calls that
+provider's "create API key" endpoint and stores the result. Start with the
+providers where this is documented and we already have admin auth:
+
+- **DigitalOcean** — `POST /v2/account/keys` ([docs](https://docs.digitalocean.com/reference/api/api-reference/#operation/sshKeys_create)) — needs an existing admin token.
+- **Vercel** — `POST /v9/access-tokens` — needs admin auth.
+- **GitHub** itself — `POST /user/keys`, fine-grained PAT minting via REST.
+- **Doppler** — has a Service-Account token model that's a one-time setup, then unattended.
+
+For each: `scripts/providers/<name>/mint-key.sh` + a Provider Adapter contract
+documented in `engines/CONTRACT.md`.
+
+**Skip** providers that don't expose a key-minting API
+(Jules, OpenRouter, Keploy, Mabl — these are manual-only at the provider end).
+
+### Phase 3 — Watchdog ties it all together
+A scheduled workflow that:
+1. Reads `docs/TOOL_COST_INDEX.md` to know which providers we use.
+2. For each, checks if the secret is present + valid (calling the provider's
+   "whoami" endpoint).
+3. If missing or expired → if a mint adapter exists, **calls it**; otherwise
+   files a Work Request labeled `needs-human-credential` with the exact
+   provider URL + step-by-step instructions (per the standards: don't leave
+   the human guessing).
+4. All decisions logged to `docs/UPGRADE_LOG.md`.
+
+---
+
+## Hard rules (carried from the standards)
+
+1. **Never auto-spend** to provision a credential above the cost gates in
+   `docs/API_LIMIT_AUTO_UPGRADE.md`. Auto-mint of a free-tier key = fine.
+   Auto-creating a paid plan = forbidden without owner approval.
+2. **Always log** every mint/rotation/store action to `docs/UPGRADE_LOG.md`.
+3. **Never delete** old keys (revoke at the provider, mark commented in our
+   own records) — keeps audit trail intact.
+4. **One source of truth for what we need** — the lists in
+   `secrets-health-check.yml` and `secret-persistence-guard.yml` are
+   authoritative. Don't sprinkle copies elsewhere.
+
+---
+
+## What this serves (the enterprise pitch angle)
+
+Same as `docs/API_LIMIT_AUTO_UPGRADE.md`: a buyer asks *"how do you manage
+credentials at scale?"* and you point at:
+- This roadmap (the phased plan + hard rules)
+- `docs/UPGRADE_LOG.md` (the audit trail)
+- `docs/TOOL_COST_INDEX.md` (the inventory)
+- `scripts/credential-backup-harness.js` (the multi-source restore)
+
+That story is more credible than most startups have.
+
+---
+
+## Next concrete action
+
+Phase 1 — `scripts/secret-set.sh`. ~30 lines of bash, no new permissions
+needed. Want me to build it now or queue it?

--- a/docs/TESTING_STACK.md
+++ b/docs/TESTING_STACK.md
@@ -1,0 +1,59 @@
+# Testing Stack — what we use, what we paused, why
+
+Per revvel-standards convention: every testing tool we evaluated gets a record
+here — what it does, what we liked, what we didn't, and (if paused) the
+replacement. Nothing is dropped — everything is recoverable in one edit.
+
+---
+
+## ✅ Active
+
+### Keploy (GitHub App + Chrome extension)
+**What it does**
+- **Keploy App** (`https://github.com/apps/keploy`) — AI auto-generates **validated unit + API tests** directly inside PRs, code-level, no external dashboard for the test logic.
+- **Keploy API Test Recorder** (Chrome extension) — captures real API traffic from your browser. Feed the recording to Keploy and it generates API tests from realistic request/response data instead of guessing.
+
+**What we like**
+- Tests land **in the repo**, visible to the pipeline + agents + code review (unlike Mabl, where tests lived in a cloud dashboard).
+- No paid key for the basic tier.
+- Test recorder lets us drive a real session in the browser and convert it into committed test code — closes the loop between user-flow and unit/API coverage.
+- Pairs naturally with the **Completeness Gate** (`docs/DEFINITION_OF_DONE.md`): a deliverable that ships with auto-generated tests is more credibly "done."
+
+**What we don't (caveats)**
+- Doesn't replace true browser **E2E** (multi-page user journeys, visual regression). For those, add **Playwright** in the affected app.
+- AI-generated tests still need a human/agent skim — bad input → bad tests. Treat them as a *floor*, not a ceiling.
+
+**How to use the Chrome extension**
+1. Install from the Chrome Web Store: *Keploy API Test Recorder*.
+2. Open the deployed app you want to capture (e.g. the lead-engine Vercel preview).
+3. Click record, exercise the flow (capture leads, dedupe, etc.).
+4. Export the capture → Keploy turns it into API tests committed via PR.
+
+### WCAG_PR_Checker — `eco-github-extensions.yml`
+Runs on every PR; uses Playwright + axe-core to scan the deployed Vercel preview for a11y violations (alt text, contrast, ARIA). See workflow file for details.
+
+### SEO + A11y Guard — `scripts/seo-a11y-guard.js` + `seo-a11y-guard.yml`
+Source-level scanner that fails a PR for missing alt, junk image filenames, or pages missing a meta description. Pre-merge, before WCAG_PR_Checker runs.
+
+### ImgBot (GitHub App)
+Opens a follow-up PR after images are committed, with compressed versions. Saves bytes; no manual config.
+
+---
+
+## ⏸ Paused (kept commented, restorable in one edit)
+
+### Mabl — `mabl.yml` (PAUSED 2026-05-27)
+**Why paused:** test plans lived in the Mabl dashboard (not in this repo) so the pipeline + agents couldn't see them; required a paid `MABL_API_KEY` that kept going missing → Sentinel spam; in practice it no-op'd silently most of the time.
+
+**Replaced by:** Keploy (above).
+
+**Full evaluation:** see the header of `.github/workflows/mabl.yml`. To re-enable: uncomment the `push:` / `pull_request:` blocks in `mabl.yml`, set `MABL_API_KEY`, and configure plans in the Mabl dashboard. Companion comment-outs in `secrets-health-check.yml`, `secret-persistence-guard.yml`, and `credential-gatekeeper.yml` also need to be uncommented.
+
+---
+
+## 📋 Recommended additions (when needed)
+
+- **Playwright in-app** — for real browser E2E (login flows, multi-step user journeys). Add per-app rather than a paid cloud runner. No standing license cost.
+- **Lighthouse CI** — performance + Core Web Vitals budgets on the deployed preview. Pairs with SEO standards (`docs/SEO_STANDARDS.md`).
+
+Add these only when a specific product needs them — don't pre-install paid tools.

--- a/docs/TESTING_STACK.md
+++ b/docs/TESTING_STACK.md
@@ -8,26 +8,52 @@ replacement. Nothing is dropped — everything is recoverable in one edit.
 
 ## ✅ Active
 
-### Keploy (GitHub App + Chrome extension)
+### Keploy (GitHub App + Chrome extension + CLI)
 **What it does**
-- **Keploy App** (`https://github.com/apps/keploy`) — AI auto-generates **validated unit + API tests** directly inside PRs, code-level, no external dashboard for the test logic.
-- **Keploy API Test Recorder** (Chrome extension) — captures real API traffic from your browser. Feed the recording to Keploy and it generates API tests from realistic request/response data instead of guessing.
+- **Keploy GitHub App** (`https://github.com/apps/keploy`) — auto-generates **validated unit + API tests** in PRs.
+- **Keploy API Test Recorder** (Chrome extension) — captures real API traffic from a browser session and converts it into API tests via Keploy.
+- **Keploy Navigator** (separate GitHub bot) — broader test-automation companion. Optional; install if you want continuous coverage beyond per-PR generation.
+- **Keploy CLI** (`keploy record` / `keploy test`) — local capture + replay of real traffic; useful when you want to author tests outside the browser.
+
+**Feature inventory — exploit these where they fit**
+- Unit test generation in PRs (Java, Go, Node, Python).
+- API test generation from recorded HTTP traffic (no manual stub-writing).
+- Mocked dependency calls in replay (no need to spin up real backends in CI).
+- Mutation testing on generated tests (catches false-confidence coverage).
+- Diff-based test impact (only run affected tests on a PR — faster CI).
+- Code coverage reporting integrated with the generator.
+- Dashboard at app.keploy.io for run history (optional; primary value is in-repo tests).
+
+**Pricing (free → paid tiers — verify at keploy.io/pricing before relying on numbers)**
+- **Free** — covers low-volume repos: limited test generations/month and a cap on concurrent runs. Sufficient for a single dev / small product cluster.
+- **Pro/Team** — per-seat monthly tier (estimated **$20–$40/seat/mo** range as of 2026; treat as estimate until verified). Lifts the generation cap + adds team features.
+- **Enterprise** — custom; SSO, audit logs, SOC2, dedicated support. Custom quote.
+
+> **Verify before sharing as policy.** Keploy adjusts tiers frequently. The
+> `docs/API_LIMIT_AUTO_UPGRADE.md` decision standard governs *when* an upgrade
+> auto-fires vs requires research, regardless of current price.
 
 **What we like**
 - Tests land **in the repo**, visible to the pipeline + agents + code review (unlike Mabl, where tests lived in a cloud dashboard).
-- No paid key for the basic tier.
-- Test recorder lets us drive a real session in the browser and convert it into committed test code — closes the loop between user-flow and unit/API coverage.
+- No paid key for the basic tier — real value before you ever pay.
+- The Chrome extension closes the loop between a browser session and committed test code — record once, replay in CI forever.
 - Pairs naturally with the **Completeness Gate** (`docs/DEFINITION_OF_DONE.md`): a deliverable that ships with auto-generated tests is more credibly "done."
 
 **What we don't (caveats)**
-- Doesn't replace true browser **E2E** (multi-page user journeys, visual regression). For those, add **Playwright** in the affected app.
+- Doesn't replace true browser **E2E** (multi-page user journeys, visual regression). For those, add **Playwright** per app.
 - AI-generated tests still need a human/agent skim — bad input → bad tests. Treat them as a *floor*, not a ceiling.
+- Free-tier rate limits are real — see auto-upgrade decision standard.
 
 **How to use the Chrome extension**
 1. Install from the Chrome Web Store: *Keploy API Test Recorder*.
 2. Open the deployed app you want to capture (e.g. the lead-engine Vercel preview).
 3. Click record, exercise the flow (capture leads, dedupe, etc.).
 4. Export the capture → Keploy turns it into API tests committed via PR.
+
+**Error-handling + auto-upgrade on rate limit**
+When a Keploy run fails with a rate-limit / quota-exceeded error, the standard in
+`docs/API_LIMIT_AUTO_UPGRADE.md` decides what happens (auto-upgrade vs research-
+first). This is a general standard — applies to any SaaS we hit a limit on.
 
 ### WCAG_PR_Checker — `eco-github-extensions.yml`
 Runs on every PR; uses Playwright + axe-core to scan the deployed Vercel preview for a11y violations (alt text, contrast, ARIA). See workflow file for details.

--- a/docs/TESTING_STACK.md
+++ b/docs/TESTING_STACK.md
@@ -83,3 +83,53 @@ Opens a follow-up PR after images are committed, with compressed versions. Saves
 - **Lighthouse CI** — performance + Core Web Vitals budgets on the deployed preview. Pairs with SEO standards (`docs/SEO_STANDARDS.md`).
 
 Add these only when a specific product needs them — don't pre-install paid tools.
+
+---
+
+## 🔍 Evaluated alternatives (and why we said yes / no)
+
+Per the standards convention, every tool we considered gets a record. Cost
+decisions follow `docs/API_LIMIT_AUTO_UPGRADE.md`.
+
+| Tool | What it does | Verdict | Why |
+| --- | --- | --- | --- |
+| **Test.ai** | AI-driven cross-platform test automation | ❌ **Skip — redundant** | Overlaps Keploy's AI test generation. Adding it = two AI testers competing for the same job. Re-evaluate only if Keploy can't keep up. |
+| **BrowserStack** | Cloud cross-browser device farm | ⏸ **Defer — expensive** | ~$29/seat/mo starting tier. Genuine value only if we ship multiple browser-critical apps. Today's Next.js products work in modern evergreen browsers. Add when a real cross-browser requirement appears. |
+| **Jenkins** | Self-hosted CI/CD | ❌ **Skip — redundant** | We already have GitHub Actions (free for public, generous for private). Jenkins adds ops burden (a server to maintain) for nothing we don't already have. |
+| **Cypress** | E2E browser testing | ✅ **Add per-app when E2E is needed** | Free for OSS, excellent DX, what most teams reach for. Don't install repo-wide; add `cypress/` per product app that needs E2E. See template below. |
+| **Applitools** | Visual regression / AI-eye diff | ✅ **Add when visual fidelity matters** | Free tier = 100 checkpoints/mo (often enough for one product). Catches UI regressions Keploy can't see. Integrates with Cypress/Playwright. |
+| **Postman** | Manual API exploration + collection sharing | ✅ **Install as dev tool, not pipeline-wired** | Free tier strong; great for poking APIs by hand, building collections to share, generating curl snippets. Keploy covers automated API testing; Postman covers the human side. |
+
+### Pattern: which tool to reach for, by need
+
+| Need | Reach for |
+| --- | --- |
+| Unit tests for a product's logic | **Keploy** (auto-generates in PRs) |
+| API tests for a product's endpoints | **Keploy** (record traffic via Chrome extension or CLI, replay in CI) |
+| Manual API exploration / shareable collections | **Postman** (dev's laptop, not CI) |
+| End-to-end browser flows (login, multi-page) | **Cypress** per app |
+| Pixel-level UI regression / visual diff | **Applitools** alongside Cypress |
+| Cross-browser smoke tests | **BrowserStack** (only when needed; expensive) |
+| Performance / Core Web Vitals | **Lighthouse CI** per app |
+| A11y violations (deployed page) | **WCAG_PR_Checker** (already wired) |
+| A11y violations (source code) | **SEO + A11y Guard** (already wired) |
+
+### Per-app Cypress setup template
+When a product genuinely needs E2E, add to the app:
+```bash
+npm i -D cypress @testing-library/cypress
+npx cypress open   # interactive
+npx cypress run    # CI
+```
+Then wire a per-app workflow that runs `npx cypress run` on PRs, against the
+Vercel preview URL. Don't pre-install in revvel-standards itself.
+
+---
+
+## 🔐 Manus-style auto-credential management — roadmap
+
+What we want (per owner): the pipeline can **generate a new API token from a
+provider** (e.g., mint a fresh Jules key) **and automatically store it as a
+GitHub secret** — no manual UI clicks. See **`docs/CREDENTIAL_AUTOMATION_ROADMAP.md`**
+for the phased plan, what's already wired (the backup/restore half), and what's
+missing (the auto-generate half).

--- a/docs/TOOL_COST_INDEX.md
+++ b/docs/TOOL_COST_INDEX.md
@@ -1,0 +1,32 @@
+# Tool Cost Index
+
+Single source of truth for current + next-tier costs of every SaaS the pipeline
+uses. The **API-Limit Auto-Upgrade Decision Standard**
+(`docs/API_LIMIT_AUTO_UPGRADE.md`) reads from this file when a quota wall is
+hit. If a tool isn't listed here, a research WR must populate it before any
+upgrade decision can be made.
+
+> Numbers are estimates as of 2026-05-28 — verify at each provider's pricing
+> page before committing. Update this file when a tier changes.
+
+| Tool | Current tier | Current cost | Next-tier name | Next-tier cost | Source |
+| --- | --- | --- | --- | --- | --- |
+| Keploy | Free | $0 | Pro / Team | est. $20–$40 / seat / mo | keploy.io/pricing |
+| Vercel | Hobby | $0 | Pro | $20 / user / mo | vercel.com/pricing |
+| OpenRouter | usage-priced (no tier) | varies | — | n/a | openrouter.ai/pricing |
+| Jules | per Google plan | varies | per Google plan | varies | jules.google.com |
+| DigitalOcean | usage-priced | varies | — | n/a | digitalocean.com/pricing |
+| Doppler | Free (Developer) | $0 | Team | $18 / user / mo | doppler.com/pricing |
+| ImgBot | Open-source | $0 | — | n/a (free indefinitely) | imgbot.net |
+| CodeRabbit | Free (limited) | $0 | Pro | est. $24 / user / mo | coderabbit.ai/pricing |
+| Bito | Free (limited) | $0 | Pro | est. $15 / user / mo | bito.ai/pricing |
+| Mabl | **PAUSED** | $0 | — | est. starts $150+ / mo | mabl.com/pricing (verify) |
+| Augment Code | Free (limited) | $0 | per their pricing | per their pricing | augmentcode.com |
+
+## Update procedure
+
+1. When a provider changes their pricing OR we hit a limit and need to know the
+   real number → update the row here.
+2. Add a corresponding entry to `docs/UPGRADE_LOG.md` if the change triggered a
+   tier action.
+3. Workflows should *read* from this file, not hardcode prices inline.

--- a/docs/TOOL_COST_INDEX.md
+++ b/docs/TOOL_COST_INDEX.md
@@ -22,6 +22,12 @@ upgrade decision can be made.
 | Bito | Free (limited) | $0 | Pro | est. $15 / user / mo | bito.ai/pricing |
 | Mabl | **PAUSED** | $0 | — | est. starts $150+ / mo | mabl.com/pricing (verify) |
 | Augment Code | Free (limited) | $0 | per their pricing | per their pricing | augmentcode.com |
+| Cypress | OSS / Free | $0 | Cypress Cloud — est. $75/mo team | est. $75 / mo | cypress.io/pricing (verify) |
+| Applitools | Free (100 checkpoints/mo) | $0 | Starter | est. $45 / mo | applitools.com/pricing (verify) |
+| Postman | Free | $0 | Basic | est. $14 / user / mo | postman.com/pricing (verify) |
+| BrowserStack | n/a (deferred) | $0 | Live | est. $29 / user / mo | browserstack.com/pricing |
+| Test.ai | n/a (skipped — overlaps Keploy) | — | — | — | — |
+| Jenkins | n/a (skipped — overlaps GH Actions) | $0 (OSS) | n/a | $0 | jenkins.io |
 
 ## Update procedure
 

--- a/docs/UPGRADE_LOG.md
+++ b/docs/UPGRADE_LOG.md
@@ -1,0 +1,11 @@
+# Upgrade Log — every tool-tier change, dated
+
+Append-only audit trail of every paid-tier change the pipeline makes (or
+recommends). Governed by `docs/API_LIMIT_AUTO_UPGRADE.md`. **Don't garbage-
+collect this file** — it's the evidence trail for the enterprise spend-control
+pitch.
+
+| Date | Tool | Trigger | Tier from → to | Monthly cost | Decision band | WR/PR | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 2026-05-27 | Mabl | Owner request | Active → **Paused** | $X → $0 | Pause (no upgrade) | #13967 | Replaced by Keploy; eval kept in workflow header per standards. |
+| 2026-05-28 | Keploy | Initial install | none → **Free** | $0 | Tier 0 (free-tier-first rule) | (install only) | App + Chrome Recorder onboarded; see `docs/TESTING_STACK.md`. |


### PR DESCRIPTION
## Summary

Per your "every evaluated tool gets a what-it-did / liked / didn't / why-changed record" convention, this **pauses Mabl** (commented, not deleted) and documents the evaluation in the workflow header.

### What changed
- `.github/workflows/mabl.yml`: `push:` and `pull_request:` triggers commented out. `workflow_dispatch:` kept so it can be manually re-run if needed. **Full eval added at the top of the file** — what it did, what we liked, what we didn't, the replacement, and one-edit instructions to re-enable.
- `docs/AUTOMATION_AUDIT.md`: line 35 marked **⏸ PAUSED** with the same context.

### What Mabl was actually doing
The workflow installed `mabl-cli` and called `mabl tests run` on every push/PR — but the test PLANS lived in the Mabl dashboard, not in this repo. Without plans configured for the matching labels, the CLI just runs and nothing executes (silent no-op). With `MABL_API_KEY` recently missing it has been short-circuiting at the key-check anyway. That's why you "never saw it running much."

### Replacement
[Keploy](https://github.com/apps/keploy) — AI-generated, validated unit + API tests written directly into PRs. Code-level (not dashboard-only), visible to the pipeline + agents + code review, no paid key needed for the basic tier. **Install the GitHub App separately** (one click); this PR only handles the in-repo side.

### Test plan
- [x] `mabl.yml` still parses (workflow_dispatch trigger kept so the file remains valid).
- [x] AUTOMATION_AUDIT.md updated.
- [ ] After merge + Keploy install: confirm Keploy opens its first test-PR on a real change.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR pauses the Mabl automated testing workflow by commenting out automatic triggers while preserving manual execution capability. The changes document a comprehensive evaluation explaining why Mabl is being replaced with Keploy, following the team's convention of keeping a detailed record for every evaluated tool. The workflow file now contains extensive inline documentation covering what Mabl did, its pros and cons, the replacement rationale, and instructions for re-enabling if needed. The automation audit document is updated to reflect the paused status with a reference to the detailed evaluation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/AUTOMATION_AUDIT.md` |
| 2 | `.github/workflows/mabl.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paused Mabl auto-triggers and switched testing to Keploy for visible, in-repo tests. Kept manual `workflow_dispatch`, aligned secret checks, unified Jules secret naming, and added cost governance plus a credential automation roadmap with tested-tool alternatives.

- **Refactors**
  - Commented `push`/`pull_request` in `.github/workflows/mabl.yml`; kept `workflow_dispatch` with header notes (what Mabl did, pros/cons, replacement, re-enable steps).
  - Marked Mabl as paused in `docs/AUTOMATION_AUDIT.md`.
  - Commented `MABL_API_KEY` checks in `secrets-health-check.yml`, `secret-persistence-guard.yml`, and `credential-gatekeeper.yml` (with re-enable notes).
  - Unified Jules secret to `JULES_API_KEY` in `jules-coding-agent.yml` (old `JULES_TOKEN` kept commented).
  - Added docs:
    - `docs/TESTING_STACK.md` (Keploy app + Chrome recorder, evaluated alternatives, per-app Cypress template).
    - `docs/API_LIMIT_AUTO_UPGRADE.md` (tiered rate-limit decision standard) and `docs/UPGRADE_LOG.md` (audit trail).
    - `docs/TOOL_COST_INDEX.md` (extended cost index for testing tools).
    - `docs/CREDENTIAL_AUTOMATION_ROADMAP.md` (Manus-style auto-credential plan and phases).

- **Migration**
  - Install the Keploy GitHub App to start generating test PRs (optional: Keploy Chrome API Test Recorder).
  - To restore Mabl: uncomment triggers in `mabl.yml`, set `MABL_API_KEY`, and configure plans in the Mabl dashboard.

<sup>Written for commit f17feb54e36af0d0f787eb0dda47765d7c388527. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13967?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

