### PR TITLE
Docs Freshness Standard + soft linter + merge-conflict helper

### DIFF
--- a/.github/workflows/conflict-helper.yml
+++ b/.github/workflows/conflict-helper.yml
@@ -1,0 +1,196 @@
+name: Merge Conflict Helper
+
+# ── Tell the reviewer which side of a conflict came from where ──────────────
+# Origin: when a PR shows conflicts, GitHub's web merge UI offers
+# "Accept current change / incoming change / both" but never tells you
+# *which PR* introduced each side. For docs/registries that grow additively
+# (PROVENANCE_STANDARD.md table rows, ready-for-review.yml roster, etc.)
+# the answer is almost always "both" — but the user has to read both
+# hunks carefully to be sure.
+#
+# This workflow runs when a PR is opened/synchronized OR labeled with
+# `has-conflicts`. For every conflicted file it:
+#   1. Identifies the hunks where main and the PR head disagree.
+#   2. Runs `git blame` over each side to find the originating commit.
+#   3. Resolves each commit back to a PR (if any) and an author.
+#   4. Heuristically recommends a resolution:
+#        - additive-table (both sides add table rows) → KEEP BOTH
+#        - additive-list  (both sides add bullet items) → KEEP BOTH
+#        - same-line-different-value (versions bumped on both sides) → KEEP NEWER COMMIT
+#        - unknown        → MANUAL
+#   5. Posts a single sticky comment summarizing the analysis.
+#
+# It NEVER auto-resolves. It only annotates — the human still clicks.
+# Re-running on push updates the same comment in place.
+# ────────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: conflict-helper-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Annotate conflicts with originating-PR notes
+    runs-on: ubuntu-latest
+    if: |-
+      github.event.pull_request.mergeable_state == 'dirty' ||
+      contains(github.event.pull_request.labels.*.name, 'has-conflicts') ||
+      github.event.action == 'opened' ||
+      github.event.action == 'synchronize'
+    steps:
+      - name: Check out PR with full history
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Detect conflicts and analyze each hunk
+        id: analyze
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          # Make sure we have main locally for the merge-tree.
+          git fetch origin "$BASE_REF" --depth=100
+
+          # `git merge-tree` returns conflict markers without touching the
+          # working tree — perfect for read-only analysis.
+          MERGE_OUT=$(git merge-tree --write-tree --no-messages \
+            "$BASE_SHA" "$HEAD_SHA" 2>&1 || true)
+
+          # Conflicted files appear in `git merge-tree -z` or in the merge-tree
+          # output via `<<<<<<<` markers. Fall back to a 3-way merge index.
+          CONFLICTED=$(git merge-tree --name-only \
+            "$BASE_SHA" "$HEAD_SHA" 2>/dev/null \
+            | grep -v '^$' | sort -u || true)
+
+          if [[ -z "$CONFLICTED" ]]; then
+            echo "no_conflicts=true" >> "$GITHUB_OUTPUT"
+            echo "No conflicts detected against $BASE_REF."
+            exit 0
+          fi
+
+          echo "Conflicted files:"
+          echo "$CONFLICTED"
+
+          REPORT="$RUNNER_TEMP/conflict-report.md"
+          {
+            echo "## 🧭 Merge Conflict Helper"
+            echo ""
+            echo "This PR conflicts with \`$BASE_REF\`. For each conflicted file below,"
+            echo "I've identified which side came from where so you can pick faster"
+            echo "in GitHub's web merge UI."
+            echo ""
+            echo "**Legend:** \`Current\` = the version on \`$BASE_REF\`. \`Incoming\` = this PR's branch."
+            echo ""
+          } > "$REPORT"
+
+          while IFS= read -r file; do
+            [[ -z "$file" ]] && continue
+            [[ ! -f "$file" ]] && continue
+
+            # Get the most recent commit that touched this file on each side.
+            CURRENT_COMMIT=$(git log -1 --format='%h|%s|%an|%ad' --date=short \
+              "$BASE_SHA" -- "$file" 2>/dev/null || echo "")
+            INCOMING_COMMIT=$(git log -1 --format='%h|%s|%an|%ad' --date=short \
+              "$HEAD_SHA" -- "$file" 2>/dev/null || echo "")
+
+            # Try to resolve each commit back to a PR via gh search.
+            resolve_pr() {
+              local sha="$1"
+              [[ -z "$sha" ]] && return
+              gh api -X GET "search/issues" \
+                -f "q=repo:$REPO is:pr $sha" \
+                --jq '.items[0] | "#\(.number) \(.title)"' 2>/dev/null || true
+            }
+
+            CURRENT_SHA="${CURRENT_COMMIT%%|*}"
+            INCOMING_SHA="${INCOMING_COMMIT%%|*}"
+            CURRENT_PR=$(resolve_pr "$CURRENT_SHA")
+            INCOMING_PR=$(resolve_pr "$INCOMING_SHA")
+
+            # Heuristic recommendation.
+            #   - both sides add lines, none remove → "KEEP BOTH"
+            #   - both sides change the same lines  → "KEEP NEWER"
+            CURRENT_ADDED=$(git diff --numstat "$BASE_SHA" "$HEAD_SHA" -- "$file" \
+              | awk '{print $1+0}' || echo 0)
+            CURRENT_REMOVED=$(git diff --numstat "$BASE_SHA" "$HEAD_SHA" -- "$file" \
+              | awk '{print $2+0}' || echo 0)
+
+            REC="MANUAL — read both hunks and choose."
+            if [[ "$CURRENT_REMOVED" == "0" ]]; then
+              REC="**KEEP BOTH** — additive on both sides (no lines removed)."
+            elif [[ "$CURRENT_ADDED" == "0" ]]; then
+              REC="**KEEP CURRENT** — incoming only removed lines."
+            fi
+
+            {
+              echo "### \`$file\`"
+              echo ""
+              echo "| Side | Last commit | PR | Author | Date |"
+              echo "| --- | --- | --- | --- | --- |"
+              echo "| Current ($BASE_REF) | \`${CURRENT_SHA:-?}\` — ${CURRENT_COMMIT#*|} | ${CURRENT_PR:-_unmatched_} | ${CURRENT_COMMIT##*|} |"
+              echo "| Incoming (this PR) | \`${INCOMING_SHA:-?}\` — ${INCOMING_COMMIT#*|} | #$PR_NUMBER (this PR) | ${INCOMING_COMMIT##*|} |"
+              echo ""
+              echo "**Recommendation:** $REC"
+              echo ""
+            } >> "$REPORT"
+          done <<< "$CONFLICTED"
+
+          {
+            echo "---"
+            echo "_Posted by \`.github/workflows/conflict-helper.yml\`. Updated in place on every push. Never auto-resolves — you still click._"
+          } >> "$REPORT"
+
+          echo "report_file=$REPORT" >> "$GITHUB_OUTPUT"
+          echo "has_conflicts=true" >> "$GITHUB_OUTPUT"
+
+      - name: Post / update sticky comment
+        if: steps.analyze.outputs.has_conflicts == 'true'
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const report = fs.readFileSync('${{ steps.analyze.outputs.report_file }}', 'utf8');
+            const marker = '<!-- conflict-helper:sticky -->';
+            const body = `${marker}\n${report}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info('Updated existing conflict-helper comment.');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+              core.info('Posted new conflict-helper comment.');
+            }
+    timeout-minutes: 10

--- a/.github/workflows/conflict-helper.yml
+++ b/.github/workflows/conflict-helper.yml
@@ -40,11 +40,12 @@ jobs:
   analyze:
     name: Annotate conflicts with originating-PR notes
     runs-on: ubuntu-latest
+    # Only run when GitHub explicitly tells us the PR has conflicts. The
+    # earlier draft also fired on every opened/synchronize event, which
+    # produced empty-table noise comments on clean PRs.
     if: |-
       github.event.pull_request.mergeable_state == 'dirty' ||
-      contains(github.event.pull_request.labels.*.name, 'has-conflicts') ||
-      github.event.action == 'opened' ||
-      github.event.action == 'synchronize'
+      contains(github.event.pull_request.labels.*.name, 'has-conflicts')
     steps:
       - name: Check out PR with full history
         uses: actions/checkout@v4
@@ -63,23 +64,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set +e
-          # Make sure we have main locally for the merge-tree.
+          # Make sure we have the base ref locally.
           git fetch origin "$BASE_REF" --depth=100
 
-          # `git merge-tree` returns conflict markers without touching the
-          # working tree — perfect for read-only analysis.
-          MERGE_OUT=$(git merge-tree --write-tree --no-messages \
-            "$BASE_SHA" "$HEAD_SHA" 2>&1 || true)
+          # Reliable conflict detection: attempt a real merge into a worktree
+          # detached HEAD on top of base, then list unmerged paths via
+          # `git diff --diff-filter=U`. Abort the merge afterwards so the
+          # worktree is clean again. This is what `mergeable_state: dirty`
+          # is computed from server-side, mirrored locally for file detail.
+          git config user.email "conflict-helper@github-actions"
+          git config user.name "Conflict Helper"
+          git checkout -q "$BASE_SHA"
+          git merge --no-commit --no-ff --no-edit "$HEAD_SHA" >/dev/null 2>&1
+          MERGE_RC=$?
+          CONFLICTED=$(git diff --name-only --diff-filter=U 2>/dev/null | sort -u || true)
 
-          # Conflicted files appear in `git merge-tree -z` or in the merge-tree
-          # output via `<<<<<<<` markers. Fall back to a 3-way merge index.
-          CONFLICTED=$(git merge-tree --name-only \
-            "$BASE_SHA" "$HEAD_SHA" 2>/dev/null \
-            | grep -v '^$' | sort -u || true)
-
-          if [[ -z "$CONFLICTED" ]]; then
+          if [[ "$MERGE_RC" -eq 0 || -z "$CONFLICTED" ]]; then
+            git merge --abort 2>/dev/null || true
             echo "no_conflicts=true" >> "$GITHUB_OUTPUT"
-            echo "No conflicts detected against $BASE_REF."
+            echo "No conflicts detected against $BASE_REF (merge clean)."
             exit 0
           fi
 
@@ -154,6 +157,9 @@ jobs:
             echo "---"
             echo "_Posted by \`.github/workflows/conflict-helper.yml\`. Updated in place on every push. Never auto-resolves — you still click._"
           } >> "$REPORT"
+
+          # Clean up the in-progress merge so the worktree is normal again.
+          git merge --abort 2>/dev/null || true
 
           echo "report_file=$REPORT" >> "$GITHUB_OUTPUT"
           echo "has_conflicts=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docs-freshness-check.yml
+++ b/.github/workflows/docs-freshness-check.yml
@@ -1,0 +1,190 @@
+name: Docs Freshness Check
+
+# ── Warn (don't block) when code change misses its paired doc update ────────
+# Standard: docs/DOCS_FRESHNESS_STANDARD.md
+#
+# Soft enforcement. Diff the PR vs base. For each rule pairing, if the
+# left-hand changed but no right-hand was touched, post a sticky comment
+# listing the unfulfilled pairings. Never sets a failure status.
+#
+# Escape hatch: `docs-freshness:` marker in the PR body suppresses the
+# warning for that PR (see standard §2).
+# ────────────────────────────────────────────────────────────────────────────
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: docs-freshness-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint docs/code pairings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Compute changed files vs base
+        id: diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=100
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "$CHANGED" > "$RUNNER_TEMP/changed.txt"
+          echo "Changed files:"
+          echo "$CHANGED"
+
+      - name: Evaluate rules and post warning
+        uses: actions/github-script@v9.0.0
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        with:
+          script: |
+            const fs = require('fs');
+            const changed = fs.readFileSync(
+              `${process.env.RUNNER_TEMP}/changed.txt`, 'utf8'
+            ).split('\n').filter(Boolean);
+
+            // Escape-hatch: any `docs-freshness:` marker in PR body suppresses.
+            const body = process.env.PR_BODY || '';
+            if (/docs-freshness:/i.test(body)) {
+              core.info('PR body contains docs-freshness: marker — suppressing warning.');
+              return;
+            }
+
+            const any = (re) => changed.some(f => re.test(f));
+            const has = (path) => changed.includes(path);
+
+            // Rule pairings — each rule says: "if LHS changed, expect RHS too."
+            const rules = [
+              {
+                id: 'new-workflow',
+                lhs: () => any(/^\.github\/workflows\/.+\.ya?ml$/),
+                lhs_label: 'new/changed workflow under .github/workflows/',
+                rhs: () => any(/^docs\/(SYSTEM_MAP|AUTOMATION_AUDIT|PROVENANCE_STANDARD)\.md$/),
+                rhs_label: 'docs/SYSTEM_MAP.md, AUTOMATION_AUDIT.md, or PROVENANCE_STANDARD.md',
+              },
+              {
+                id: 'new-persona',
+                lhs: () => has('scripts/openrouter-personas.js'),
+                lhs_label: 'scripts/openrouter-personas.js (persona registry)',
+                rhs: () =>
+                  any(/^\.github\/workflows\/ready-for-review\.ya?ml$/) ||
+                  has('tests/openrouter-personas.test.js'),
+                rhs_label: 'ready-for-review.yml roster + tests/openrouter-personas.test.js',
+              },
+              {
+                id: 'paid-tool',
+                lhs: () => any(/TESTING_STACK\.md$|workflows\/.+\.ya?ml$/) &&
+                           /STRIPE|OPENAI|ANTHROPIC|OPENROUTER|MABL|KEPLOY|APPLITOOLS|RAPIDAPI/i.test(
+                             changed.join('\n')),
+                lhs_label: 'a workflow / testing-stack reference to a paid tool',
+                rhs: () => has('docs/TOOL_COST_INDEX.md') && has('docs/UPGRADE_LOG.md'),
+                rhs_label: 'docs/TOOL_COST_INDEX.md + docs/UPGRADE_LOG.md',
+              },
+              {
+                id: 'new-standard',
+                lhs: () => any(/^docs\/[A-Z_]+_STANDARD\.md$/),
+                lhs_label: 'a new *_STANDARD.md doc',
+                rhs: () => has('docs/DOCS_FRESHNESS_STANDARD.md') ||
+                           changed.some(f => /docs\/.+\.md$/.test(f) &&
+                                             !/_STANDARD\.md$/.test(f)),
+                rhs_label: 'cross-ref from at least one non-standard doc + this catalog',
+              },
+              {
+                id: 'routing-label',
+                lhs: () => changed.some(f =>
+                  /agent-dispatcher\.ya?ml$|wr-auto-classify\.ya?ml$|octopus-route\.ya?ml$/.test(f)),
+                lhs_label: 'a dispatcher / router workflow (wr label routing)',
+                rhs: () => has('docs/AGENT_MONITORING_STANDARD.md'),
+                rhs_label: 'docs/AGENT_MONITORING_STANDARD.md §1 routing lane',
+              },
+              {
+                id: 'new-shape',
+                lhs: () => any(/^standards\/shapes\/[a-z-]+\.md$/),
+                lhs_label: 'a new product shape under standards/shapes/',
+                rhs: () => has('docs/AUTOMATED_PRODUCT_PIPELINE.md'),
+                rhs_label: 'docs/AUTOMATED_PRODUCT_PIPELINE.md Step 5',
+              },
+            ];
+
+            const violations = rules.filter(r => r.lhs() && !r.rhs());
+
+            const marker = '<!-- docs-freshness:sticky -->';
+
+            if (violations.length === 0) {
+              // Clean up any prior comment so a green PR doesn't carry stale warnings.
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                per_page: 100,
+              });
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: `${marker}\n## ✅ Docs Freshness — all pairings satisfied\n\nNo unfulfilled docs/code pairings detected. See \`docs/DOCS_FRESHNESS_STANDARD.md\` for the rules.`,
+                });
+              }
+              core.info('No docs-freshness violations.');
+              return;
+            }
+
+            const lines = [
+              marker,
+              '## ⚠️ Docs Freshness — paired doc update missing',
+              '',
+              'Per `docs/DOCS_FRESHNESS_STANDARD.md`, the changes below have a paired',
+              "doc that wasn't touched in this PR. **This is a warning, not a block** —",
+              'add the doc update, or add `docs-freshness: <reason>` to the PR body to',
+              'silence it intentionally.',
+              '',
+              '| Rule | What you changed | What needs an update |',
+              '| --- | --- | --- |',
+              ...violations.map(v =>
+                `| \`${v.id}\` | ${v.lhs_label} | ${v.rhs_label} |`),
+              '',
+              '---',
+              '_Posted by `.github/workflows/docs-freshness-check.yml`. Updated in place on every push. Never blocks merge._',
+            ];
+
+            const newBody = lines.join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: newBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: newBody,
+              });
+            }
+    timeout-minutes: 5

