### PR TITLE
Research preemptive input packs — close the one-iteration gap for visual/merch WRs

### DIFF
--- a/docs/RESEARCH_ENGINE_STANDARD.md
+++ b/docs/RESEARCH_ENGINE_STANDARD.md
@@ -102,6 +102,7 @@ The synthesizer uses `RESEARCH_SYNTHESIS_MODEL`, defaulting to `anthropic/claude
 - [ ] Split research into independent specialist lanes with named agents.
 - [ ] Run each lane through OpenRouter model triangulation or a configured MAS provider.
 - [ ] Require evidence, citations, confidence, and explicit unknowns from every lane.
+- [ ] **If Output Type is visual / branded / merchandise / asset-artifact** — run the three **preemptive input packs** under [`templates/research-preemptive-inputs/`](../templates/research-preemptive-inputs/) so the human owner doesn't have to add regional motifs, color palettes, or generation prompts as PR comments later. See PR [#14085](https://github.com/midnghtsapphire/revvel-standards/pull/14085) for the originating case.
 - [ ] Synthesize marketing, SEO, competitors, audience, chatter, factual validation, delivery, and revenue into one packet.
 - [ ] Create a code-review packet that asks review agents for comments and automatic-fix commits.
 - [ ] Apply research lifecycle labels so stuck items are visible.

--- a/docs/REVVEL_MASTER_STANDARDS.md
+++ b/docs/REVVEL_MASTER_STANDARDS.md
@@ -72,7 +72,7 @@ This document is the master policy document. For detailed implementation specifi
 **EXRUP** is the core execution framework for all Revvel and MIDNGHTSAPPHIRE projects. It is designed for maximum speed, one-iteration production delivery, and comprehensive artifact generation.
 
 ### Core Principles
-- **One-Iteration Delivery:** The goal is to move from idea to production-ready deployment in a single, intense iteration.
+- **One-Iteration Delivery:** The goal is to move from idea to production-ready deployment in a single, intense iteration. Mid-PR retro-research (the owner having to drop "you should have considered X" comments) is the failure mode this principle exists to prevent. For visual / branded / merchandise WRs, the [`templates/research-preemptive-inputs/`](../templates/research-preemptive-inputs/) packs are the enforcement — research engine MUST surface regional motifs, palette tiers, and ready-to-use prompt packs in the first pass. Originating case: [PR #14085](https://github.com/midnghtsapphire/revvel-standards/pull/14085).
 - **Artifact-First:** Every project must generate a complete set of artifacts (Blueprints, Roadmaps, Specs) before or alongside code.
 - **Genius Orchestration:** Use multi-agent AI systems (OpenRouter, Kimi, Venice, Grok, Sonnet 4 and 4.5, DeepSeek) to handle complex research, design, and coding tasks autonomously.
 - **FOSS Priority:** Always prioritize Free and Open Source Software tools and libraries.

--- a/templates/research-preemptive-inputs/README.md
+++ b/templates/research-preemptive-inputs/README.md
@@ -1,0 +1,68 @@
+# Research Preemptive Input Packs
+
+These templates are the **one-iteration enablers** for design / merchandise /
+asset-artifact WRs. The research engine MUST consult each pack when scoping
+a WR whose Output Type involves visual or branded artifacts so that the
+human owner does not have to add region/palette/prompt guidance mid-PR.
+
+> Cross-refs:
+> `docs/RESEARCH_ENGINE_STANDARD.md` (Master Checklist now requires these) ·
+> `docs/REVVEL_MASTER_STANDARDS.md` (EXRUP one-iteration delivery) ·
+> Originating case: PR [#14085](https://github.com/midnghtsapphire/revvel-standards/pull/14085) — owner had to drop in Knoxville motifs, UT color palettes, and image-prompt packs as PR comments because the research lane omitted them.
+
+## When to use these packs
+
+| WR Output Type | Apply packs? | Which ones |
+| --- | --- | --- |
+| `merchandise`, `logo`, `branded-asset`, `apparel`, `sticker-pack`, `print-collateral` | **Required** | All three |
+| `web`, `mobile`, `api` with a brand-identity scope | **Required if regional/local audience** | Regional + Palette |
+| `pdf`, `sellable-pdf` with cover design | **Required** | Palette + Prompt-pack |
+| `research`, `cli`, anything non-visual | Skip | — |
+
+The research orchestrator decides via the WR's Output Type field. When in
+doubt — include them; redundant context is cheaper than a second iteration.
+
+## The three packs
+
+| File | What it forces the research lane to produce |
+| --- | --- |
+| [`regional-cultural-motif-template.md`](./regional-cultural-motif-template.md) | A ranked motif shortlist for the WR's target region, with a licensing-risk + cultural-fit gate, derived from the actual local landmarks / traditions / colors. |
+| [`color-palette-template.md`](./color-palette-template.md) | At least three candidate palettes (official, traditional accent, natural-environment), each with hex codes + the story that justifies them. |
+| [`prompt-pack-template.md`](./prompt-pack-template.md) | Reusable image-generation prompts (multi-palette concept grids, hero composition, alt compositions) parameterized for the WR's subject so the artifact step doesn't start from scratch. |
+
+## Master output contract (what every pack delivers)
+
+For each pack the research lane MUST return:
+
+1. **Inputs section** — what local research surfaced (landmarks, traditions, traditions, palette anchors, prompt skeletons).
+2. **Gate section** — a small table with Visual Value / Licensing Risk / Cultural Fit / Keep-or-Drop per candidate.
+3. **Safe-use outputs** — the licensed/cleared subset, ready to hand to the asset-artifact step.
+4. **Citations** — at least one source per claim (Wikipedia, official org pages, licensing portals).
+
+A pack that returns inputs without the gate or without safe-use outputs is
+incomplete — escalate as `research:blocked` per
+`docs/RESEARCH_ENGINE_STANDARD.md` §"Missing Secret Behavior" pattern.
+
+## How packs feed the EXRUP one-iteration loop
+
+```
+WR opens
+   │
+   ▼
+Research orchestrator inspects Output Type
+   │
+   ├── visual / branded? → load all three packs
+   │       │
+   │       ▼
+   │   For each pack: research lane fills template,
+   │                  applies gate, outputs safe-use subset
+   │       │
+   │       ▼
+   │   Pack outputs glued into the WR doc and into
+   │   the asset-artifact step's input bundle
+   │
+   ▼
+Implementer ships in one pass — no comment-driven retro-research.
+```
+
+That's what "one iteration" means for design-touching WRs.

--- a/templates/research-preemptive-inputs/color-palette-template.md
+++ b/templates/research-preemptive-inputs/color-palette-template.md
@@ -1,0 +1,111 @@
+# Color Palette Template
+
+Three palette tiers must be surfaced for any visual/branded WR with a
+regional or institutional flavor. The Knoxville example in #14085 had:
+official (UT orange + white + checkerboard), traditional accent (Smokey
+charcoal grey), and natural environment (Smoky-Mountains blue/purple,
+forest greens, river blues). Future WRs get this pattern by default.
+
+> Cross-ref: [`README.md`](./README.md), [`regional-cultural-motif-template.md`](./regional-cultural-motif-template.md).
+
+## 1. Subject capture
+
+| Field | Value |
+| --- | --- |
+| Subject of the artifact | _e.g., banana mascot baseball logo for Knoxville-themed apparel_ |
+| Primary regional anchor | _e.g., University of Tennessee Volunteers_ |
+| Audience expectation | _e.g., immediately recognizable as UT-flavored without infringing UT marks_ |
+
+## 2. Three palette tiers — required
+
+### Tier A. Official / signature palette
+
+The "they'd-recognize-it-in-the-dark" palette. Source: the institution's
+brand guide if available; otherwise the dominant public-facing identity.
+
+| Role | Color name | Hex | Notes / source |
+| --- | --- | --- | --- |
+| Primary | _e.g., Tennessee Orange_ | `#FF8200` | _brand.utk.edu — official; reference, do not infringe_ |
+| Secondary | _e.g., White_ | `#FFFFFF` | _Contrast base for the primary_ |
+| Pattern accent | _e.g., Orange-and-white checkerboard_ | n/a | _Functions like a color; safe as pattern_ |
+
+### Tier B. Traditional / athletic accent palette
+
+A 3rd color that the audience associates with the brand but isn't the
+primary. Adds depth, premium feel, avoids "logo on white" sameness.
+
+| Role | Color name | Hex | Notes / source |
+| --- | --- | --- | --- |
+| Accent | _e.g., Smokey Charcoal Grey_ | `#58595B` | _Named after Smokey the Bluetick Coonhound (UT mascot)_ |
+| Soft neutral | _e.g., Cream_ | `#F5EFE0` | _Vintage / heritage feel_ |
+| Optional 3rd | _e.g., Mustard gold_ | `#C8A55A` | _Adds warm depth_ |
+
+### Tier C. Natural environment / place-based palette
+
+Colors pulled from the actual geography. Lets the design feel like the
+place without leaning on trademarked marks.
+
+| Role | Color name | Hex | Notes / source |
+| --- | --- | --- | --- |
+| Mountain haze | _e.g., Smoky blue_ | `#7A8FAF` | _Great Smoky Mountains visual signature_ |
+| Mountain haze accent | _e.g., Muted purple_ | `#6E5C7B` | _Distant ridges_ |
+| Forest | _e.g., Deep pine green_ | `#1F4332` | _Heavily forested region_ |
+| Water | _e.g., River blue_ | `#3D6B8C` | _Tennessee River — Vol Navy nod_ |
+| Optional warm | _e.g., Sunset gold_ | `#E5A23F` | _Gameday / on-the-water mood_ |
+
+## 3. Recommended combinations (output to the asset step)
+
+The research lane must propose at least four combinations that mix the
+tiers in distinct ways so the asset step has variety to grid out.
+
+| Combo name | Composition | Use case |
+| --- | --- | --- |
+| Tradition-rich | Primary + secondary + small charcoal accents | Classic apparel, logo-forward |
+| Checkerboard power | Pattern fill + solid primary + cream | Bold banners, sportswear |
+| UT Natural | Primary + Smoky blue + River blue | Sunset-on-the-river illustrations |
+| Elegant accent | Charcoal as field + primary used sparingly | Premium / black-tie merch |
+| _add 2–4 more_ | | |
+
+## 4. Hex contract for the asset-artifact step
+
+When the asset step ingests this template, it expects:
+
+```json
+{
+  "palettes": [
+    {
+      "name": "Tradition-rich",
+      "hexes": ["#FF8200", "#FFFFFF", "#58595B"],
+      "use_case": "Classic apparel, logo-forward"
+    },
+    {
+      "name": "UT Natural",
+      "hexes": ["#FF8200", "#7A8FAF", "#3D6B8C"],
+      "use_case": "Sunset-on-the-river illustrations"
+    }
+  ]
+}
+```
+
+Including hexes (not color names) eliminates ambiguity for downstream
+generators.
+
+## 5. Licensing call-outs
+
+| Color / pattern | Risk | Mitigation |
+| --- | --- | --- |
+| Tennessee Orange (`#FF8200`) | Color itself not trademarkable, but UT brand guide governs paired use with marks | Use the hex; do not pair with Power-T or other UT marks unless licensed |
+| Checkerboard endzone pattern | Pattern not trademarked; widely used | Safe as background |
+| Smokey charcoal grey | Color named after mascot; no IP issue using the hex | Safe |
+| _any vendor-specific palette (Pantone)_ | Pantone codes are licensed for color matching but hex equivalents are unrestricted | Use hex equivalents |
+
+## 6. Citations
+
+```
+- UT brand guide — https://brand.utk.edu/
+- Tennessee Orange origin — https://en.wikipedia.org/wiki/University_of_Tennessee#Color
+- Great Smoky Mountains palette reference — https://www.nps.gov/grsm/
+- Pantone vs hex licensing — Pantone's terms apply only to PMS book usage
+```
+
+Minimum 1 source per palette tier.

--- a/templates/research-preemptive-inputs/prompt-pack-template.md
+++ b/templates/research-preemptive-inputs/prompt-pack-template.md
@@ -1,0 +1,151 @@
+# Prompt Pack Template
+
+When a visual artifact is the WR deliverable, the research lane must hand
+the asset-artifact step a **ready-to-use prompt pack** — not a description
+of what to generate. The Knoxville case in #14085 had the owner paste the
+actual prompts they'd already iterated on (multi-palette concept grids,
+batting-pose emblem variants); future WRs derive these unprompted from
+the motif + palette templates and ship them as part of the research packet.
+
+> Cross-ref: [`README.md`](./README.md), [`regional-cultural-motif-template.md`](./regional-cultural-motif-template.md), [`color-palette-template.md`](./color-palette-template.md).
+
+## 1. Subject capture
+
+| Field | Value |
+| --- | --- |
+| Artifact format | _e.g., 2x2 concept grid, hero composition, vector logo, sticker pack_ |
+| Subject character / element | _e.g., banana mascot in baseball uniform_ |
+| Composition setting | _e.g., Neyland Stadium with Tennessee River + Vol Navy boats_ |
+| Output medium | _e.g., screen-printable apparel, RGB-first web logo, CMYK print collateral_ |
+
+## 2. The prompt slots
+
+A complete pack ships at least these four prompts. Each one references the
+motif shortlist and a specific palette combo from the palette template.
+
+### Slot 1 — Multi-palette concept grid
+
+Use case: side-by-side palette comparison so the human picks fast.
+
+```
+A vector graphic design showcase sheet featuring four variations of {SUBJECT},
+organized in a clean 2x2 grid. The main composition is {COMPOSITION_DESCRIPTION},
+referencing {MOTIF_1, MOTIF_2, MOTIF_3} (all KEEP-flagged in the motif gate).
+
+Each of the four quadrants showcases a distinct color palette variation:
+- Top-Left:    {PALETTE_A_DESCRIPTION}, hexes {PALETTE_A_HEXES}
+- Top-Right:   {PALETTE_B_DESCRIPTION}, hexes {PALETTE_B_HEXES}
+- Bottom-Left: {PALETTE_C_DESCRIPTION}, hexes {PALETTE_C_HEXES}
+- Bottom-Right: {PALETTE_D_DESCRIPTION}, hexes {PALETTE_D_HEXES}
+
+The entire layout is presented on a clean, single sheet of parchment paper
+background for a professional design portfolio style. Clean lines, screen-printed
+aesthetic, no overlapping frames. {ANY LICENSING-AWARE INSTRUCTIONS:
+e.g., use stylized silhouettes, avoid trademarked marks}.
+```
+
+### Slot 2 — Hero composition (single, finished)
+
+Use case: the "this is the answer" version once a palette has been picked.
+
+```
+A vector graphic of {SUBJECT} in {COMPOSITION_DESCRIPTION}.
+
+Color palette: {PICKED_PALETTE_NAME}, hexes {PICKED_PALETTE_HEXES}.
+
+References (safe-use): {MOTIF_1 (silhouette only), MOTIF_2, MOTIF_3}.
+
+Style: {clean vector / flat color / screen-print aesthetic}.
+Composition: {centered emblem / banner across the middle / circular frame}.
+Output: {transparent PNG at 4000x4000 + SVG}.
+
+Do not include: {any trademarked marks, brand wordmarks, mascot likenesses
+of licensed properties}.
+```
+
+### Slot 3 — Alternate composition (variant pose / framing)
+
+Use case: gives the asset step a B-side for the same palette.
+
+```
+{Same SUBJECT and PALETTE as slot 2, but the pose / framing is shifted to
+ALT_COMPOSITION_DESCRIPTION}. Otherwise identical instructions.
+```
+
+### Slot 4 — Pattern / texture asset
+
+Use case: backgrounds, packaging, web hero strips.
+
+```
+A seamless tileable pattern derived from {KEEP-flagged PATTERN_MOTIF, e.g.,
+orange-and-white checkerboard from §2 of the motif template}.
+
+Colors: hexes {PALETTE_HEXES_FOR_PATTERN}.
+
+Constraints: tileable, vector, no trademarked elements, contrast suitable
+for both light and dark backgrounds.
+```
+
+## 3. Worked example (filled from #14085 inputs)
+
+This is the kind of output the owner pasted manually — every future WR
+should produce this from the templates automatically.
+
+> **Slot 1 — Multi-palette grid for "Bananas / Vol Navy sailgating":**
+>
+> ```
+> A vector graphic design showcase sheet featuring four variations of a sports
+> team logo, organized in a clean 2x2 grid. The main character is a cartoon
+> banana mascot wearing a baseball cap and a striped jersey, happily steering
+> a small vintage wooden boat labeled "VOL NAVY" with a checkerboard hull
+> pattern. The boat is on the Tennessee River with a stylized Neyland
+> Stadium, the Sunsphere, and a bridge in the background. A banner reads
+> "Bananas" in bold cursive text, with a small Bluetick Coonhound (generic
+> silhouette — no UT mascot likeness) wearing an orange bandana next to a
+> baseball.
+>
+> Each of the four quadrants showcases a distinct color palette variation:
+> - Top-Left:    High-contrast Tennessee orange (#FF8200) and white with a deep navy field.
+> - Top-Right:   Cool Smokey charcoal grey (#58595B) and muted orange accents.
+> - Bottom-Left: Deep river blues (#3D6B8C), smoky mountain purples (#6E5C7B), and soft sunset golds (#E5A23F).
+> - Bottom-Right: Premium dark grey base with vibrant golden-orange text and highlights.
+>
+> The entire layout is presented on a clean, single sheet of parchment paper
+> background for a professional design portfolio style. Clean lines,
+> screen-printed aesthetic, no overlapping frames. Stylized silhouettes
+> only — no UT trademarked marks (Power-T, Smokey likeness, etc.).
+> ```
+
+The same template ships variants for batting-pose emblem, sticker-pack grid,
+and so on — derived purely from the WR's motif + palette inputs.
+
+## 4. Hand-off contract
+
+Each slot's prompt MUST be:
+
+1. **Self-contained** — runnable as-is in any image-gen model (no "see WR" references).
+2. **Licensing-aware** — every trademarked motif from the gate is either filtered out or has a "stylized silhouette only" instruction.
+3. **Hex-explicit** — palette references use hex codes, not color names.
+4. **Output-formatted** — names the format (PNG/SVG), dimensions, background (transparent / parchment / etc.).
+
+A prompt pack that's missing any of these is incomplete — return for
+revision before handing to the asset-artifact step.
+
+## 5. Storage
+
+Generated prompt packs ship into the WR's `assets/prompts/` directory
+alongside the WR doc, so re-runs and audits can replay them exactly.
+
+```
+wr/issues/issue-NNNNN-...md          ← the WR doc
+wr/issues/issue-NNNNN-...assets/
+  prompts/
+    grid-multi-palette.md            ← slot 1
+    hero-composition.md              ← slot 2
+    alt-composition.md               ← slot 3
+    pattern-texture.md               ← slot 4
+```
+
+Committing the prompts gives the asset-artifact step a stable input and
+the audit trail later answers "what exactly did we ask the model to make?"
+without rummaging through PR comments.

--- a/templates/research-preemptive-inputs/regional-cultural-motif-template.md
+++ b/templates/research-preemptive-inputs/regional-cultural-motif-template.md
@@ -1,0 +1,97 @@
+# Regional / Cultural Motif Template
+
+Fill this out per WR. The research lane is responsible for surfacing motifs
+the human owner would otherwise have to add as PR comments later (Knoxville
+case in #14085 — Sunsphere, Tennessee River / Vol Navy, checkerboard, Smokey
+the Bluetick Coonhound, Power-T, volunteer-era accents — all of which the
+research engine should have surfaced unprompted because the WR's geography
+flagged it).
+
+> Cross-ref: [`README.md`](./README.md) for when this pack is required.
+
+## 1. Region capture
+
+| Field | Value |
+| --- | --- |
+| Region (specific) | _e.g., Knoxville, TN / East TN / UT campus area_ |
+| Audience overlap (institutions, fandoms) | _e.g., University of Tennessee Volunteers fan base, Vol Navy sailgaters_ |
+| Adjacent regions worth scanning | _e.g., Great Smoky Mountains, Nashville_ |
+
+## 2. Candidate motif shortlist
+
+Surface candidates from at least these categories. Use the local landmark,
+tradition, and natural-environment lenses — that's where unique flavor
+lives.
+
+### 2a. Landmarks
+
+| Motif | Why it's iconic | Source |
+| --- | --- | --- |
+| _e.g., Sunsphere_ | _Built for the 1982 World's Fair; only-in-Knoxville silhouette_ | _wikipedia.org/wiki/Sunsphere_ |
+| _e.g., Tennessee River + Vol Navy_ | _Sailgating tradition tied directly to Neyland Stadium_ | _utsports.com or local press_ |
+| _add 3–5 more_ | _…_ | _…_ |
+
+### 2b. Cultural / traditional details
+
+| Motif | Why it resonates | Source |
+| --- | --- | --- |
+| _e.g., Power-T_ | _Official UT mark — instantly readable_ | _utsports.com/branding_ |
+| _e.g., Smokey the Bluetick Coonhound_ | _Live mascot; affectionate brand asset_ | _utsports.com_ |
+| _e.g., Orange-and-white checkerboard endzones_ | _Pattern functions like a color of its own_ | _wikipedia.org/wiki/Neyland\_Stadium_ |
+| _add 3–5 more_ | _…_ | _…_ |
+
+### 2c. Natural environment
+
+| Motif | Why it grounds the brand | Source |
+| --- | --- | --- |
+| _e.g., Great Smoky Mountains haze_ | _Muted blue/purple horizon — sense of place_ | _nps.gov/grsm_ |
+| _e.g., Forest greens_ | _Heavily wooded region — natural counter to bright orange_ | _…_ |
+| _add 1–3 more_ | _…_ | _…_ |
+
+### 2d. Volunteer-era / historic accents
+
+| Motif | Why it carries narrative weight | Source |
+| --- | --- | --- |
+| _e.g., Crossed muskets + tricorn hats_ | _"Volunteer State" provenance — visual nod, not literal use_ | _wikipedia.org/wiki/Tennessee_ |
+| _add 1–3 more_ | _…_ | _…_ |
+
+## 3. Motif gate — KEEP / DROP each candidate
+
+| Motif | Visual Value (1–5) | Licensing Risk (low/med/high) | Cultural Fit (1–5) | Keep or Drop | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Sunsphere | 5 | low (public landmark) | 5 | KEEP | Generic stylized silhouette OK; avoid trademarked rendering |
+| Power-T | 5 | **high** (UT trademark) | 5 | DROP for unlicensed use | Use as inspiration only; no direct reproduction |
+| Checkerboard endzone | 4 | low (pattern, not mark) | 5 | KEEP | Safe as background pattern |
+| Smokey (literal) | 4 | high (mascot likeness) | 5 | DROP unless licensed | Substitute generic bluetick coonhound silhouette |
+| _…each candidate from §2…_ | | | | | |
+
+**Risk rubric:**
+
+- **Low**: public-domain landmark, geographic feature, generic regional pattern.
+- **Medium**: requires attribution but no license fee (e.g., NPS imagery with credit).
+- **High**: trademarked university/team/corporate mark; licensing required or substitute.
+
+## 4. Safe-use shortlist (output to the asset-artifact step)
+
+After running the gate, output a clean shortlist of motifs that are KEEP-flagged
+plus the safe-use rendering instructions for each.
+
+| Motif | Safe rendering instruction |
+| --- | --- |
+| Sunsphere | Stylized silhouette, not photorealistic; no UT logos overlaid |
+| Checkerboard | Orange-and-white pattern as background or border only |
+| Generic bluetick coonhound | No mascot likeness — generic breed silhouette, custom collar |
+| Tennessee River + small boats | Generic riverboat shapes; no "Vol Navy" wordmark |
+| _…rest of KEEP rows…_ | |
+
+## 5. Citations
+
+List every source consulted. Format:
+
+```
+- Sunsphere — https://en.wikipedia.org/wiki/Sunsphere (public landmark, reproduction OK)
+- UT Branding guidelines — https://brand.utk.edu/ (consulted for trademark scope)
+- Neyland Stadium checkerboard — https://en.wikipedia.org/wiki/Neyland_Stadium#Checkerboard_end_zones
+```
+
+Minimum 1 source per kept motif. No citation = drop the motif.


### PR DESCRIPTION
## Summary

Closes the "one-iteration" gap for visual/branded WRs by extracting what you had to add manually to #14085 into reusable templates the research engine must consult on the **first pass**.

In #14085 you had to drop three big LLM-derived comments into the PR:
1. Knoxville motifs (Sunsphere, Vol Navy, checkerboard, Smokey, Power-T licensing-aware references)
2. UT-area color palettes (official orange + white, Smokey charcoal grey, Smoky Mountain blue/purple, river blues, sunset golds)
3. The actual image-generation prompts for multi-palette concept grids

That's exactly the **mid-PR retro-research** EXRUP one-iteration delivery is supposed to prevent. This PR captures all three as templates, then wires them into RESEARCH_ENGINE_STANDARD's Master Checklist as a required step for any WR whose Output Type is visual / branded / merchandise / asset-artifact.

## What changed

### `templates/research-preemptive-inputs/`
- `README.md` — index + when-to-apply table + master output contract (Inputs / Gate / Safe-use / Citations) + flow diagram
- `regional-cultural-motif-template.md` — Landmarks / Cultural / Natural / Historic motif buckets, a Visual-Value × Licensing-Risk × Cultural-Fit gate, and a safe-use shortlist contract
- `color-palette-template.md` — three required palette tiers (Official, Traditional accent, Natural environment) with hex contracts + licensing call-outs
- `prompt-pack-template.md` — four prompt slots (multi-palette grid, hero, alt, pattern) with a worked example reproducing your #14085 Bananas/Vol Navy prompt, plus a hand-off contract that requires hex-explicit, licensing-aware, output-formatted prompts

### `docs/RESEARCH_ENGINE_STANDARD.md`
Master Checklist now has a required step: if Output Type is visual/branded/merchandise/asset-artifact, run all three packs. Cites #14085 as the originating case.

### `docs/REVVEL_MASTER_STANDARDS.md`
EXRUP "One-Iteration Delivery" principle now names the packs as the enforcement mechanism and links the originating PR.

## Net effect

| Before | After |
|---|---|
| Research engine ships a generic WR for "Knoxville merch design" → owner pastes Sunsphere/Vol Navy/checkerboard suggestions as PR comments → second iteration → coder regenerates | Research engine sees Output Type = `merchandise` + region tag → loads three packs → WR already contains motif shortlist + 3-tier palettes + ready-to-run prompts → coder ships in one pass |

## Test plan

- [x] Templates self-validate (each section has the contract sections called out in README)
- [ ] Apply on next merchandise/visual WR after merge — verify the research lane fills all three templates without the owner having to add comments
- [ ] After the third "no-comments-needed" WR, lock the rule into the auto-classifier so Output Type = `merchandise` automatically triggers the packs

## Cross-refs

- PR #14085 — originating case (Knoxville Bananas/Vol Navy merch WR)
- `docs/RESEARCH_ENGINE_STANDARD.md` — Master Checklist enforcement
- `docs/REVVEL_MASTER_STANDARDS.md` §1 EXRUP — principle this enforces
- `docs/DOCS_FRESHNESS_STANDARD.md` (merged from #14072) — companion principle: when you add new templates / standards, the catalogs that list them get updated in the same PR

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces three reusable template packs (regional motifs, color palettes, and image-generation prompts) that the research engine must consult on the first pass for any visual, branded, or merchandise work requests. The change eliminates the "one-iteration gap" where owners previously had to manually add regional context, licensing-aware design guidance, and ready-to-run prompts as mid-PR comments. The templates capture the motif shortlists, multi-tier palette specifications with hex codes, and parameterized prompt skeletons that were manually injected in PR #14085, and wire them into the `RESEARCH_ENGINE_STANDARD` Master Checklist as a required step for asset-artifact output types. The `REVVEL_MASTER_STANDARDS` EXRUP principle is updated to explicitly name these packs as the enforcement mechanism for one-iteration delivery on visual work.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `templates/research-preemptive-inputs/README.md` |
| 2 | `templates/research-preemptive-inputs/regional-cultural-motif-template.md` |
| 3 | `templates/research-preemptive-inputs/color-palette-template.md` |
| 4 | `templates/research-preemptive-inputs/prompt-pack-template.md` |
| 5 | `docs/RESEARCH_ENGINE_STANDARD.md` |
| 6 | `docs/REVVEL_MASTER_STANDARDS.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds preemptive research input packs for visual/branded/merchandise WRs so regional motifs, palette tiers, and ready-to-run prompt packs land on the first pass. Updates standards to require these packs, closing the one-iteration gap seen in #14085.

- New Features
  - Added templates under `templates/research-preemptive-inputs/`: `regional-cultural-motif-template.md`, `color-palette-template.md`, `prompt-pack-template.md`.
  - Added `README.md` with when-to-apply guidance and a clear output contract (Inputs → Gate → Safe-use → Citations).
  - Updated `docs/RESEARCH_ENGINE_STANDARD.md` to require these packs when Output Type is visual/branded/merchandise/asset-artifact, and `docs/REVVEL_MASTER_STANDARDS.md` to name them as the EXRUP enforcement (origin: #14085).

- Migration
  - Research engine: when Output Type is visual/branded/merchandise/asset-artifact, run all three packs on the first pass.
  - Asset step: expect hex-explicit palettes and prompt files committed under `wr/issues/.../assets/prompts/`.

<sup>Written for commit 1976eb4002cc66ee71f8772b8693f82085a1c206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

