### PR TITLE
Add Provenance Standard — name publisher + exact package for every tool

### DIFF
--- a/docs/PROVENANCE_STANDARD.md
+++ b/docs/PROVENANCE_STANDARD.md
@@ -1,0 +1,129 @@
+# Provenance Standard — name the source every time
+
+Every reference to an external tool, service, agent, model, or workflow in
+**any** doc / wireframe / schema / workflow file / PR description / comment
+**must include its source** so a reader (or future-agent) can follow it
+without guessing.
+
+> Today "Jules" means three different things in this repo depending on which
+> file you read. This standard fixes that.
+
+---
+
+## The rule
+
+Whenever you name a tool, write it as:
+
+```
+Tool name (Publisher / Sponsor) via `package@version` [nested: dep1, dep2]
+```
+
+Each piece:
+
+| Piece | What it answers | Example |
+| --- | --- | --- |
+| **Tool name** | Plain-language name | Jules |
+| **(Publisher / Sponsor)** | Who owns / maintains it (Google, BeksOmega, sanjay3290, our org, etc.) | (Google) |
+| **via `package@version`** | The exact action, SDK, package, image, or URL the workflow uses | via `BeksOmega/jules-action@v1.0.0` |
+| **[nested: …]** | Anything *inside* the tool that matters (downstream deps, sub-services, models) | [nested: Render for previews] |
+
+For internal artifacts (our own scripts, repos, workflows), still name the
+file path so the reader can click straight to it:
+
+```
+the coder (us) via `scripts/openrouter_coder.py` [models: Claude / Gemini / GPT triad]
+```
+
+---
+
+## Good vs bad
+
+❌ **Bad** — ambiguous, agent has to guess
+```
+Jules reviews this PR.
+```
+
+✅ **Good** — agent knows exactly where to look
+```
+Jules (Google) via `BeksOmega/jules-action@v1.0.0` — see jules-invoke.yml.
+Note: `sanjay3290/jules-pr-reviewer@v1` (different author!) was SILENCED in
+#13974 because it was broken; only the BeksOmega family is active.
+```
+
+❌ **Bad**
+```
+The coder builds a PR.
+```
+
+✅ **Good**
+```
+The coder (us) via `openrouter-coder.yml`, which calls `scripts/openrouter_coder.py`
+[nested: OpenRouter API → Claude Opus 4.7 (anthropic/claude-opus-4-7) by default,
+fallback to Gemini Pro 1.5 then DeepSeek Chat].
+```
+
+❌ **Bad**
+```
+Mabl runs tests.
+```
+
+✅ **Good — and reflects current state**
+```
+Mabl (Mabl Inc., paused 2026-05-27 — see workflow header) via `@mablhq/mabl-cli`.
+Replaced by Keploy (Keploy Inc.) via the GitHub App + Chrome extension.
+```
+
+---
+
+## Where this applies
+
+This isn't optional in any of these surfaces — if it mentions a tool, it must
+say where the tool comes from:
+
+| Surface | Where the provenance goes |
+| --- | --- |
+| Workflow files (`.github/workflows/*.yml`) | Header comment at the top |
+| Standards docs in `docs/` | Wherever the tool is first introduced + in any reference table |
+| `docs/SYSTEM_MAP.md`, `docs/AUTOMATION_AUDIT.md` | The columns must include Publisher and Package/URL |
+| `docs/TESTING_STACK.md`, `docs/TOOL_COST_INDEX.md` | Already updated as the reference pattern — match its style |
+| Wireframes / mermaid diagrams | Each named tool node carries `(Publisher · package)` in the label |
+| Schemas (JSON Schema, OpenAPI, etc.) | `description` field on every external-dep property names its source |
+| Work Request docs (`wr/issues/*.md`) | The "Reuse manifest" and "Build it with" sections must name publishers |
+| PR descriptions | When citing tools in summaries |
+
+---
+
+## Why this matters (the enterprise pitch angle, again)
+
+A buyer asks: *"What's actually under the hood?"* Today the honest answer for
+some tools is "I'd have to dig through three workflows to tell you." With this
+standard:
+- The first place they look (`docs/SYSTEM_MAP.md`, the workflow headers, the
+  cost index) names every dependency by publisher and exact package.
+- No ambiguity = no awkward "let me get back to you" moments.
+- Audit-ready out of the box.
+
+It also helps agents: a Work Request that says "use Jules" is ambiguous; one
+that says "use Jules (Google) via `BeksOmega/jules-action@v1.0.0`" sends the
+agent to exactly the right action without guessing.
+
+---
+
+## Quick reference — the families you'll mention most
+
+| You write… | Means |
+| --- | --- |
+| `Jules (Google) via BeksOmega/jules-action@v1.0.0` | The active Jules invoke lane |
+| `Jules feedback (Google) via BeksOmega/jules-comms@v1.0.0` | Jules feedback lane |
+| `Jules publish (Google) via BeksOmega/jules-publish@v1.0.0` | Jules publish lane |
+| `Jules PR review (Google) via sanjay3290/jules-pr-reviewer@v1 — SILENCED` | The broken one in #13974 |
+| `Keploy (Keploy Inc.) via github.com/apps/keploy + Chrome extension` | Our test generator |
+| `OpenRouter (OpenRouter Inc.) via openrouter-coder.yml` | Our coder lane |
+| `The Professor (us) via scripts/openrouter-personas.js (perplexity/sonar-pro)` | The research persona |
+| `Vercel (Vercel Inc.) via the GitHub-Vercel integration` | Hosting |
+| `ImgBot (ImgBot.net) via the GitHub App` | Image optimization |
+| `Mabl (Mabl Inc., PAUSED) via @mablhq/mabl-cli` | Paused testing tool |
+
+Extend as we add. Source of truth for costs stays
+`docs/TOOL_COST_INDEX.md`; source of truth for active tools stays
+`docs/TESTING_STACK.md`; this file is just the *naming standard*.


### PR DESCRIPTION
## Summary

Locks in the **provenance convention**: every reference to an external tool / service / agent / model in any doc / wireframe / schema / workflow header / WR / PR description must include where it comes from. Today "Jules" means three different things depending on which file you read — this stops that.

### The rule
```
Tool name (Publisher / Sponsor) via `package@version` [nested: deps]
```
- **Publisher** — who maintains it (Google, BeksOmega, sanjay3290, us, etc.)
- **`package@version`** — the exact action / SDK / image / URL the workflow uses
- **[nested: …]** — anything inside that matters (downstream services, model triads)

### Where it applies
Workflow headers, standards docs, `SYSTEM_MAP`, `AUTOMATION_AUDIT`, `TESTING_STACK`, `TOOL_COST_INDEX`, mermaid diagrams, JSON Schemas (in `description`), WR docs, PR descriptions.

### Reference families included
The most-mentioned tools get a copy-paste-ready form:
- **Jules invoke** (Google) via `BeksOmega/jules-action@v1.0.0`
- **Jules feedback** (Google) via `BeksOmega/jules-comms@v1.0.0`
- **Jules publish** (Google) via `BeksOmega/jules-publish@v1.0.0`
- **Jules PR review** (community — *broken*) via `sanjay3290/jules-pr-reviewer@v1` — silenced in #13974
- **Keploy** (Keploy Inc.) via `github.com/apps/keploy` + Chrome ext
- **OpenRouter** (OpenRouter Inc.) via `openrouter-coder.yml`
- **The Professor** (us) via `scripts/openrouter-personas.js` (perplexity/sonar-pro)
- **Mabl** (paused) via `@mablhq/mabl-cli`
- … and the rest in the file.

### Why it matters (enterprise pitch)
Buyer asks *"what's actually under the hood?"* — they read the workflow header / cost index / SYSTEM_MAP and see publisher + exact package for every tool. No "let me get back to you." Audit-ready out of the box.

It also helps agents: a WR saying "use Jules" sends them three places to guess; "use Jules (Google) via `BeksOmega/jules-action@v1.0.0`" sends them to exactly one.

### Follow-on after #13967 lands
`TOOL_COST_INDEX.md` gains a `Publisher` column to match this standard explicitly.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a documentation standard that requires every reference to an external tool, service, or model to include its publisher and exact package version. The standard aims to eliminate ambiguity (for example, "Jules" currently refers to three different things in the codebase) by mandating a consistent format: `Tool name (Publisher) via package@version [nested: deps]`. This applies across workflow headers, standards docs, system maps, schemas, work requests, and PR descriptions. The goal is to make the codebase audit-ready for enterprise buyers and to help both human reviewers and AI agents quickly identify the exact dependency being referenced without guessing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/PROVENANCE_STANDARD.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a provenance naming standard that requires publisher and exact package/version for every external tool reference across docs, workflows, schemas, and PRs. This removes ambiguity (e.g., “Jules”) and makes the stack audit-ready.

- **New Features**
  - Standard format: Tool name (Publisher) via `package@version` [nested: deps].
  - Applies to workflow headers, standards docs, system maps/audits, testing/cost indexes, diagrams, schemas, WRs, and PR descriptions.
  - Quick-reference examples include Jules lanes (prefer `BeksOmega/jules-action@v1.0.0`; `sanjay3290/jules-pr-reviewer@v1` silenced), Keploy (`github.com/apps/keploy`), OpenRouter (`openrouter-coder.yml`), The Professor (`scripts/openrouter-personas.js`), and Mabl (`@mablhq/mabl-cli`, paused).
  - Follow-up: add a Publisher column to `docs/TOOL_COST_INDEX.md` after #13967.

<sup>Written for commit 3deb6eb68e42c6438c2111f5036d841aea07acab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/13975?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

