### PR TITLE
fix: unstick Octopus WRs — octopus-route on `labeled` + recovery-engine label fix

### DIFF
--- a/.github/workflows/octopus-route.yml
+++ b/.github/workflows/octopus-route.yml
@@ -56,11 +56,16 @@ concurrency:
 
 jobs:
   route-single:
-    name: Translate labels for a freshly opened Octopus issue
+    name: Translate labels on an Octopus issue (opened or recovery-labeled)
     # Fires on:
     #   - issues: opened   when Octopus files something new
-    #   - issues: labeled  when the recovery-engine applies
-    #                      `recovery:translate-me` to a stuck older Octopus issue
+    #   - issues: labeled  when a maintainer (or future external token-holder)
+    #                      applies `recovery:translate-me`. NB: workflows
+    #                      using the default GITHUB_TOKEN CANNOT trigger this
+    #                      path due to GitHub's anti-recursion rule —
+    #                      recovery-engine.yml therefore translates inline
+    #                      under its own token instead of cascading through
+    #                      this trigger (per Copilot review on PR #14107).
     if: |-
       github.event_name == 'issues' &&
       github.event.issue.user.login == 'octopus-review[bot]' &&
@@ -135,8 +140,33 @@ jobs:
           MAX_ISSUES: ${{ github.event.inputs.max_issues || '100' }}
         with:
           script: |
-            const rateLimitMinutes = Number.parseInt(process.env.RATE_LIMIT_MINUTES, 10) || 0;
-            const maxIssues = Number.parseInt(process.env.MAX_ISSUES, 10) || 100;
+            // Per Copilot review on PR #14107:
+            //   (1) Use Number.isFinite to avoid `0 || default` swallowing
+            //       an explicit max_issues=0 (the previous `|| 100` would
+            //       turn 0 into 100).
+            //   (2) Cap rateLimitMinutes * maxIssues to a safe job budget
+            //       so a drip-feed run can't hit GitHub's 6h timeout and
+            //       leave the queue half-translated with no resume.
+            const rawRate = Number.parseInt(process.env.RATE_LIMIT_MINUTES, 10);
+            const rateLimitMinutes = Number.isFinite(rawRate) ? Math.max(0, rawRate) : 0;
+            const rawMax = Number.parseInt(process.env.MAX_ISSUES, 10);
+            const maxIssues = Number.isFinite(rawMax) ? Math.max(0, rawMax) : 100;
+
+            const SAFE_JOB_BUDGET_MIN = 300; // 5h — leaves headroom under the 6h cap.
+            const plannedMinutes = rateLimitMinutes * Math.max(maxIssues - 1, 0);
+            if (plannedMinutes > SAFE_JOB_BUDGET_MIN) {
+              core.setFailed(
+                `rate_limit_minutes (${rateLimitMinutes}) × (max_issues - 1) = ${plannedMinutes} min ` +
+                `exceeds the safe job budget of ${SAFE_JOB_BUDGET_MIN} min. ` +
+                `Lower max_issues or rate_limit_minutes, or split across multiple dispatches.`
+              );
+              return;
+            }
+
+            if (maxIssues === 0) {
+              core.notice('max_issues=0 — nothing to do.');
+              return;
+            }
 
             const iter = github.paginate.iterator(
               github.rest.search.issuesAndPullRequests,
@@ -184,9 +214,10 @@ jobs:
                   core.info(`#${issue.number}: added ${toAdd.join(', ')} (${processed}/${maxIssues})`);
                   translated++;
                   // Drip-feed: pause between issues so downstream
-                  // openrouter-coder runs spread out instead of bursting,
-                  // keeping the cost curve gentle.
-                  if (rateLimitMinutes > 0) {
+                  // openrouter-coder runs spread out. Don't sleep after the
+                  // last issue or when we're already at the cap — pointless
+                  // runner-minute burn (per Copilot review on PR #14107).
+                  if (rateLimitMinutes > 0 && processed < maxIssues) {
                     core.info(`Sleeping ${rateLimitMinutes} min before next issue...`);
                     await sleep(rateLimitMinutes * 60 * 1000);
                   }

--- a/.github/workflows/octopus-route.yml
+++ b/.github/workflows/octopus-route.yml
@@ -23,7 +23,11 @@ name: Octopus Issue Router
 
 on:
   issues:
-    types: [opened]
+    # `opened` covers newly-filed Octopus issues. `labeled` is the recovery
+    # hook the recovery-engine uses to re-translate issues that missed the
+    # original opened-event window (the original engine labeled them
+    # `has-conflicts` which did NOTHING here — fixed in this PR).
+    types: [opened, labeled]
   workflow_dispatch:
     inputs:
       backfill:
@@ -31,6 +35,16 @@ on:
         type: boolean
         required: false
         default: false
+      rate_limit_minutes:
+        description: "Minutes to sleep between issues during backfill (0 = burst). Use 5–15 to drip-feed costs."
+        type: number
+        required: false
+        default: 0
+      max_issues:
+        description: "Maximum issues to process in this run (safety cap)"
+        type: number
+        required: false
+        default: 100
 
 permissions:
   issues: write
@@ -43,9 +57,15 @@ concurrency:
 jobs:
   route-single:
     name: Translate labels for a freshly opened Octopus issue
+    # Fires on:
+    #   - issues: opened   when Octopus files something new
+    #   - issues: labeled  when the recovery-engine applies
+    #                      `recovery:translate-me` to a stuck older Octopus issue
     if: |-
       github.event_name == 'issues' &&
-      github.event.issue.user.login == 'octopus-review[bot]'
+      github.event.issue.user.login == 'octopus-review[bot]' &&
+      (github.event.action == 'opened' ||
+       (github.event.action == 'labeled' && github.event.label.name == 'recovery:translate-me'))
     runs-on: ubuntu-latest
     steps:
       - name: Translate labels + ensure [WR] title prefix
@@ -110,8 +130,14 @@ jobs:
     steps:
       - name: Walk open octopus-review[bot] issues
         uses: actions/github-script@v9.0.0
+        env:
+          RATE_LIMIT_MINUTES: ${{ github.event.inputs.rate_limit_minutes || '0' }}
+          MAX_ISSUES: ${{ github.event.inputs.max_issues || '100' }}
         with:
           script: |
+            const rateLimitMinutes = Number.parseInt(process.env.RATE_LIMIT_MINUTES, 10) || 0;
+            const maxIssues = Number.parseInt(process.env.MAX_ISSUES, 10) || 100;
+
             const iter = github.paginate.iterator(
               github.rest.search.issuesAndPullRequests,
               {
@@ -122,8 +148,14 @@ jobs:
 
             let translated = 0;
             let skipped = 0;
+            let processed = 0;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
             for await (const { data } of iter) {
               for (const issue of data.items) {
+                if (processed >= maxIssues) break;
+                processed++;
+
                 const labels = (issue.labels || [])
                   .map(l => typeof l === 'string' ? l : l.name);
 
@@ -149,13 +181,21 @@ jobs:
                 }
 
                 if (toAdd.length > 0) {
-                  core.info(`#${issue.number}: added ${toAdd.join(', ')}`);
+                  core.info(`#${issue.number}: added ${toAdd.join(', ')} (${processed}/${maxIssues})`);
                   translated++;
+                  // Drip-feed: pause between issues so downstream
+                  // openrouter-coder runs spread out instead of bursting,
+                  // keeping the cost curve gentle.
+                  if (rateLimitMinutes > 0) {
+                    core.info(`Sleeping ${rateLimitMinutes} min before next issue...`);
+                    await sleep(rateLimitMinutes * 60 * 1000);
+                  }
                 } else {
-                  core.info(`#${issue.number}: already labeled`);
+                  core.info(`#${issue.number}: already labeled (${processed}/${maxIssues})`);
                   skipped++;
                 }
               }
+              if (processed >= maxIssues) break;
             }
 
             core.summary

--- a/.github/workflows/recovery-engine.yml
+++ b/.github/workflows/recovery-engine.yml
@@ -227,6 +227,11 @@ jobs:
               if (hasLabel(labels, 'recovery:hands-off')) continue;
 
               // 5) Octopus issue without wr:code for too long → kick translator.
+              // Octopus-route fires on `issues: labeled` when this exact label
+              // is applied (octopus-route.yml triggers on `recovery:translate-me`).
+              // Earlier this code applied `has-conflicts` which did nothing —
+              // that label triggers conflict-helper, which doesn't handle
+              // issues. Fixed in this PR.
               const isOctopus = hasLabel(labels, 'octopus-review');
               const hasWrCode = hasLabel(labels, 'wr:code');
               const createdAt = Date.parse(issue.created_at || '');
@@ -234,10 +239,23 @@ jobs:
                 actions.push({
                   kind: 'Issue',
                   n: issue.number,
-                  action: 'label has-conflicts (kicks octopus-route translator)',
+                  action: 'label recovery:translate-me (fires octopus-route)',
                 });
-                await ensureLabel(issue.number, 'has-conflicts', 'd93f0b',
-                  'Set by recovery-engine to re-fire octopus-route');
+                // Toggle the label so a re-apply re-fires the issues: labeled
+                // event even if the label was already there (e.g., from a
+                // previous run that didn't translate cleanly).
+                if (hasLabel(labels, 'recovery:translate-me') && !dryRun) {
+                  await github.rest.issues
+                    .removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: issue.number,
+                      name: 'recovery:translate-me',
+                    })
+                    .catch(() => {});
+                }
+                await ensureLabel(issue.number, 'recovery:translate-me', 'd93f0b',
+                  'Set by recovery-engine to re-fire octopus-route on a stale Octopus issue');
                 continue;
               }
 

--- a/.github/workflows/recovery-engine.yml
+++ b/.github/workflows/recovery-engine.yml
@@ -226,36 +226,54 @@ jobs:
               const labels = issue.labels || [];
               if (hasLabel(labels, 'recovery:hands-off')) continue;
 
-              // 5) Octopus issue without wr:code for too long → kick translator.
-              // Octopus-route fires on `issues: labeled` when this exact label
-              // is applied (octopus-route.yml triggers on `recovery:translate-me`).
-              // Earlier this code applied `has-conflicts` which did nothing —
-              // that label triggers conflict-helper, which doesn't handle
-              // issues. Fixed in this PR.
+              // 5) Octopus issue without wr:code for too long → translate INLINE.
+              // Earlier versions tried to cascade via labels (`has-conflicts` →
+              // wrong workflow; then `recovery:translate-me` → blocked by
+              // GitHub's anti-recursion rule, which prevents a workflow using
+              // GITHUB_TOKEN from triggering another workflow via the
+              // `issues: labeled` event). Both broken. Per Copilot review on
+              // #14107: inline the work here instead of cascading. The
+              // translation is small — exactly the same three operations
+              // octopus-route does — and runs under the recovery-engine's
+              // own token, no cross-workflow fire needed.
               const isOctopus = hasLabel(labels, 'octopus-review');
               const hasWrCode = hasLabel(labels, 'wr:code');
               const createdAt = Date.parse(issue.created_at || '');
               if (isOctopus && !hasWrCode && createdAt && NOW - createdAt > STALE_OCTOPUS_MS) {
+                const toAdd = ['work-request', 'wr:code']
+                  .filter((l) => !labels.map((x) => typeof x === 'string' ? x : x.name).includes(l));
+
                 actions.push({
                   kind: 'Issue',
                   n: issue.number,
-                  action: 'label recovery:translate-me (fires octopus-route)',
+                  action: `inline-translate: add ${toAdd.join(', ') || '(labels already present)'} + ensure [WR] title`,
                 });
-                // Toggle the label so a re-apply re-fires the issues: labeled
-                // event even if the label was already there (e.g., from a
-                // previous run that didn't translate cleanly).
-                if (hasLabel(labels, 'recovery:translate-me') && !dryRun) {
-                  await github.rest.issues
-                    .removeLabel({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      issue_number: issue.number,
-                      name: 'recovery:translate-me',
-                    })
-                    .catch(() => {});
+
+                if (!dryRun) {
+                  if (toAdd.length > 0) {
+                    await github.rest.issues
+                      .addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue.number,
+                        labels: toAdd,
+                      })
+                      .catch((e) => core.warning(`#${issue.number} addLabels: ${e.message}`));
+                  }
+                  if (!/^\[WR\]/i.test(issue.title || '')) {
+                    const PREFIX = '[WR] ';
+                    const maxBodyLen = 256 - PREFIX.length;
+                    const newTitle = PREFIX + (issue.title || '').slice(0, maxBodyLen);
+                    await github.rest.issues
+                      .update({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issue.number,
+                        title: newTitle,
+                      })
+                      .catch((e) => core.warning(`#${issue.number} title update: ${e.message}`));
+                  }
                 }
-                await ensureLabel(issue.number, 'recovery:translate-me', 'd93f0b',
-                  'Set by recovery-engine to re-fire octopus-route on a stale Octopus issue');
                 continue;
               }
 


### PR DESCRIPTION
## Summary

Real bug — surfaced by your "all the octopus WRs are stuck." The recovery engine I shipped in #14101 has the right intent but the wrong wiring: it applies `has-conflicts` to stale Octopus issues to "kick octopus-route." But:

- `octopus-route.yml` only triggered on `issues: opened` — **NOT on `labeled`**, so the label did nothing
- `has-conflicts` is the conflict-helper's trigger, which handles **PR merge conflicts**, not Octopus translation

The 73 stuck issues stay stuck because nothing actually fires the translator on them after the original `opened` event passed.

## Three fixes in one PR

### 1. `octopus-route.yml` — add `labeled` trigger
Now fires on `issues: labeled` when label name is exactly `recovery:translate-me`. The `opened` path still handles fresh Octopus issues; the `labeled` path is the recovery hook for stale ones.

### 2. `recovery-engine.yml` — apply the correct label
Switched from `has-conflicts` to `recovery:translate-me`. Also toggles the label (remove + re-add) when already present, so a re-run actually re-fires the `issues: labeled` event.

### 3. `octopus-route.yml` backfill — drip-feed + cap
Added two `workflow_dispatch` inputs:
- **`rate_limit_minutes`** (default 0): sleep N minutes between issues to spread downstream openrouter-coder cost. 0 = burst.
- **`max_issues`** (default 100): cap total processed in one run.

Example controlled clear:
```bash
gh workflow run octopus-route.yml -f backfill=true -f max_issues=10
```

## Net effect once merged

```
Hourly recovery-engine cron
   │
   ├── For each Octopus issue with octopus-review label but no wr:code, age > 1h:
   │      Apply (or re-apply) `recovery:translate-me`
   │
   └── For each labeling:
          octopus-route fires
            → adds work-request + wr:code
            → prefixes [WR] in title
            → agent-dispatcher picks up wr:code
            → openrouter-coder runs
```

Backlog drains naturally at ~hourly cadence without anyone manually dispatching anything. If you want it faster, the new `max_issues` + `rate_limit_minutes` give you a controlled accelerator.

docs-freshness: workflow-level fix to an existing routing standard (`AGENT_MONITORING_STANDARD.md` §1 already documents the Octopus lane). No new lane introduced.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Fixes a bug preventing stuck Octopus work requests from being processed by correcting the workflow triggering mechanism. The recovery engine was applying the wrong label (`has-conflicts` instead of `recovery:translate-me`) and `octopus-route.yml` wasn't listening for `labeled` events. Changes include: adding `labeled` trigger to `octopus-route.yml` so it fires when `recovery:translate-me` is applied, updating `recovery-engine.yml` to apply the correct label with toggle behavior to re-fire events, and adding `rate_limit_minutes` and `max_issues` parameters to control backfill processing speed and cost.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/recovery-engine.yml` |
| 2 | `.github/workflows/octopus-route.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unstuck Octopus WRs by inlining translation in the recovery engine and adding safe, paced backfill. `octopus-route` still handles new issues and manual recovery via `issues: labeled`.

- **Bug Fixes**
  - `recovery-engine.yml`: inline translate stale Octopus issues (add `work-request` + `wr:code`, ensure `[WR]` title) instead of label-cascading; clears on the hourly cron.
  - `octopus-route.yml`: also trigger on `issues: labeled` when label is `recovery:translate-me` (keeps `opened`); kept for manual/external-token cases.
  - Backfill safety: 5h job budget cap, correct parsing so `max_issues=0` is respected, and no sleep after the last item.

- **New Features**
  - Backfill controls in `octopus-route.yml`: `rate_limit_minutes` and `max_issues` to throttle and cap runs. Example: `gh workflow run octopus-route.yml -f backfill=true -f max_issues=10`.

<sup>Written for commit f3671b7e06d4ab6c87ae242648a8f6b2bb11bcc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

