### PR TITLE
fix(docs-freshness): defensive — read PR body from event, soft-fail comments

### DIFF
--- a/.github/workflows/docs-freshness-check.yml
+++ b/.github/workflows/docs-freshness-check.yml
@@ -43,17 +43,27 @@ jobs:
         run: |
           set +e
           # Make the base ref reachable. If the depth-100 fetch can't reach
-          # BASE_SHA on long-lived branches, fall back to fetching unshallow
-          # so `git diff` against BASE_SHA always works. Both fetches are
-          # idempotent — second is a no-op if first already covered it.
-          git fetch origin "$BASE_REF" --depth=100 2>/dev/null
+          # BASE_SHA on long-lived branches, deepen the SAME base ref rather
+          # than fetching every branch (the earlier wide-refspec fallback
+          # added meaningful network cost on large repos for no extra value;
+          # all we need is BASE_SHA — per Copilot review on #14102).
+          # `2>&1` keeps stderr in the run log so debugging is possible;
+          # `|| true` is what makes the step soft-fail, not redirection.
+          git fetch origin "$BASE_REF" --depth=100 2>&1 || true
           if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
-            git fetch origin --unshallow 2>/dev/null \
-              || git fetch origin "+refs/heads/*:refs/remotes/origin/*" --depth=10000 2>/dev/null
+            git fetch origin "$BASE_REF" --depth=10000 2>&1 || true
+            if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+              git fetch origin --unshallow 2>&1 || true
+            fi
           fi
           # Compute the diff; if even this fails (very rare), write empty
           # so the JS step still runs and posts nothing instead of erroring.
-          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "")
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>&1)
+          DIFF_RC=$?
+          if [[ "$DIFF_RC" -ne 0 ]]; then
+            echo "git diff failed (rc=$DIFF_RC): $CHANGED" >&2
+            CHANGED=""
+          fi
           echo "$CHANGED" > "$RUNNER_TEMP/changed.txt"
           echo "Changed files:"
           echo "$CHANGED"
@@ -65,8 +75,10 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            // Read changed-files from the previous step; fall through to
-            // empty if the file isn't there.
+            // Read changed-files from the previous step. If the file is
+            // missing (shouldn't happen — the bash step always writes it,
+            // even empty), warn and skip the rest. Comment now matches
+            // actual behavior — per Copilot review on #14102.
             let changed = [];
             try {
               changed = fs.readFileSync(

--- a/.github/workflows/docs-freshness-check.yml
+++ b/.github/workflows/docs-freshness-check.yml
@@ -41,25 +41,49 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch origin "$BASE_REF" --depth=100
-          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          set +e
+          # Make the base ref reachable. If the depth-100 fetch can't reach
+          # BASE_SHA on long-lived branches, fall back to fetching unshallow
+          # so `git diff` against BASE_SHA always works. Both fetches are
+          # idempotent — second is a no-op if first already covered it.
+          git fetch origin "$BASE_REF" --depth=100 2>/dev/null
+          if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+            git fetch origin --unshallow 2>/dev/null \
+              || git fetch origin "+refs/heads/*:refs/remotes/origin/*" --depth=10000 2>/dev/null
+          fi
+          # Compute the diff; if even this fails (very rare), write empty
+          # so the JS step still runs and posts nothing instead of erroring.
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "")
           echo "$CHANGED" > "$RUNNER_TEMP/changed.txt"
           echo "Changed files:"
           echo "$CHANGED"
+          # Always succeed — this is a soft-warn check.
+          exit 0
 
       - name: Evaluate rules and post warning
         uses: actions/github-script@v9.0.0
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
         with:
           script: |
             const fs = require('fs');
-            const changed = fs.readFileSync(
-              `${process.env.RUNNER_TEMP}/changed.txt`, 'utf8'
-            ).split('\n').filter(Boolean);
+            // Read changed-files from the previous step; fall through to
+            // empty if the file isn't there.
+            let changed = [];
+            try {
+              changed = fs.readFileSync(
+                `${process.env.RUNNER_TEMP}/changed.txt`, 'utf8'
+              ).split('\n').filter(Boolean);
+            } catch (e) {
+              core.warning(`Could not read changed-files: ${e.message}. Skipping.`);
+              return;
+            }
+
+            // Read PR body from the event payload directly. Earlier versions
+            // passed it via env var, which failed silently on very long PR
+            // descriptions or bodies with special characters — making the
+            // whole job fail the check status. Direct read avoids that.
+            const body = context.payload.pull_request?.body || '';
 
             // Escape-hatch: any `docs-freshness:` marker in PR body suppresses.
-            const body = process.env.PR_BODY || '';
             if (/docs-freshness:/i.test(body)) {
               core.info('PR body contains docs-freshness: marker — suppressing warning.');
               return;
@@ -127,20 +151,26 @@ jobs:
 
             if (violations.length === 0) {
               // Clean up any prior comment so a green PR doesn't carry stale warnings.
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                per_page: 100,
-              });
-              const existing = comments.find(c => c.body && c.body.includes(marker));
-              if (existing) {
-                await github.rest.issues.updateComment({
+              // Wrap every API call in try/catch — a permissions issue or
+              // transient error must not fail this informational check.
+              try {
+                const { data: comments } = await github.rest.issues.listComments({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body: `${marker}\n## ✅ Docs Freshness — all pairings satisfied\n\nNo unfulfilled docs/code pairings detected. See \`docs/DOCS_FRESHNESS_STANDARD.md\` for the rules.`,
+                  issue_number: context.payload.pull_request.number,
+                  per_page: 100,
                 });
+                const existing = comments.find(c => c.body && c.body.includes(marker));
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                    body: `${marker}\n## ✅ Docs Freshness — all pairings satisfied\n\nNo unfulfilled docs/code pairings detected. See \`docs/DOCS_FRESHNESS_STANDARD.md\` for the rules.`,
+                  });
+                }
+              } catch (e) {
+                core.warning(`Failed to update sticky comment (non-fatal): ${e.message}`);
               }
               core.info('No docs-freshness violations.');
               return;
@@ -165,26 +195,32 @@ jobs:
             ];
 
             const newBody = lines.join('\n');
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: newBody,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            // Wrap comment posting in try/catch so a 403 / rate-limit / 422
+            // doesn't fail the entire informational check.
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: newBody,
+                per_page: 100,
               });
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: newBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: newBody,
+                });
+              }
+            } catch (e) {
+              core.warning(`Failed to post / update sticky comment (non-fatal): ${e.message}`);
             }
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

The `Lint docs/code pairings` check failed on #14092 (large PR body with code blocks). Three real reliability bugs surfaced — fixing all three.

The linter is designed as **informational only** ("never blocks merge" — its own header says so), but in practice it was failing the check status because the job itself was crashing before getting to the "I'm informational" branch. This PR makes it actually live up to that promise.

## Bugs fixed

### 1. PR body via env-var truncates on large/complex bodies
```yaml
env:
  PR_BODY: ${{ github.event.pull_request.body }}
```
On PR descriptions with heavy code blocks or special characters, the env-var passing through `${{ }}` can fail before the JS step even runs.

**Fix**: read body directly via `context.payload.pull_request?.body` inside the JS. No env limits, no encoding edge cases.

### 2. Bash diff step has no error handling
```bash
git fetch origin "$BASE_REF" --depth=100
CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
```
On long-lived branches, the shallow fetch can miss `BASE_SHA`; then `git diff` exits non-zero and fails the step.

**Fix**: explicit `set +e`, a fallback `git fetch --unshallow`, and `exit 0` at the end. If the diff genuinely can't be computed, the JS step reads empty and skips gracefully.

### 3. Comment API calls had no try/catch
A 403 / 422 / rate-limit on any of `listComments` / `createComment` / `updateComment` would fail the whole job.

**Fix**: wrap each API-call block in `try/catch` with `core.warning` so the issue is logged but never fails the check.

## Net effect

The linter now genuinely behaves as informational. CI status from this check should be `success` on every PR regardless of:
- PR body shape (length, code blocks, special chars)
- Branch age (shallow fetch reachability)
- Transient API errors

If there are violations, they still surface as a sticky comment — the user-visible behavior is unchanged.

docs-freshness: defensive fix to the freshness linter itself; no new lane, no behavior change to the standard. The escape-hatch marker silences the linter's own catch on this PR per `docs/DOCS_FRESHNESS_STANDARD.md` §2.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes three reliability bugs in the docs-freshness linter CI check to ensure it truly behaves as informational-only and never blocks merge. The changes include: reading the PR body directly from the event payload instead of environment variables (which truncates on large/complex bodies), adding error handling to the bash `git diff` step with fallback to unshallow fetch for long-lived branches, and wrapping all GitHub API calls in try/catch blocks to prevent transient API errors from failing the check. These defensive improvements ensure the check status is always `success` regardless of PR body shape, branch age, or API failures, while still posting sticky comments for violations when possible.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/docs-freshness-check.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the docs-freshness linter truly informational. It no longer fails the check due to large PR bodies, unreachable base SHAs in shallow clones, or comment API errors. Violations still show as a sticky comment; the check stays green.

- **Bug Fixes**
  - Read PR body from the event payload inside `actions/github-script` to avoid env var truncation/encoding issues.
  - Make the diff step robust and non-fatal: progressively deepen only the base ref (depth=100 → 10000 → `--unshallow`), preserve stderr in logs, capture `git diff` stderr/exit code, and always exit 0.
  - Soft-fail comment operations: wrap `listComments`, `createComment`, and `updateComment` in try/catch with warnings; if changed-files can’t be read, warn and skip; fix JS comments to match behavior.

<sup>Written for commit e742a9def4daaa897a927beafb8c482cdfe63ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

