### PR TITLE
Stuck-PR sweeper + cross-repo deployment for the conflict-helper

### DIFF
--- a/.github/workflows/stuck-pr-sweep.yml
+++ b/.github/workflows/stuck-pr-sweep.yml
@@ -1,0 +1,158 @@
+name: Stuck PR Sweeper
+
+# ── Find every open PR with merge conflicts and re-trigger conflict-helper ──
+# Origin: the owner reported a queue of stuck PRs (#14082 21 conflicts,
+# #13805 38, #13951 25, datascope-standalone#4 10) blocking work, all
+# needing the auto-resolver from #14092. This workflow walks every open PR
+# whose mergeable_state is `dirty` and applies the `has-conflicts` label,
+# which is one of the triggers conflict-helper.yml watches — so the helper
+# fires once per stuck PR without anyone touching the branches.
+#
+# Triggers:
+#   - workflow_dispatch (manual: clear the queue on demand)
+#   - schedule (Mondays 13:00 UTC: weekly cleanup so PRs don't rot)
+#
+# Output:
+#   - Sticky comment on each stuck PR (label) → conflict-helper takes over
+#   - Summary job-summary listing each PR processed
+#
+# Never auto-resolves anything itself; that's conflict-helper's job. This
+# is the "kick" layer.
+# ────────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "If true, list stuck PRs without labeling them"
+        type: boolean
+        required: false
+        default: false
+      max_prs:
+        description: "Maximum PRs to process in one run (safety cap)"
+        type: number
+        required: false
+        default: 25
+  schedule:
+    # Mondays 13:00 UTC — early in the week so a fresh kick happens before
+    # owner returns to the queue.
+    - cron: "0 13 * * 1"
+
+permissions:
+  pull-requests: write
+  contents: read
+  issues: write
+
+concurrency:
+  group: stuck-pr-sweeper
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Label stuck PRs to re-trigger conflict-helper
+    runs-on: ubuntu-latest
+    steps:
+      - name: Walk open PRs and label the dirty ones
+        uses: actions/github-script@v9.0.0
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          MAX_PRS: ${{ github.event.inputs.max_prs || '25' }}
+        with:
+          script: |
+            const dryRun = String(process.env.DRY_RUN).toLowerCase() === 'true';
+            const maxPrs = Number.parseInt(process.env.MAX_PRS, 10) || 25;
+
+            // Walk every open PR. GitHub doesn't compute mergeable_state up-front,
+            // so we have to `get` each one to materialize the current value.
+            const listed = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const processed = [];
+            for (const pr of listed) {
+              if (processed.length >= maxPrs) break;
+
+              // Materialize mergeable_state (may take a moment for huge diffs).
+              const { data: full } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+
+              if (full.mergeable_state !== 'dirty') continue;
+
+              const existingLabels = (full.labels || []).map((l) => l.name);
+              const alreadyLabeled = existingLabels.includes('has-conflicts');
+
+              const note = alreadyLabeled
+                ? 'already labeled has-conflicts (helper re-fires on label update)'
+                : 'applying has-conflicts label to re-trigger conflict-helper';
+
+              core.info(`#${full.number}: ${full.title} — ${note}`);
+
+              if (!dryRun) {
+                if (!alreadyLabeled) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: full.number,
+                    labels: ['has-conflicts'],
+                  });
+                } else {
+                  // Bump the label so the conflict-helper's `labeled` trigger
+                  // refires on already-labeled PRs.
+                  await github.rest.issues
+                    .removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: full.number,
+                      name: 'has-conflicts',
+                    })
+                    .catch(() => {});
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: full.number,
+                    labels: ['has-conflicts'],
+                  });
+                }
+              }
+
+              processed.push({
+                number: full.number,
+                title: full.title,
+                url: full.html_url,
+                head: full.head.ref,
+                already_labeled: alreadyLabeled,
+              });
+            }
+
+            // Job summary so the run is auditable.
+            const summary = core.summary
+              .addHeading(`Stuck PR sweep — ${processed.length} PR(s) ${dryRun ? '[DRY RUN]' : 'kicked'}`, 2)
+              .addRaw(dryRun ? '_Dry run — no labels were applied._\n' : '')
+              .addRaw('\n');
+            if (processed.length === 0) {
+              summary.addRaw('No PRs with `mergeable_state: dirty` found.');
+            } else {
+              summary
+                .addTable([
+                  [
+                    { data: '#', header: true },
+                    { data: 'Title', header: true },
+                    { data: 'Branch', header: true },
+                    { data: 'Action', header: true },
+                  ],
+                  ...processed.map((p) => [
+                    `<a href="${p.url}">#${p.number}</a>`,
+                    p.title,
+                    `\`${p.head}\``,
+                    p.already_labeled ? 're-bumped label' : 'labeled has-conflicts',
+                  ]),
+                ]);
+            }
+            await summary.write();
+    timeout-minutes: 15

--- a/.github/workflows/stuck-pr-sweep.yml
+++ b/.github/workflows/stuck-pr-sweep.yml
@@ -28,11 +28,16 @@ on:
         type: boolean
         required: false
         default: false
-      max_prs:
-        description: "Maximum PRs to process in one run (safety cap)"
+      max_dirty:
+        description: "Stop after labeling this many DIRTY PRs (safety cap)"
         type: number
         required: false
         default: 25
+      max_inspected:
+        description: "Stop after inspecting this many open PRs total (rate-limit cap)"
+        type: number
+        required: false
+        default: 300
   schedule:
     # Mondays 13:00 UTC — early in the week so a fresh kick happens before
     # owner returns to the queue.
@@ -56,14 +61,19 @@ jobs:
         uses: actions/github-script@v9.0.0
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
-          MAX_PRS: ${{ github.event.inputs.max_prs || '25' }}
+          MAX_DIRTY: ${{ github.event.inputs.max_dirty || '25' }}
+          MAX_INSPECTED: ${{ github.event.inputs.max_inspected || '300' }}
         with:
           script: |
             const dryRun = String(process.env.DRY_RUN).toLowerCase() === 'true';
-            const maxPrs = Number.parseInt(process.env.MAX_PRS, 10) || 25;
+            const maxDirty = Number.parseInt(process.env.MAX_DIRTY, 10) || 25;
+            const maxInspected = Number.parseInt(process.env.MAX_INSPECTED, 10) || 300;
 
             // Walk every open PR. GitHub doesn't compute mergeable_state up-front,
-            // so we have to `get` each one to materialize the current value.
+            // so we have to `get` each one to materialize the current value —
+            // that's an API call per PR, so we cap total inspections separately
+            // from dirty-count to keep weekly cron runs predictable on
+            // hundred-PR queues (per Copilot review on #14099).
             const listed = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -72,10 +82,13 @@ jobs:
             });
 
             const processed = [];
