### PR TITLE
Inject PR/issue context into personas so oAudrey stops asking "what repo? what PR?"

### DIFF
--- a/scripts/persona-comment-runner.js
+++ b/scripts/persona-comment-runner.js
@@ -100,6 +100,139 @@ function postComment(repo, issueNumber, markdown) {
 }
 
 /**
+ * Best-effort PR/issue context fetch. Personas have been answering "share the
+ * repo URL and PR number" because the runner only passed them the comment
+ * text. With this, the persona sees the title, body, labels, mergeability,
+ * the most recent CI failures, and (for PRs) a head of the diff — enough to
+ * actually diagnose without asking. All gh calls are soft-failed so a
+ * permissions or network hiccup never blocks the reply.
+ *
+ * Returns a markdown block ready to prepend to the persona's task, or "" on
+ * total failure.
+ */
+function gatherContext(repo, issueNumber) {
+  const MAX_DIFF_CHARS = 6000;
+  const sh = (args) => {
+    try {
+      return execFileSync("gh", args, { encoding: "utf8" }).trim();
+    } catch (_err) {
+      return "";
+    }
+  };
+
+  // Both issues and PRs are addressable as `gh issue view` — but `gh pr view`
+  // works only for PRs. Probe with `gh pr view` first; if it errors, it's an
+  // issue.
+  const prJson = sh([
+    "pr",
+    "view",
+    String(issueNumber),
+    "--repo",
+    repo,
+    "--json",
+    "number,title,body,state,mergeable,mergeStateStatus,headRefOid,headRefName,baseRefName,additions,deletions,changedFiles,labels,isDraft,url",
+  ]);
+
+  if (prJson) {
+    let pr = {};
+    try {
+      pr = JSON.parse(prJson);
+    } catch (_e) {
+      pr = {};
+    }
+    const labels = (pr.labels || []).map((l) => l.name).join(", ");
+
+    // Most recent failed check runs on the head SHA.
+    let failingChecks = "";
+    if (pr.headRefOid) {
+      const checksJson = sh([
+        "api",
+        `repos/${repo}/commits/${pr.headRefOid}/check-runs`,
+        "--jq",
+        '[.check_runs[] | select(.conclusion=="failure" or .conclusion=="cancelled" or .conclusion=="timed_out") | {name, conclusion, url: .html_url}] | .[0:8]',
+      ]);
+      if (checksJson && checksJson !== "[]") {
+        failingChecks = checksJson;
+      }
+    }
+
+    // First N chars of the diff so the persona can reason about *what changed*.
+    let diffHead = "";
+    if (pr.changedFiles && pr.changedFiles <= 50) {
+      const diff = sh(["pr", "diff", String(issueNumber), "--repo", repo]);
+      diffHead = diff.slice(0, MAX_DIFF_CHARS);
+      if (diff.length > MAX_DIFF_CHARS) {
+        diffHead += `\n\n[diff truncated at ${MAX_DIFF_CHARS} chars; full diff has ${diff.length} chars total]`;
+      }
+    } else if (pr.changedFiles) {
+      diffHead = `[diff omitted — ${pr.changedFiles} changed files exceeds the 50-file cap; ask explicitly if needed]`;
+    }
+
+    return [
+      "## PR Context",
+      `- **Repository:** \`${repo}\``,
+      `- **PR:** #${pr.number} — ${pr.title}`,
+      `- **URL:** ${pr.url || `https://github.com/${repo}/pull/${pr.number}`}`,
+      `- **State:** ${pr.state}${pr.isDraft ? " (draft)" : ""}`,
+      `- **Mergeable:** ${pr.mergeable || "?"} / ${pr.mergeStateStatus || "?"}`,
+      `- **Branches:** \`${pr.headRefName}\` → \`${pr.baseRefName}\``,
+      `- **Diff size:** +${pr.additions || 0} / −${pr.deletions || 0} across ${pr.changedFiles || 0} file(s)`,
+      `- **Labels:** ${labels || "(none)"}`,
+      "",
+      "### PR description",
+      "```",
+      (pr.body || "(empty)").slice(0, 2000),
+      "```",
+      "",
+      "### Failing checks (latest)",
+      failingChecks ? "```json\n" + failingChecks + "\n```" : "_(none failing)_",
+      "",
+      "### Diff head",
+      diffHead ? "```diff\n" + diffHead + "\n```" : "_(no diff captured)_",
+      "",
+      "---",
+      "",
+    ].join("\n");
+  }
+
+  // Fall back to issue context.
+  const issueJson = sh([
+    "issue",
+    "view",
+    String(issueNumber),
+    "--repo",
+    repo,
+    "--json",
+    "number,title,body,state,labels,url",
+  ]);
+  if (!issueJson) return "";
+
+  let issue = {};
+  try {
+    issue = JSON.parse(issueJson);
+  } catch (_e) {
+    return "";
+  }
+  const labels = (issue.labels || []).map((l) => l.name).join(", ");
+  return [
+    "## Issue Context",
+    `- **Repository:** \`${repo}\``,
+    `- **Issue:** #${issue.number} — ${issue.title}`,
+    `- **URL:** ${issue.url || `https://github.com/${repo}/issues/${issue.number}`}`,
+    `- **State:** ${issue.state}`,
+    `- **Labels:** ${labels || "(none)"}`,
+    "",
+    "### Issue body",
+    "```",
+    (issue.body || "(empty)").slice(0, 4000),
+    "```",
+    "",
+    "---",
+    "",
+  ].join("\n");
+}
+
+/**
  * EXECUTION mode: file a real Work Request issue and trigger the working coder.
  * Returns the new issue number (or the raw gh output if it can't be parsed).
  */
@@ -166,8 +299,16 @@ async function main() {
       ? command.task
       : "Review this thread and advise on the next concrete step.";
 
+  // Inject PR/issue context so the persona doesn't have to ask "what repo?
+  // what PR? what error?" — the runtime already knows. Soft-failed: if we
+  // can't fetch, fall through with the bare task and let the persona ask.
+  const context = gatherContext(repo, issueNumber);
+  const augmentedTask = context
+    ? `${context}\nUser request:\n${task}\n\nNote: you already have the repo, the PR/issue, the labels, the failing checks, and the diff above. Do NOT ask the user to share these again — diagnose from the context.`
+    : task;
+
   console.log(`🫆 Summoning ${command.handle} (eager) for issue #${issueNumber}...`);
-  const result = await instantiate(command.handle, { mode: "eager", task, silent: true });
+  const result = await instantiate(command.handle, { mode: "eager", task: augmentedTask, silent: true });
 
   const reply = `## ${result.name} ${result.role ? `— ${result.role}` : ""}\n\n${result.text}\n\n---\n_Summoned via comment trigger · model: ${result.modelUsed || "unknown"}_`;
   postComment(repo, issueNumber, reply);
@@ -181,4 +322,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { parsePersonaCommand, sanitizeMentions };
+module.exports = { parsePersonaCommand, sanitizeMentions, gatherContext };


### PR DESCRIPTION
## Summary

Direct fix for the "oAudrey still has bad memory cannot diagnose a PR when in it" problem you flagged.

Right now `/oaudrey` on a PR posts:

> Share the GitHub repository URL  
> Share the specific PR number or link  
> Tell me what API keys are failing or what errors you're seeing  
> Decision: Need repository context before proceeding

That's not bad memory — it's bad context. `scripts/persona-comment-runner.js:170` calls `instantiate(handle, { mode, task: <comment text only>, silent: true })`. The persona literally has none of the things oAudrey is asking for in her prompt, so she has no choice but to ask.

## What changed

### `scripts/persona-comment-runner.js`

Adds `gatherContext(repo, issueNumber)` that runs before `instantiate()`:

| What | Source |
|---|---|
| Repo URL + PR/issue number + title + URL | `gh pr view --json …` (falls back to `gh issue view` for plain issues) |
| Mergeable state + mergeStateStatus | Same |
| Branches, additions/deletions, changedFiles, labels, draft status | Same |
| PR description (first 2000 chars) | Same |
| Failing check runs on head SHA (top 8) | `gh api repos/.../commits/SHA/check-runs` filtered for `failure`/`cancelled`/`timed_out` |
| Diff head (up to 6000 chars, skipped if >50 files) | `gh pr diff N` |

`main()` then builds the persona task as:

```
## PR Context
- Repository: ...
- PR: #N — title
- Mergeable: ... / ...
- Failing checks: [...]
- Diff head: ```diff ... ```
---
User request:
<the comment text>

Note: you already have the repo, the PR/issue, the labels, the failing
checks, and the diff above. Do NOT ask the user to share these again —
diagnose from the context.
```

Soft-failed throughout — if any `gh` call dies, the function returns `""` and the persona falls back to the old behavior (asking). **No new failure modes**: worst case is identical to today.

## Before / after on the specific oAudrey post

**Before** (today):
> I need to see the specific PR and repository to help you fix the API key issues and get it merged. Could you please:
> - Share the GitHub repository URL
> - Share the specific PR number or link  
> …

**After** (with this PR merged):
> Looking at PR #N — `<branch>` → `main`, mergeStateStatus = `BLOCKING`. Failing checks: `Octopus Review` (procedural fast-fail, not content), `guard` (no-destroy or seo-a11y — see logs). API-key issue is in step "Run openrouter-coder" at line N of openrouter-coder.yml — the env var is referenced as `OPENROUTER_API_KEY` but no secret with that exact case exists; check whether you set it as `OPENROUTER_KEY`. Suggested fix: …

That's the difference between "useless" and "first line of sight."

## Test plan

- [x] Syntax-check passes (`node -c`)
- [ ] After merge: post `/oaudrey what's blocking this?` on any open PR — verify the reply names specific checks/labels instead of asking for them
- [ ] After merge: post `/professor what does the diff change?` — verify she cites the diff head, not asks for a link

## Cross-refs

- `scripts/openrouter-personas.js` (persona registry — system prompts unchanged; this PR just fixes what they receive at runtime)
- `.github/workflows/persona-comment-trigger.yml` (trigger — unchanged)
- Companion PRs in flight: #14068 (Octopus routing), #14091 (research preemptive inputs), #14092 (auto-resolve conflicts) — all separate concerns, no overlap

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes the issue where AI personas (like oAudrey) invoked via comments on PRs/issues would ask users for repository and PR context that should already be available. The change adds a new `gatherContext()` function that collects PR/issue metadata, failing check runs, diff summaries, labels, and other relevant information from the GitHub CLI before invoking the persona. This context is then injected into the persona's task prompt with an explicit instruction not to ask for information that's already provided, enabling personas to immediately diagnose issues instead of requesting basic context from users.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/persona-comment-runner.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects PR/issue context into persona comment runs so assistants stop asking for repo/PR details and can diagnose directly. The runner now prepends title, labels, state, failing checks, and a diff head to the task, and falls back safely if context can’t be fetched.

- New Features
  - Added `gatherContext(repo, issueNumber)` in `scripts/persona-comment-runner.js` using `gh pr view` (PR) or `gh issue view` (issue).
  - Captures repo, link, title, state, labels, mergeability/`mergeStateStatus`, branches, additions/deletions/changed files.
  - Pulls latest failing check runs for head SHA (top 8) and a truncated `gh pr diff` (6k chars; skipped if >50 files).
  - Augments persona task with the context and an instruction not to re-ask for it; soft-fails to previous behavior on any `gh` error.
  - Exports `gatherContext` from the module.

<sup>Written for commit 0500dfb4450d5c06bc26a185e67160d9adb99d0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

