### PR TITLE
scripts/secret-set.sh — one-command GitHub secret + backup (Phase 1)

### DIFF
--- a/scripts/secret-set.sh
+++ b/scripts/secret-set.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# scripts/secret-set.sh — set a GitHub repo secret in one command.
+#
+# Phase 1 of docs/CREDENTIAL_AUTOMATION_ROADMAP.md — wraps `gh secret set`
+# so you don't have to click through Settings → Secrets → New → name → paste
+# every time you generate a new key from a provider.
+#
+# Usage:
+#   ./scripts/secret-set.sh NAME VALUE
+#   ./scripts/secret-set.sh NAME           # reads VALUE from stdin
+#   cat key.pem | ./scripts/secret-set.sh APP_PRIVATE_KEY    # multi-line keys
+#   ./scripts/secret-set.sh NAME VALUE --backup PATH         # also write to backup JSON file
+#
+# Optional --backup updates a local JSON file (gitignored) so future
+# auto-restore from CREDENTIAL_BACKUP_JSON has the new key too.
+#
+# Requires: gh CLI (`brew install gh`), authenticated (`gh auth status`).
+
+set -euo pipefail
+
+# ─── parse args ───────────────────────────────────────────────────────────
+NAME="${1:-}"
+VALUE="${2:-}"
+BACKUP_PATH=""
+
+# Strip optional --backup PATH from args
+shift 2 2>/dev/null || shift 1 2>/dev/null || true
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --backup) BACKUP_PATH="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [ -z "$NAME" ]; then
+  echo "Usage: $0 NAME [VALUE] [--backup PATH]" >&2
+  echo "       cat key.pem | $0 NAME    # for multi-line values" >&2
+  exit 1
+fi
+
+# Read VALUE from stdin if not provided as arg
+if [ -z "$VALUE" ]; then
+  if [ -t 0 ]; then
+    echo "❌ No value provided and stdin is a terminal. Either pass VALUE as arg" >&2
+    echo "   or pipe it: cat key.pem | $0 $NAME" >&2
+    exit 1
+  fi
+  VALUE="$(cat)"
+fi
+
+REPO="${GH_REPO:-midnghtsapphire/revvel-standards}"
+
+# ─── set the GitHub secret ────────────────────────────────────────────────
+echo "→ setting GitHub secret: $NAME (repo: $REPO)"
+printf '%s' "$VALUE" | gh secret set "$NAME" --repo "$REPO" --body -
+echo "✅ GitHub secret $NAME set"
+
+# ─── optional: update local backup JSON ───────────────────────────────────
+if [ -n "$BACKUP_PATH" ]; then
+  if [ -f "$BACKUP_PATH" ]; then
+    UPDATED=$(jq --arg k "$NAME" --arg v "$VALUE" '. + {($k): $v}' "$BACKUP_PATH")
+  else
+    UPDATED=$(jq -n --arg k "$NAME" --arg v "$VALUE" '{($k): $v}')
+    mkdir -p "$(dirname "$BACKUP_PATH")"
+  fi
+  printf '%s\n' "$UPDATED" > "$BACKUP_PATH"
+  chmod 600 "$BACKUP_PATH"
+  echo "✅ backup JSON updated: $BACKUP_PATH (chmod 600)"
+  echo "   To sync this file to CREDENTIAL_BACKUP_JSON (the auto-restore secret):"
+  echo "     gh secret set CREDENTIAL_BACKUP_JSON --repo $REPO < $BACKUP_PATH"
+fi
+
+echo "done."


### PR DESCRIPTION
## Summary

**Phase 1** of `docs/CREDENTIAL_AUTOMATION_ROADMAP.md` — saves a click forever.

Instead of: GitHub → Settings → Secrets → New → name → paste → save (per key)
Just: `./scripts/secret-set.sh NAME VALUE`

### Usage
```bash
# Simple value
./scripts/secret-set.sh JULES_API_KEY abc-123

# Multi-line (e.g., PEM files) via stdin
cat ~/Downloads/app.pem | ./scripts/secret-set.sh APP_PRIVATE_KEY

# Also write to local backup JSON for auto-restore
./scripts/secret-set.sh JULES_API_KEY abc-123 --backup ~/.revvel-backup.json
```

When `--backup` is used, the script chmod-600s the file and prints the exact `gh secret set CREDENTIAL_BACKUP_JSON` command to sync it for the auto-restore harness.

### What's next on the roadmap
- **Phase 2**: per-provider mint adapters (DigitalOcean, Vercel, GitHub, Doppler service-account) — separate PR; needs per-provider API details.
- **Phase 3**: watchdog that calls mint adapter or files `needs-human-credential` WR — depends on Phase 2.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a convenience script that wraps the GitHub CLI to set repository secrets in a single command, eliminating the need to manually navigate through the GitHub UI. The script supports both inline values and stdin input for multi-line secrets like PEM files, and optionally maintains a local backup JSON file (with secure permissions) that can be synced to a `CREDENTIAL_BACKUP_JSON` secret for auto-restore functionality. This is Phase 1 of a credential automation roadmap, with future phases planned for provider-specific credential minting and automated renewal.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/secret-set.sh` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-command script to set GitHub repo secrets and optionally back them up to a local JSON for easy auto-restore. This is Phase 1 of the credential automation roadmap to reduce UI clicks.

- **New Features**
  - `scripts/secret-set.sh` wraps `gh secret set` to set a secret for `$GH_REPO` (defaults to `midnghtsapphire/revvel-standards`).
  - Accepts value as an arg or via stdin for multi-line secrets.
  - `--backup PATH` writes/updates a local JSON (chmod 600) and prints the `gh secret set CREDENTIAL_BACKUP_JSON` command to sync.

<sup>Written for commit 2ae6168e14ed7747c204189782551c2f01b46058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13970?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