+            let inspected = 0;
             for (const pr of listed) {
-              if (processed.length >= maxPrs) break;
+              if (processed.length >= maxDirty) break;
+              if (inspected >= maxInspected) break;
 
               // Materialize mergeable_state (may take a moment for huge diffs).
+              inspected++;
               const { data: full } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -134,6 +147,7 @@ jobs:
             const summary = core.summary
               .addHeading(`Stuck PR sweep — ${processed.length} PR(s) ${dryRun ? '[DRY RUN]' : 'kicked'}`, 2)
               .addRaw(dryRun ? '_Dry run — no labels were applied._\n' : '')
+              .addRaw(`Inspected ${inspected} / ${listed.length} open PR(s) before stopping (max_inspected cap: ${maxInspected}, max_dirty cap: ${maxDirty}).\n`)
               .addRaw('\n');
             if (processed.length === 0) {
               summary.addRaw('No PRs with `mergeable_state: dirty` found.');

--- a/scripts/deploy-conflict-helper-to-repos.sh
+++ b/scripts/deploy-conflict-helper-to-repos.sh
@@ -30,7 +30,11 @@ set -euo pipefail
 
 SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 DRY_RUN="${DRY_RUN:-false}"
-BRANCH_NAME="${BRANCH_NAME:-claude/import-conflict-helper}"
+# Suffix the branch name with a UTC timestamp so re-running this script
+# never collides with a leftover branch from a previous attempt (e.g. a
+# push that succeeded but the target repo never merged the resulting PR).
+# Override with `BRANCH_NAME` to pin if you really want to.
+BRANCH_NAME="${BRANCH_NAME:-claude/import-conflict-helper-$(date -u +%Y%m%dT%H%M%S)}"
 
 ARTIFACTS=(
   ".github/workflows/conflict-helper.yml"
@@ -140,7 +144,10 @@ for target in "${TARGETS[@]}"; do
     continue
   fi
 
-  # Apply.
+  # Apply. Track exactly which files were actually copied so the PR body
+  # reflects reality (per Copilot review on #14099 — earlier versions
+  # hard-coded a 2-file list while the script could copy 3).
+  copied_files=()
   for f in "${ARTIFACTS[@]}"; do
     src="$SOURCE_REPO_ROOT/$f"
     [[ -f "$src" ]] || continue
@@ -148,6 +155,7 @@ for target in "${TARGETS[@]}"; do
     cp "$src" "$f"
     git add "$f"
     echo "  + $f"
+    copied_files+=("$f")
   done
 
   git config user.email "deploy-conflict-helper@github-actions"
@@ -185,6 +193,15 @@ Imported by scripts/deploy-conflict-helper-to-repos.sh.
     continue
   fi
 
+  # Build the file list for the PR body from what was actually copied,
+  # not a hard-coded set. Keeps the description honest when the resolver
+  # script is absent (Phase-1-only deploy) or when the standard doc is
+  # missing.
+  files_md=""
+  for f in "${copied_files[@]:-}"; do
+    files_md+="- \`$f\`"$'\n'
+  done
+
   pr_url=$(gh pr create \
     --repo "$target" \
     --base "$(gh repo view "$target" --json defaultBranchRef --jq '.defaultBranchRef.name')" \
@@ -192,10 +209,8 @@ Imported by scripts/deploy-conflict-helper-to-repos.sh.
     --title "Import conflict-helper + auto-resolve from revvel-standards" \
     --body "Imports the merge-conflict auto-resolver workflow + script from \`midnghtsapphire/revvel-standards\` so this repo benefits from the same auto-resolve + Jules-fallback flow.
 
-Files:
-- \`.github/workflows/conflict-helper.yml\`
-- \`scripts/auto-resolve-mechanical-conflicts.js\`
-
+Files copied:
+${files_md}
 Merge to enable.
 " 2>/dev/null || true)
 

--- a/scripts/deploy-conflict-helper-to-repos.sh
+++ b/scripts/deploy-conflict-helper-to-repos.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Deploy the conflict-helper workflow + auto-resolver script to other repos
+# under the same owner. Drops them in via a fresh branch + PR so the target
+# repo's reviewers see exactly what's landing.
+#
+# Origin: the owner reported `datascope-standalone#4` (a non-revvel-standards
+# repo) stuck on the same kind of conflicts the revvel-standards
+# conflict-helper resolves automatically. Rather than copy/paste each time,
+# this script propagates the standard across `midnghtsapphire/*` repos.
+#
+# Usage:
+#   REPOS="midnghtsapphire/datascope-standalone midnghtsapphire/mind-mappr" \
+#     scripts/deploy-conflict-helper-to-repos.sh
+#
+#   # or pass a file with one `owner/repo` per line
+#   REPOS_FILE=/tmp/targets.txt scripts/deploy-conflict-helper-to-repos.sh
+#
+#   # dry-run (clone + commit but don't push or open PR)
+#   DRY_RUN=true scripts/deploy-conflict-helper-to-repos.sh
+#
+# Files copied:
+#   .github/workflows/conflict-helper.yml
+#   scripts/auto-resolve-mechanical-conflicts.js
+#   docs/CONFLICT_RESOLUTION_STANDARD.md           (if present)
+#
+# Requires: gh CLI authenticated, git, mktemp.
+# Skips any repo where the file already exists at HEAD (idempotent).
+
+set -euo pipefail
+
+SOURCE_REPO_ROOT="${SOURCE_REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+DRY_RUN="${DRY_RUN:-false}"
+BRANCH_NAME="${BRANCH_NAME:-claude/import-conflict-helper}"
+
+ARTIFACTS=(
+  ".github/workflows/conflict-helper.yml"
+  "scripts/auto-resolve-mechanical-conflicts.js"
+  "docs/CONFLICT_RESOLUTION_STANDARD.md"
+)
+
+# ── Resolve target list ─────────────────────────────────────────────────────
+
+if [[ -n "${REPOS:-}" ]]; then
+  read -r -a TARGETS <<< "$REPOS"
+elif [[ -n "${REPOS_FILE:-}" ]]; then
+  mapfile -t TARGETS < <(grep -v '^[[:space:]]*$' "$REPOS_FILE" | grep -v '^#')
+else
+  echo "error: set REPOS='owner/repo owner/repo' or REPOS_FILE=/path/to/list" >&2
+  exit 1
+fi
+
+# ── Verify source artifacts exist ───────────────────────────────────────────
+
+missing=()
+for f in "${ARTIFACTS[@]}"; do
+  src="$SOURCE_REPO_ROOT/$f"
+  if [[ ! -f "$src" ]]; then
+    # CONFLICT_RESOLUTION_STANDARD.md is optional (may not be merged yet).
+    if [[ "$f" == "docs/CONFLICT_RESOLUTION_STANDARD.md" ]]; then
+      echo "note: $f missing — will skip in copied set"
+      continue
+    fi
+    missing+=("$f")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  echo "error: source artifacts missing in $SOURCE_REPO_ROOT:" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 2
+fi
+
+# ── Per-repo loop ───────────────────────────────────────────────────────────
+
+opened_prs=()
+skipped=()
+
+for target in "${TARGETS[@]}"; do
+  echo
+  echo "==> $target"
+
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+
+  if ! gh repo clone "$target" "$tmp/repo" -- --depth=1 --no-tags >/dev/null 2>&1; then
+    echo "  skip: clone failed (auth / permissions?)"
+    skipped+=("$target (clone failed)")
+    continue
+  fi
+
+  cd "$tmp/repo"
+
+  # Idempotency check: skip if conflict-helper already exists on default branch.
+  if [[ -f ".github/workflows/conflict-helper.yml" ]]; then
+    echo "  skip: conflict-helper.yml already exists"
+    skipped+=("$target (already deployed)")
+    cd - >/dev/null
+    continue
+  fi
+
+  # Apply.
+  for f in "${ARTIFACTS[@]}"; do
+    src="$SOURCE_REPO_ROOT/$f"
+    [[ -f "$src" ]] || continue
+    mkdir -p "$(dirname "$f")"
+    cp "$src" "$f"
+    git add "$f"
+    echo "  + $f"
+  done
+
+  git config user.email "deploy-conflict-helper@github-actions"
+  git config user.name "Conflict Helper Deployer"
+
+  git checkout -b "$BRANCH_NAME" >/dev/null 2>&1
+
+  commit_msg="Import revvel-standards conflict-helper (auto-resolve + Jules fallback)
+
+Brings in the deterministic merge-conflict resolver from
+midnghtsapphire/revvel-standards. Two patterns auto-fire on every PR
+with conflicts:
+
+  - VERSION_BUMP — same uses: owner/repo@ref both sides, newer ref wins
+  - ADDITIVE — both sides added structurally additive rows, keep both
+
+Anything ambiguous gets handed to Jules via the existing lane (NOT
+Copilot, NOT Bito). See docs/CONFLICT_RESOLUTION_STANDARD.md (if
+present) or the source repo for the standard.
+
+Imported by scripts/deploy-conflict-helper-to-repos.sh.
+"
+  git commit -m "$commit_msg" >/dev/null
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "  [dry-run] would push branch + open PR"
+    cd - >/dev/null
+    continue
+  fi
+
+  if ! git push -u origin "$BRANCH_NAME" >/dev/null 2>&1; then
+    echo "  skip: push failed (branch protection? token scope?)"
+    skipped+=("$target (push failed)")
+    cd - >/dev/null
+    continue
+  fi
+
+  pr_url=$(gh pr create \
+    --repo "$target" \
+    --base "$(gh repo view "$target" --json defaultBranchRef --jq '.defaultBranchRef.name')" \
+    --head "$BRANCH_NAME" \
+    --title "Import conflict-helper + auto-resolve from revvel-standards" \
+    --body "Imports the merge-conflict auto-resolver workflow + script from \`midnghtsapphire/revvel-standards\` so this repo benefits from the same auto-resolve + Jules-fallback flow.
+
+Files:
+- \`.github/workflows/conflict-helper.yml\`
+- \`scripts/auto-resolve-mechanical-conflicts.js\`
+
+Merge to enable.
+" 2>/dev/null || true)
+
+  if [[ -n "$pr_url" ]]; then
+    echo "  → $pr_url"
+    opened_prs+=("$pr_url")
+  else
+    echo "  skip: PR creation failed"
+    skipped+=("$target (pr create failed)")
+  fi
+
+  cd - >/dev/null
+done
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+echo
+echo "================================================================"
+echo "Deployment summary"
+echo "================================================================"
+echo "Opened PRs: ${#opened_prs[@]}"
+printf '  %s\n' "${opened_prs[@]:-(none)}"
+echo
+echo "Skipped: ${#skipped[@]}"
+printf '  - %s\n' "${skipped[@]:-(none)}"

--- a/scripts/deploy-conflict-helper-to-repos.sh
+++ b/scripts/deploy-conflict-helper-to-repos.sh
@@ -50,27 +50,69 @@ else
 fi
 
 # ── Verify source artifacts exist ───────────────────────────────────────────
+#
+# Required: conflict-helper.yml (Phase 1 annotation — merged in #14072 to main).
+# Optional: auto-resolve-mechanical-conflicts.js (Phase 2 + 3 — merged in
+# #14092). Deploying without the resolver is still useful: target repos get
+# the annotation comment; once #14092 lands and you re-run, the resolver
+# layer goes with it.
+# Optional: docs/CONFLICT_RESOLUTION_STANDARD.md (also in #14092).
+#
+# Anything else missing is a hard error.
 
-missing=()
+OPTIONAL_FILES=(
+  "scripts/auto-resolve-mechanical-conflicts.js"
+  "docs/CONFLICT_RESOLUTION_STANDARD.md"
+)
+
+is_optional() {
+  local f="$1" o
+  for o in "${OPTIONAL_FILES[@]}"; do
+    [[ "$f" == "$o" ]] && return 0
+  done
+  return 1
+}
+
+missing_required=()
+missing_optional=()
 for f in "${ARTIFACTS[@]}"; do
   src="$SOURCE_REPO_ROOT/$f"
   if [[ ! -f "$src" ]]; then
-    # CONFLICT_RESOLUTION_STANDARD.md is optional (may not be merged yet).
-    if [[ "$f" == "docs/CONFLICT_RESOLUTION_STANDARD.md" ]]; then
-      echo "note: $f missing — will skip in copied set"
-      continue
+    if is_optional "$f"; then
+      echo "note: $f missing — will skip in copied set (Phase 1 deploy only)"
+      missing_optional+=("$f")
+    else
+      missing_required+=("$f")
     fi
-    missing+=("$f")
   fi
 done
 
-if (( ${#missing[@]} > 0 )); then
-  echo "error: source artifacts missing in $SOURCE_REPO_ROOT:" >&2
-  printf '  - %s\n' "${missing[@]}" >&2
+if (( ${#missing_required[@]} > 0 )); then
+  echo "error: required source artifacts missing in $SOURCE_REPO_ROOT:" >&2
+  printf '  - %s\n' "${missing_required[@]}" >&2
   exit 2
 fi
 
+if (( ${#missing_optional[@]} > 0 )); then
+  echo
+  echo "warning: optional artifacts missing — Phase 2 (auto-resolve) + Phase 3"
+  echo "(Jules dispatch) will not be deployed. Target repos will receive only"
+  echo "the annotation phase. Re-run after #14092 lands to ship the resolver."
+fi
+
 # ── Per-repo loop ───────────────────────────────────────────────────────────
+
+# Track every temp dir we create so we can clean them all up on exit
+# (one trap, not one-per-iteration — earlier versions overwrote the trap
+# inside the loop, leaking all but the last dir). Per-iteration cleanup
+# happens explicitly at the end of each loop body for the success path.
+TEMP_DIRS=()
+cleanup_temp_dirs() {
+  for d in "${TEMP_DIRS[@]:-}"; do
+    [[ -n "$d" && -d "$d" ]] && rm -rf "$d"
+  done
+}
+trap cleanup_temp_dirs EXIT
 
 opened_prs=()
 skipped=()
@@ -80,7 +122,7 @@ for target in "${TARGETS[@]}"; do
   echo "==> $target"
 
   tmp="$(mktemp -d)"
-  trap 'rm -rf "$tmp"' EXIT
+  TEMP_DIRS+=("$tmp")
 
   if ! gh repo clone "$target" "$tmp/repo" -- --depth=1 --no-tags >/dev/null 2>&1; then
     echo "  skip: clone failed (auth / permissions?)"


### PR DESCRIPTION
## Summary

Two follow-ups to #14092 that turn the conflict-helper from "per-PR" into "queue-wide" and from "this repo only" into "any midnghtsapphire/* repo." Directly answers the queue you flagged: #14082, #13805, #13951 + the cross-repo case `datascope-standalone#4`.

## What ships

### `.github/workflows/stuck-pr-sweep.yml`

- **Triggers**: `workflow_dispatch` (with `dry_run` + `max_prs` inputs) **+ Monday 13:00 UTC cron** for weekly hygiene.
- **Action**: walks every open PR, materializes each one's `mergeable_state` (GitHub doesn't compute it eagerly), and for every `dirty` PR applies (or re-bumps) the `has-conflicts` label. That label is already one of the conflict-helper's triggers, so the helper fires once per stuck PR without anyone touching the branches.
- **Safety**: `max_prs: 25` default cap prevents queue-storming; `dry_run: true` lists what it *would* label without doing anything.
- **Audit**: sticky job summary lists every PR processed with title, branch, action taken.

### `scripts/deploy-conflict-helper-to-repos.sh`

- **Usage**:
  ```bash
  REPOS="midnghtsapphire/datascope-standalone midnghtsapphire/mind-mappr" \
    scripts/deploy-conflict-helper-to-repos.sh
  ```
- For each target: clones `--depth=1`, copies `conflict-helper.yml` + `auto-resolve-mechanical-conflicts.js` + `CONFLICT_RESOLUTION_STANDARD.md` (if present), commits on a new branch, opens a PR titled "Import conflict-helper + auto-resolve from revvel-standards."
- **Idempotent**: skips repos where the workflow already exists.
- **`DRY_RUN=true`** clones + commits without pushing — safe to test.

## Net effect once #14092 lands

```
1. Merge #14092 (auto-resolver + Jules fallback).
2. Merge this PR (sweeper + cross-repo deployer).
3. `gh workflow run stuck-pr-sweep.yml` → walks the queue, labels every
   `mergeable_state: dirty` PR → conflict-helper fires on each →
   mechanical conflicts auto-resolve, ambiguity → Jules.
4. `REPOS=midnghtsapphire/datascope-standalone scripts/deploy-conflict-helper-to-repos.sh`
   → PR opens in datascope-standalone with the same workflow.
5. Weekly cron keeps the queue swept without intervention.
```

The queue you flagged (#14082, #13805, #13951, `datascope-standalone#4`) gets handled in one button press + one script invocation.

## Cost

- Sweeper: free (GH Actions native API calls)
- Deployer: free (local bash + `gh`)
- Conflict-helper itself: free (script in #14092) + Jules (already paid)
- **Total marginal cost per stuck PR cleared: $0**

## Test plan

- [x] YAML + bash syntax-check pass
- [ ] After merge of both: `gh workflow run stuck-pr-sweep.yml -f dry_run=true` → verify the listed PRs match your "Needs action" view
- [ ] Then: `gh workflow run stuck-pr-sweep.yml` (non-dry) → watch each PR get a `has-conflicts` label → conflict-helper sticky comment → resolution commit
- [ ] After: `DRY_RUN=true REPOS=midnghtsapphire/datascope-standalone scripts/deploy-conflict-helper-to-repos.sh` → verify the import PR draft looks right

## Cross-refs

- #14092 (the auto-resolver this orchestrates — depends-on for full Phase 2/3 behavior)
- `docs/CONFLICT_RESOLUTION_STANDARD.md` (in #14092)
- `docs/DOCS_FRESHNESS_STANDARD.md` (already merged)

docs-freshness: orchestration layer over the conflict-helper standard (which is being landed in #14092 alongside CONFLICT_RESOLUTION_STANDARD.md). No new lane introduced — sweeper just re-fires existing triggers; deployer just copies existing files. The linter correctly fired on the touched-workflow rule; this marker silences it intentionally per `docs/DOCS_FRESHNESS_STANDARD.md` §2.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs