### PR TITLE
Recovery Engine: hourly auto-recovery for stuck PRs and issues

### DIFF
--- a/.github/workflows/recovery-engine.yml
+++ b/.github/workflows/recovery-engine.yml
@@ -1,0 +1,277 @@
+name: PR & Issue Recovery Engine
+
+# ── Standing auto-recovery for stuck PRs and issues ─────────────────────────
+# Owner request: "make sure if these are stuck or whatever the issues it
+# gets picked up and reprocessed" (PR #14092 comment, 2026-05-29).
+#
+# Runs hourly. For each open PR + issue, classifies the stuck state and
+# applies the right targeted recovery:
+#
+#   Stuck PR state                   → Recovery action
+#   ──────────────────────────────    ───────────────────────────────────────
+#   mergeable_state == 'dirty'        → label has-conflicts (refires
+#                                       conflict-helper from #14072 / #14092)
+#   check in_progress > 45 min        → rerequest that check_run
+#   reviewer pending > 4 h            → label review:stuck (annotation only;
+#                                       no auto-dismiss — humans decide)
+#   Ralph Loop hit 5/5 same failure   → label needs-human + recovery:gave-up
+#
+#   Stuck issue state                → Recovery action
+#   ──────────────────────────────    ───────────────────────────────────────
+#   octopus-review w/o wr:code > 1 h  → label has-conflicts (kicks
+#                                       octopus-route translator)
+#   wr:new w/o motion > 24 h          → label recovery:stale-wr (annotation)
+#
+# Opt-out: apply label `recovery:hands-off` to any PR / issue to skip it.
+# Audit: every action is logged in the job summary and shown in actions tab.
+#
+# Designed to be IDEMPOTENT — re-running does the same thing (labels stay,
+# rerequests are deduped by check_run state, etc.). Cap on inspections
+# matches the sweeper for predictable cron cost.
+# ────────────────────────────────────────────────────────────────────────────
+
+on:
+  schedule:
+    # Hourly — top of each hour.
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "If true, classify stuck items without acting"
+        type: boolean
+        required: false
+        default: false
+      max_inspected:
+        description: "Stop after inspecting this many open items total"
+        type: number
+        required: false
+        default: 200
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+  checks: write
+
+concurrency:
+  group: recovery-engine
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    name: Classify + recover stuck PRs and issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Walk open PRs and issues, apply recovery actions
+        uses: actions/github-script@v9.0.0
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          MAX_INSPECTED: ${{ github.event.inputs.max_inspected || '200' }}
+        with:
+          script: |
+            const dryRun = String(process.env.DRY_RUN).toLowerCase() === 'true';
+            const maxInspected = Number.parseInt(process.env.MAX_INSPECTED, 10) || 200;
+
+            // Thresholds — tuned to be quiet by default; humans don't get
+            // pinged for short-lived "in progress" states.
+            const NOW = Date.now();
+            const HOUR = 60 * 60 * 1000;
+            const STUCK_CHECK_MS = 45 * 60 * 1000;     // 45 min
+            const STUCK_REVIEWER_MS = 4 * HOUR;        // 4 h
+            const STALE_OCTOPUS_MS = 1 * HOUR;         // 1 h
+            const STALE_WR_MS = 24 * HOUR;             // 24 h
+            const RALPH_EXHAUSTED_RE = /Ralph Loop.*Attempt 5\/5/i;
+
+            const hasLabel = (labels, name) =>
+              (labels || []).some((l) => (typeof l === 'string' ? l : l.name) === name);
+
+            const ensureLabel = async (issueNumber, name, color = 'ededed', description = '') => {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues
+                    .createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name,
+                      color,
+                      description,
+                    })
+                    .catch(() => {});
+                }
+              }
+              if (dryRun) return;
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [name],
+              }).catch(() => {});
+            };
+
+            const actions = [];
+            let inspected = 0;
+
+            // ── PRs ────────────────────────────────────────────────────────
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            for (const pr of prs) {
+              if (inspected >= maxInspected) break;
+              inspected++;
+
+              const { data: full } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+
+              const labels = full.labels || [];
+              if (hasLabel(labels, 'recovery:hands-off')) continue;
+
+              // 1) Merge conflicts — re-fire conflict-helper via label.
+              if (full.mergeable_state === 'dirty' && !hasLabel(labels, 'has-conflicts')) {
+                actions.push({ kind: 'PR', n: pr.number, action: 'label has-conflicts (dirty)' });
+                await ensureLabel(pr.number, 'has-conflicts', 'd93f0b',
+                  'Set by recovery-engine when mergeable_state is dirty');
+                continue;
+              }
+
+              // 2) Stuck check runs (in_progress > 45 min) — rerequest.
+              const sha = full.head?.sha;
+              if (sha) {
+                const { data: checks } = await github.rest.checks.listForRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: sha,
+                  per_page: 100,
+                });
+                for (const run of checks.check_runs || []) {
+                  if (run.status !== 'in_progress') continue;
+                  const startedAt = Date.parse(run.started_at || '');
+                  if (!startedAt) continue;
+                  if (NOW - startedAt < STUCK_CHECK_MS) continue;
+                  actions.push({
+                    kind: 'PR',
+                    n: pr.number,
+                    action: `rerequest check_run "${run.name}" (in_progress ${Math.round((NOW - startedAt) / 60000)} min)`,
+                  });
+                  if (!dryRun) {
+                    await github.rest.checks
+                      .rerequestSuite({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        check_suite_id: run.check_suite?.id,
+                      })
+                      .catch(() => {});
+                  }
+                }
+              }
+
+              // 3) Ralph Loop exhausted — escalate.
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const ralphExhausted = comments.some((c) => RALPH_EXHAUSTED_RE.test(c.body || ''));
+              if (ralphExhausted && !hasLabel(labels, 'needs-human')) {
+                actions.push({ kind: 'PR', n: pr.number, action: 'label needs-human + recovery:gave-up (Ralph 5/5)' });
+                await ensureLabel(pr.number, 'needs-human', 'e99695',
+                  'Recovery engine could not auto-clear; human required');
+                await ensureLabel(pr.number, 'recovery:gave-up', 'e99695',
+                  'Recovery engine has exhausted automatic recovery options');
+              }
+
+              // 4) Reviewer pending too long — annotate (no auto-dismiss).
+              const reviewers = (full.requested_reviewers || []).map((u) => u.login);
+              if (reviewers.length > 0) {
+                const updatedAt = Date.parse(full.updated_at || '');
+                if (updatedAt && NOW - updatedAt > STUCK_REVIEWER_MS &&
+                    !hasLabel(labels, 'review:stuck')) {
+                  actions.push({
+                    kind: 'PR',
+                    n: pr.number,
+                    action: `label review:stuck (reviewers ${reviewers.join(', ')} pending > 4 h)`,
+                  });
+                  await ensureLabel(pr.number, 'review:stuck', 'fbca04',
+                    'Reviewer request has been pending for over 4 hours');
+                }
+              }
+            }
+
+            // ── Issues ─────────────────────────────────────────────────────
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue; // pulls already handled above
+              if (inspected >= maxInspected) break;
+              inspected++;
+
+              const labels = issue.labels || [];
+              if (hasLabel(labels, 'recovery:hands-off')) continue;
+
+              // 5) Octopus issue without wr:code for too long → kick translator.
+              const isOctopus = hasLabel(labels, 'octopus-review');
+              const hasWrCode = hasLabel(labels, 'wr:code');
+              const createdAt = Date.parse(issue.created_at || '');
+              if (isOctopus && !hasWrCode && createdAt && NOW - createdAt > STALE_OCTOPUS_MS) {
+                actions.push({
+                  kind: 'Issue',
+                  n: issue.number,
+                  action: 'label has-conflicts (kicks octopus-route translator)',
+                });
+                await ensureLabel(issue.number, 'has-conflicts', 'd93f0b',
+                  'Set by recovery-engine to re-fire octopus-route');
+                continue;
+              }
+
+              // 6) wr:new without motion → annotate.
+              const isStaleWr = hasLabel(labels, 'wr:new');
+              const updatedAt = Date.parse(issue.updated_at || '');
+              if (isStaleWr && updatedAt && NOW - updatedAt > STALE_WR_MS &&
+                  !hasLabel(labels, 'recovery:stale-wr')) {
+                actions.push({
+                  kind: 'Issue',
+                  n: issue.number,
+                  action: `label recovery:stale-wr (wr:new, no motion > 24 h)`,
+                });
+                await ensureLabel(issue.number, 'recovery:stale-wr', 'fbca04',
+                  'WR has been wr:new for over 24 hours without motion');
+              }
+            }
+
+            // ── Summary ────────────────────────────────────────────────────
+            const summary = core.summary
+              .addHeading(`Recovery sweep — ${actions.length} action(s) ${dryRun ? '[DRY RUN]' : 'applied'}`, 2)
+              .addRaw(`Inspected ${inspected} item(s). Cap: ${maxInspected}.\n`)
+              .addRaw(dryRun ? '\n_Dry run — no labels or check-reruns were applied._\n' : '\n');
+            if (actions.length === 0) {
+              summary.addRaw('Nothing stuck — queue is clean.');
+            } else {
+              summary.addTable([
+                [
+                  { data: 'Kind', header: true },
+                  { data: '#', header: true },
+                  { data: 'Action', header: true },
+                ],
+                ...actions.map((a) => [a.kind, `#${a.n}`, a.action]),
+              ]);
+            }
+            await summary.write();
+    timeout-minutes: 15


### PR DESCRIPTION
## Summary

Direct answer to "make sure if these are stuck or whatever the issues it gets picked up and reprocessed" (your comment on #14092).

Standing **hourly cron** that walks every open PR + issue, classifies stuck states, and applies the right targeted recovery. The queue self-clears without you running the sweeper manually.

## Stuck → recovery mapping

| Item | Stuck condition | Recovery action |
|---|---|---|
| **PR** | `mergeable_state == 'dirty'` | Label `has-conflicts` → fires conflict-helper |
| **PR** | Check in_progress > 45 min | Rerequest the check suite |
| **PR** | Reviewer pending > 4 h | Label `review:stuck` (annotation; no auto-dismiss — humans decide) |
| **PR** | Ralph Loop hit 5/5 on same failure | Label `needs-human` + `recovery:gave-up` |
| **Issue** | `octopus-review` without `wr:code` > 1 h | Label `has-conflicts` (kicks octopus-route) |
| **Issue** | `wr:new` no motion > 24 h | Label `recovery:stale-wr` |

Tuned **quiet by default** — short-lived "in progress" states don't trigger anything. Opt-out per PR/issue with `recovery:hands-off`.

## Triggers

- **Schedule**: `0 * * * *` (top of each hour)
- **Manual**: `workflow_dispatch` with `dry_run` (classify without acting) + `max_inspected` (cap, default 200)

## Cost

- Free. GitHub Actions native API calls + label applications. No LLM, no per-PR spend.
- Inspection cap keeps hourly cron predictable on hundred-PR queues.

## Audit trail

Every action surfaces in the job summary with kind / number / action. Labels self-document via description. No silent state changes.

## How this composes with the rest

```
recovery-engine (hourly)
   │
   ├── PR dirty?         → label has-conflicts → conflict-helper (Phase 1: annotate, 
   │                                              Phase 2: auto-resolve in #14092,
   │                                              Phase 3: Jules in #14092)
   │
   ├── Check stuck?      → rerequest suite     → CI runs again from scratch
   │
   ├── Reviewer stuck?   → label review:stuck   → human inspects + decides
   │
   ├── Ralph Loop dead?  → needs-human          → human triage
   │
   ├── Octopus issue?    → label has-conflicts  → octopus-route runs translator
   │
   └── Stale WR?         → label recovery:stale-wr → visible queue marker
```

Cross-refs:
- #14092 (auto-resolve + Jules fallback — recovery-engine's downstream for `has-conflicts`)
- #14099 (manual sweeper — kept; useful for on-demand kicks. Hourly engine handles the standing case.)
- `docs/CONFLICT_RESOLUTION_STANDARD.md` (in #14092)

## Test plan

- [x] YAML syntax-check passes
- [ ] After merge: first hourly run inspects the current queue → dry-run mode via `gh workflow run recovery-engine.yml -f dry_run=true` to preview what it would do
- [ ] Then: monitor labels appearing across the queue in the next few hours

docs-freshness: orchestration layer composing the existing conflict-helper (#14072) + octopus-route (#14068/#14094) + the upcoming auto-resolve (#14092). No new standard introduced — this is a runtime mechanism over the standards already documented.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces an hourly automated recovery system that monitors all open pull requests and issues for stuck states and applies targeted recovery actions. The workflow detects issues like merge conflicts, stalled CI checks (over 45 minutes), pending reviewers (over 4 hours), exhausted retry loops, and stale work requests, then automatically applies appropriate labels or rerequests checks to get things moving again. It runs at the top of every hour via cron schedule, caps inspection at 200 items for predictable runtime, supports dry-run mode for testing, and respects a `recovery:hands-off` opt-out label. This complements existing workflows like `conflict-helper` and `octopus-route` by automatically triggering them when needed, creating a self-healing queue that reduces manual intervention.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/recovery-engine.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an hourly recovery engine that scans open PRs and issues, detects stuck states, and applies targeted fixes so the queue self-clears. Supports dry-run and per-item opt-out.

- New Features
  - Runs hourly (`0 * * * *`) and can be started manually via `workflow_dispatch` with `dry_run` and `max_inspected` (default 200).
  - PR recovery: `mergeable_state: dirty` → label `has-conflicts`; checks in_progress > 45 min → re-request suite; reviewers pending > 4h → label `review:stuck`; Ralph loop 5/5 → labels `needs-human` + `recovery:gave-up`.
  - Issue recovery: `octopus-review` without `wr:code` > 1h → label `has-conflicts`; `wr:new` idle > 24h → label `recovery:stale-wr`.
  - Integrates with conflict-helper/auto-resolve in #14092 via `has-conflicts`. Opt-out via `recovery:hands-off`. Actions are logged in the job summary.

<sup>Written for commit 609b0b462e17e491c2b7a4d15445c14b0c6f8a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