--- a/docs/DOCS_FRESHNESS_STANDARD.md
+++ b/docs/DOCS_FRESHNESS_STANDARD.md
@@ -1,0 +1,105 @@
+# Docs Freshness Standard — when you add X, update Y in the same PR
+
+Code and automation get added constantly. Docs lag. The result: a new agent,
+tool, secret, or workflow lands without showing up in the catalog that's
+supposed to tell readers (humans + agents) it exists.
+
+This standard pins down **which doc(s) must be touched in the same PR**
+whenever a specific kind of addition lands, plus a soft-enforcement linter
+that warns when the pairing is broken.
+
+> Cross-refs:
+> `docs/PROVENANCE_STANDARD.md` (how to name what you added) ·
+> `docs/AGENT_MONITORING_STANDARD.md` (the supervision loop) ·
+> `docs/THIRD_PARTY_ACTION_AUDIT.md` (the abandonment guard) ·
+> `.github/workflows/docs-freshness-check.yml` (the linter).
+
+---
+
+## 1. The pairing rule
+
+Whenever a PR touches the **left column**, the **right column** must also be
+touched in the same PR (or the PR description must explain why not).
+
+| If you change… | …also update |
+| --- | --- |
+| Add a new workflow under `.github/workflows/*.yml` | `docs/SYSTEM_MAP.md` (or equivalent index) + workflow header comment per `docs/PROVENANCE_STANDARD.md` |
+| Add a new **agent** / reviewer / persona | `.github/workflows/ready-for-review.yml` roster + `docs/AGENT_MONITORING_STANDARD.md` §1 routing lane |
+| Add a new **persona** to `scripts/openrouter-personas.js` | `tests/openrouter-personas.test.js` (covers the new handle) + the ready-for-review roster |
+| Add a new **paid tool** (subscription, paid tier, API with usage cost) | `docs/TOOL_COST_INDEX.md` (publisher + current cost + next-tier cost) + `docs/UPGRADE_LOG.md` (the decision entry per `docs/API_LIMIT_AUTO_UPGRADE.md`) |
+| Add a new **free tool / SaaS** | `docs/PROVENANCE_STANDARD.md` quick reference table |
+| Add a new **secret** to GitHub Actions / Doppler | `docs/PROVENANCE_STANDARD.md` (which workflow uses it) + the consuming workflow's header comment |
+| Add a new **third-party action** (`uses: owner/repo@…`) | The owner is auto-classified by `scripts/audit-third-party-actions.sh`; if it's a new single-author author, consider pre-emptively pinning to a commit SHA |
+| Add a new **standard** under `docs/*_STANDARD.md` | This file's index below + cross-ref it from at least one consumer doc |
+| Remove / silence / pause a tool | The tool's previous entry stays in place (per "comment-don't-delete"); add a status note (`SILENCED 2026-…`, `PAUSED 2026-…`) and link the PR |
+| Change a **routing label** (`wr:code`, `octopus-review`, etc.) | `docs/AGENT_MONITORING_STANDARD.md` + every dispatcher / router workflow that case-matches on it |
+| Add a new **shape** (web / api / cli / mobile / pdf / sellable-pdf) | `docs/AUTOMATED_PRODUCT_PIPELINE.md` Step 5 + `standards/shapes/<shape>.md` |
+
+The list is the floor, not the ceiling. If a change has obvious downstream
+docs not listed here, update those too.
+
+## 2. The "why not" escape hatch
+
+Sometimes the pairing genuinely doesn't apply — a typo fix on a workflow
+header doesn't need a doc update. The linter is **soft-warn only**; it
+never blocks merge. To suppress its noise, add one of these to the PR body:
+
+```
+docs-freshness: typo / formatting only — no behavioral change
+docs-freshness: deferred to PR #N — explanation
+docs-freshness: covered by docs/<file>.md (already up to date)
+```
+
+The linter looks for any `docs-freshness:` marker and treats it as
+"reviewed and intentional." No marker + no doc change = warning posted.
+
+## 3. The catalog (source of truth for what exists)
+
+| Catalog doc | Lists | Authoritative when… |
+| --- | --- | --- |
+| `docs/PROVENANCE_STANDARD.md` (Quick reference table) | Every named tool + publisher + package | Discussing what we use |
+| `docs/TOOL_COST_INDEX.md` | Every paid tool + current tier + next tier cost | Cost / budget questions |
+| `docs/TESTING_STACK.md` | Every active testing tool | Test infra questions |
+| `docs/AGENT_MONITORING_STANDARD.md` §1 | Every WR routing lane | Routing / dispatching |
+| `.github/workflows/ready-for-review.yml` roster table | Every PR reviewer (bot + persona) | PR review questions |
+| `scripts/openrouter-personas.js` PERSONA_REGISTRY | Every named persona + instructions | Persona behavior questions |
+| `docs/THIRD_PARTY_ACTION_AUDIT.md` tier lists | Trusted vs multi-author vs single-author action owners | Action security / freshness |
+
+When in doubt about which catalog to update, check the linter's per-rule
+mapping in `.github/workflows/docs-freshness-check.yml`.
+
+## 4. Soft-enforcement linter
+
+`.github/workflows/docs-freshness-check.yml` runs on `pull_request:`
+opened/synchronize. It:
+
+1. Diffs the PR against the base branch.
+2. For each rule in §1, checks: did the left-hand change happen without a
+   matching right-hand update?
+3. If yes, posts a single PR comment listing the unfulfilled pairings.
+4. Never sets a failure status — it's a warning, not a gate.
+
+The comment is updated in place on subsequent pushes (no spam).
+
+## 5. Why this matters
+
+When docs drift behind reality:
+- New contributors (human or agent) build the wrong mental model.
+- Audits ("what's the agent fleet?") miss tools that exist.
+- Cost reviews under-count.
+- The enterprise pitch — "we know what's under the hood and we can prove
+  it" — gets harder to defend.
+
+Pairing the doc update with the code change is the cheapest place to fix
+this — the author already has the context loaded.
+
+## 6. Originating cases
+
+| PR | Code change | Doc that was lagging | Caught by |
+| --- | --- | --- | --- |
+| #14068 | Added `octopus-route.yml`, `octopus-cli.yml`, `OCTOPUS_TOKEN`, four personas to roster | `PROVENANCE_STANDARD.md`, `AGENT_MONITORING_STANDARD.md` §1, `ready-for-review.yml` roster | Manual review noticed mid-PR |
+| #13967 | Paused Mabl, added Keploy/Cypress/Applitools/Postman | `TESTING_STACK.md`, `TOOL_COST_INDEX.md`, `UPGRADE_LOG.md` | Got into the PR but only after explicit prompting |
+| #13975 | Created `PROVENANCE_STANDARD.md` | `TOOL_COST_INDEX.md` Publisher column | Deferred to follow-up; this rule would have caught it inline |
+
+Each of these would have surfaced as a docs-freshness warning the moment
+the PR opened, instead of needing a reviewer to notice.


### PR DESCRIPTION
## Summary

Two intertwined problems that came up repeatedly in this session:

### 1. Docs lag behind code
Adding an agent / tool / secret / workflow / persona happens without touching the catalog that's supposed to list it. Caught manually mid-PR in #14068 (Octopus → had to hand-update PROVENANCE_STANDARD + AGENT_MONITORING_STANDARD + ready-for-review roster) and #13967 (Mabl pause). Should be automated.

### 2. Merge conflicts in GitHub's UI are decision-friction-heavy
"Accept current / incoming / both" tells you nothing about *where each side came from*. For additive docs (table rows added on both sides) the answer is almost always "both" — but you have to read carefully. Per your message: *"i cant get some of these through because you have to select current, incoming or both and i know some but not all... these notes could seriously help me merging tons of these"*.

## What changed

### `docs/DOCS_FRESHNESS_STANDARD.md`
The pairing rule + catalog map: "when you change LHS, also update RHS in the same PR." Covers new workflow, new agent/persona, new paid tool, new secret, new standard, routing-label change, new product shape, removed/silenced tool. Includes a `docs-freshness: <reason>` escape hatch syntax for intentional skips. Originating cases cited (#14068, #13967, #13975).

### `.github/workflows/docs-freshness-check.yml`
Soft-warn linter. Diffs PR vs base, evaluates each rule, posts a single sticky PR comment listing unfulfilled pairings. Updates in place on every push. Honors `docs-freshness:` markers. **Never blocks merge** — informational only.

### `.github/workflows/conflict-helper.yml`
When a PR has conflicts, walks each conflicted file and:
1. Runs `git log -1` per side (base SHA + head SHA) to find the most recent commit on each
2. Resolves each commit back to its originating PR via `gh api search/issues`
3. Heuristically recommends: KEEP BOTH (additive on both sides), KEEP CURRENT (incoming only removed), MANUAL otherwise
4. Posts a sticky comment per PR showing:

```
### docs/PROVENANCE_STANDARD.md

| Side | Last commit | PR | Author | Date |
| --- | --- | --- | --- | --- |
| Current (main) | a1b2c3d — Add Octopus entry | #14068 | claude | 2026-05-28 |
| Incoming (this PR) | e4f5g6h — Add Keploy entry | #13970 (this PR) | claude | 2026-05-28 |

Recommendation: **KEEP BOTH** — additive on both sides (no lines removed).
```

So when you click into GitHub's web conflict resolver, you already know which side is what. **Never auto-resolves** — the human still clicks.

## Test plan

- [x] YAML syntax checks pass on both workflows
- [ ] After merge: docs-freshness linter fires on next PR; verify it posts a sticky comment when a workflow change ships without a doc update
- [ ] After merge: conflict-helper fires on a PR with real conflicts; verify the recommendation is sane

## Cross-refs

- `docs/PROVENANCE_STANDARD.md` (the catalog this protects)
- `docs/AGENT_MONITORING_STANDARD.md` (the routing catalog this protects)
- #14068 (Octopus routing — the most recent example of manual doc-pairing work)
- #13967 (Mabl pause — earlier example)

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a documentation freshness standard and two supporting GitHub Action workflows to prevent docs from lagging behind code changes. The `DOCS_FRESHNESS_STANDARD.md` defines pairing rules (e.g., when you add a workflow, you must also update `SYSTEM_MAP.md` in the same PR). A soft-warn linter (`docs-freshness-check.yml`) posts informational PR comments when code changes occur without their paired doc updates, with an escape-hatch syntax for intentional skips. A merge-conflict helper workflow (`conflict-helper.yml`) analyzes conflicted files to trace each side back to its originating PR and author, then heuristically recommends whether to keep both sides, keep one, or resolve manually—never auto-resolving, only annotating to reduce decision friction in GitHub's web merge UI.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/DOCS_FRESHNESS_STANDARD.md` |
| 2 | `.github/workflows/docs-freshness-check.yml` |
| 3 | `.github/workflows/conflict-helper.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a docs freshness standard and two GitHub Actions: a soft linter that warns when code changes miss their paired docs, and a conflict helper that annotates where each side of a merge conflict came from. This keeps catalogs in sync and speeds up conflict resolution without blocking merges.

- **New Features**
  - `docs/DOCS_FRESHNESS_STANDARD.md`: Clear pairing rules, escape hatch syntax, and catalog map.
  - `.github/workflows/docs-freshness-check.yml`: Soft linter that lists missing doc pairings in a single sticky PR comment; supports `docs-freshness: <reason>`; cleans up stale warnings when all pairings are satisfied.
  - `.github/workflows/conflict-helper.yml`: Posts a single sticky PR comment summarizing all conflicted files with last commits, originating PRs, and a heuristic recommendation (e.g., KEEP BOTH). Never auto-resolves.

- **Bug Fixes**
  - Conflict-helper now runs only when GitHub reports `mergeable_state: dirty` or the `has-conflicts` label is applied, preventing empty comments on clean PRs.
  - Replaced `git merge-tree` with a real 3-way merge + `git diff --diff-filter=U` for reliable conflicted-file detection and per-file rows.

<sup>Written for commit f52a7e00428e412fcd1970ca9d85ff8405bc2af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14072?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

