### PR TITLE
fix(octopus-route): close the broken merge — duplicate const title + dangling else

### DIFF
--- a/.github/workflows/octopus-route.yml
+++ b/.github/workflows/octopus-route.yml
@@ -76,25 +76,16 @@ jobs:
               core.info(`Added labels to #${issueNumber}: ${labelsToAdd.join(', ')}`);
             } else {
               core.info(`#${issueNumber} already had work-request + wr:code; nothing to add.`);
+            }
+
+            // Prefix [WR] if not already present. Truncate the body so the
+            // total title stays <=256 chars (GitHub's issue-title cap).
             const title = issue.title || '';
             if (!/^\[WR\]/i.test(title)) {
               const PREFIX = '[WR] ';
               const maxBodyLen = 256 - PREFIX.length;
               const body = title.length > maxBodyLen ? title.slice(0, maxBodyLen) : title;
               const newTitle = `${PREFIX}${body}`;
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                title: newTitle,
-              });
-              core.info(`Prefixed title with [WR]: ${newTitle}`);
-            }
-
-            // Prefix [WR] if not already present.
-            const title = issue.title || '';
-            if (!/^\[WR\]/i.test(title)) {
-              const newTitle = `[WR] ${title}`.slice(0, 256);
               await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary

`octopus-route.yml` on main has a bad merge from #14068 — duplicate `const title` and an unclosed `else` block in the inline `actions/github-script` body. The route-single job would throw `SyntaxError: Identifier 'title' has already been declared` on first run. Confirmed today when checking the file post-merge.

Net effect of the bug:
- Every freshly opened Octopus issue silently fails to get translated → stays stuck (same problem we just merged #14068 to fix)
- The 73-issue backfill (`workflow_dispatch -f backfill=true`) can't run either

This PR is the cleanup commit.

## What changed

`.github/workflows/octopus-route.yml`:

- Closed the `else { ... }` block before the title-prefix logic
- Dropped the duplicated `const title = …` block
- Kept the safer truncation variant: `[WR] ` + `body.slice(0, 256 - PREFIX.length)` so a 256-char title containing the prefix still fits GitHub's title cap. The dropped duplicate used `\`[WR] ${title}\`.slice(0, 256)` which would silently chop the suffix on long titles.

## Verified

- `python3 -c "import yaml; yaml.safe_load(...)"` parses clean.
- Inline JS extracted from the `script:` step has balanced braces and a single `const title` declaration.
- Diff is 4 added / 13 removed — minimal, targets only the broken section.

## After this lands

The backfill becomes safe to dispatch. Reminder: 73 stuck Octopus issues × openrouter-coder = real OpenRouter cost. Still recommend the drip-feed approach when you're ready, but the *workflow* itself can now actually run.

docs-freshness: pure syntax-error bugfix to a workflow already documented in #14068 (PROVENANCE + AGENT_MONITORING_STANDARD updated there). No behavior change, no new lane introduced. The linter correctly fired on the touched-workflow rule; this marker silences it intentionally per the standard's escape-hatch (`docs/DOCS_FRESHNESS_STANDARD.md` §2).

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs