### PR TITLE
Postman starter collection + setup doc (manual API exploration)

### DIFF
--- a/docs/POSTMAN_SETUP.md
+++ b/docs/POSTMAN_SETUP.md
@@ -1,0 +1,43 @@
+# Postman — manual API exploration
+
+**What for:** poking APIs by hand, sharing collections across team, generating
+curl/code snippets. **Not** for automated CI tests — that's Keploy's job.
+**Free tier** is plenty for what we do here.
+
+## Install (one-time)
+- macOS / Windows / Linux: download from [postman.com/downloads](https://www.postman.com/downloads/).
+- (Optional) sign in with a free account so collections sync across devices.
+
+## Import the starter collection
+1. Open Postman → **Collections** → **Import** → **File**.
+2. Pick `postman/revvel-collections.postman_collection.json` from this repo.
+3. The collection appears under "Revvel — starter collection".
+
+## Set up an environment (optional but recommended)
+Some requests use variables (`{{zip}}`, `{{leadEngineUrl}}`).
+1. Postman → **Environments** → **+** → name it "Revvel".
+2. Add:
+   - `zip` = a ZIP code you want to probe (default `90210`)
+   - `limit` = NPPES result cap (default `5`)
+   - `leadEngineUrl` = your Vercel deployment URL once the lead-engine is live
+3. Select "Revvel" in the env picker (top-right).
+
+## What's in the starter collection
+- **life-insurance-lead-engine → NPPES — providers by ZIP** — exercises the
+  free public NPI Registry the lead-engine uses. Tests assert 200 + at least
+  one result for a populated ZIP.
+- **life-insurance-lead-engine → Live app — landing** — smoke-hits the
+  deployed app once you've set `{{leadEngineUrl}}`.
+
+## Why we keep it
+- Closes the manual side of API work that Keploy can't help with (poking new
+  endpoints to figure out their shape before writing tests).
+- Collections are diffable JSON in the repo — anyone can pull and use them,
+  no separate "Postman workspace" lock-in.
+- Per the standards: cost = $0 (free tier), source-of-truth in repo.
+
+## How to add a new request to the shared collection
+1. In Postman, build/test the request.
+2. Right-click the collection → **Export** → v2.1 → overwrite
+   `postman/revvel-collections.postman_collection.json` in this repo.
+3. Open a PR like any other change.

--- a/docs/POSTMAN_SETUP.md
+++ b/docs/POSTMAN_SETUP.md
@@ -1,7 +1,8 @@
 # Postman — manual API exploration
 
 **What for:** poking APIs by hand, sharing collections across team, generating
-curl/code snippets. **Not** for automated CI tests — that's Keploy's job.
+curl/code snippets. This guide covers the Postman desktop workflow for manual
+exploration; automated collection runs in CI, where needed, go through Newman.
 **Free tier** is plenty for what we do here.
 
 ## Install (one-time)

--- a/postman/revvel-collections.postman_collection.json
+++ b/postman/revvel-collections.postman_collection.json
@@ -1,0 +1,75 @@
+{
+  "info": {
+    "name": "Revvel — starter collection",
+    "_postman_id": "00000000-0000-0000-0000-000000000001",
+    "description": "Starter Postman collection for revvel-standards products. Import into Postman → Collections → Import → File. Variables are scoped to a `Revvel` environment you create (see docs/POSTMAN_SETUP.md).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "life-insurance-lead-engine",
+      "description": "The active lead app. Pulls medical professionals from NPPES by ZIP, scores by income, generates pitch scripts.",
+      "item": [
+        {
+          "name": "NPPES — providers by ZIP",
+          "description": "Public NPI Registry. Free, no key. The lead-engine's source of truth.",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://npiregistry.cms.hhs.gov/api/?version=2.1&postal_code={{zip}}&enumeration_type=NPI-1&limit={{limit}}",
+              "protocol": "https",
+              "host": ["npiregistry", "cms", "hhs", "gov"],
+              "path": ["api", ""],
+              "query": [
+                { "key": "version", "value": "2.1" },
+                { "key": "postal_code", "value": "{{zip}}" },
+                { "key": "enumeration_type", "value": "NPI-1" },
+                { "key": "limit", "value": "{{limit}}" }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "const j = pm.response.json();",
+                  "pm.test('result_count present', () => pm.expect(j).to.have.property('result_count'));",
+                  "pm.test('returns at least one provider for a populated ZIP', () => pm.expect(j.results.length).to.be.above(0));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Live app — landing (once deployed)",
+          "description": "Smoke-hits the deployed lead-engine. Set `{{leadEngineUrl}}` to your Vercel deployment URL.",
+          "request": {
+            "method": "GET",
+            "url": { "raw": "{{leadEngineUrl}}/", "host": ["{{leadEngineUrl}}"], "path": [""] }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "pm.test('renders landing copy', () => pm.expect(pm.response.text()).to.include('Life Insurance Lead Engine'));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variable": [
+    { "key": "zip", "value": "90210" },
+    { "key": "limit", "value": "5" },
+    { "key": "leadEngineUrl", "value": "https://your-vercel-deploy.vercel.app" }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Postman as the **manual API exploration** tool per `docs/TESTING_STACK.md` — closes the human side of API work that Keploy can't help with (poking new endpoints, sharing collections).

### What's in
- **`postman/revvel-collections.postman_collection.json`** (v2.1) — starter collection:
  - **NPPES — providers by ZIP** — exercises the free public NPI Registry the lead-engine uses; tests assert 200 + ≥1 result for a populated ZIP.
  - **Live app — landing** — smoke-hits the deployed lead-engine once `{{leadEngineUrl}}` is set.
- **`docs/POSTMAN_SETUP.md`** — install, import, set up the `Revvel` environment, and the "export → commit → PR" loop for adding new requests.

### Why
- **Cost: $0** (free tier, plenty for our scale).
- Collections are **diffable JSON in the repo** — anyone pulls and uses, no separate workspace lock-in.
- New requests = open a PR like any other change.

## Test plan
- [x] Collection JSON is valid.
- [ ] After merge: import the collection in Postman; the NPPES request returns providers for ZIP 90210.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_