### PR TITLE
Tier 1: ship the real bugs Octopus caught (audit script + workflow)

### DIFF
--- a/.github/workflows/third-party-action-audit.yml
+++ b/.github/workflows/third-party-action-audit.yml
@@ -62,9 +62,20 @@ jobs:
         # so a future refactor that lets the value come from user input could
         # inject shell commands here. Env-var pass is single-quoted by bash.
         # Octopus finding #13996.
+        # The `if: always()` causes this to run even if the audit step was
+        # skipped/cancelled (e.g., checkout failed) — in that case REPORT_FILE
+        # is empty and cat would error. Guard explicitly so the workflow log
+        # explains the skip instead of a confusing `cat -- ""` failure
+        # (Devin finding on #14219).
         env:
           REPORT_FILE: ${{ steps.audit.outputs.report_file }}
         run: |
+          if [[ -z "$REPORT_FILE" || ! -f "$REPORT_FILE" ]]; then
+            echo "### Third-Party Action Freshness Audit (no report)" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "_The audit step did not produce a report. See the step log above for the upstream failure._" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           {
             echo "### Third-Party Action Freshness Audit"
             echo ""

--- a/.github/workflows/third-party-action-audit.yml
+++ b/.github/workflows/third-party-action-audit.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run audit
         id: audit
@@ -57,22 +57,34 @@ jobs:
 
       - name: Append to job summary
         if: always()
+        # Read the report path from env (set by the previous step), not from
+        # ${{ }} expression substitution. ${{ }} happens BEFORE shell parsing
+        # so a future refactor that lets the value come from user input could
+        # inject shell commands here. Env-var pass is single-quoted by bash.
+        # Octopus finding #13996.
+        env:
+          REPORT_FILE: ${{ steps.audit.outputs.report_file }}
         run: |
           {
             echo "### Third-Party Action Freshness Audit"
             echo ""
             echo '```'
-            cat "${{ steps.audit.outputs.report_file }}"
+            cat -- "$REPORT_FILE"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: File tracking WR if anything was flagged
         if: steps.audit.outputs.exit_code == '1'
-        uses: actions/github-script@v7
+        # Pass the report path via env so the JS string-interpolates a sanitized
+        # env value rather than a raw ${{ }} expression. Same injection-class
+        # fix as the summary step above. Octopus finding #13996.
+        env:
+          REPORT_FILE: ${{ steps.audit.outputs.report_file }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('${{ steps.audit.outputs.report_file }}', 'utf8');
+            const report = fs.readFileSync(process.env.REPORT_FILE, 'utf8');
             const today = new Date().toISOString().slice(0, 10);
             const title = `[WR] Third-party action audit flagged stale actions (${today})`;
 

--- a/scripts/audit-third-party-actions.sh
+++ b/scripts/audit-third-party-actions.sh
@@ -66,10 +66,12 @@ contains() {
   local item
   for item in "$@"; do
     # Case-insensitive compare — GitHub owner names are case-insensitive,
-    # so a workflow file that says `BeksOmega/...` must match the lowercased
-    # `beksomega` entry in MULTI_AUTHOR_OWNERS too. Without this, mixed-case
-    # references silently mis-tier and the audit emits false single-author
-    # warnings (Octopus finding #14004).
+    # so a workflow file that says `BeksOmega/...` must match the
+    # `BeksOmega` entry in MULTI_AUTHOR_OWNERS regardless of how either
+    # side is cased. We lowercase BOTH sides at comparison time so the
+    # OPTIONS array can keep its readable mixed-case entries. Without this,
+    # mixed-case references silently mis-tier and the audit emits false
+    # single-author warnings (Octopus finding #14004).
     [[ "${item,,}" == "$needle" ]] && return 0
   done
   return 1

--- a/scripts/audit-third-party-actions.sh
+++ b/scripts/audit-third-party-actions.sh
@@ -62,10 +62,15 @@ MULTI_AUTHOR_OWNERS=(
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 contains() {
-  local needle="$1"; shift
+  local needle="${1,,}"; shift
   local item
   for item in "$@"; do
-    [[ "$item" == "$needle" ]] && return 0
+    # Case-insensitive compare — GitHub owner names are case-insensitive,
+    # so a workflow file that says `BeksOmega/...` must match the lowercased
+    # `beksomega` entry in MULTI_AUTHOR_OWNERS too. Without this, mixed-case
+    # references silently mis-tier and the audit emits false single-author
+    # warnings (Octopus finding #14004).
+    [[ "${item,,}" == "$needle" ]] && return 0
   done
   return 1
 }
@@ -91,12 +96,18 @@ last_release_date() {
     --jq '.published_at // empty' 2>/dev/null || echo ""
 }
 
-# Days between an ISO date and today.
+# Days between an ISO date and today. Tries GNU `date -d` first (Linux
+# runners) and falls back to BSD `date -j -f` (macOS / local dev). Without
+# the BSD fallback, every age check silently returned empty on macOS and
+# all single-author actions got demoted to `warn` instead of `flag`,
+# making the tool misleading when run locally (Octopus finding #14000).
 days_since() {
   local iso="$1"
   [[ -z "$iso" ]] && { echo ""; return; }
   local then_secs now_secs
-  then_secs=$(date -d "$iso" +%s 2>/dev/null || echo "")
+  then_secs=$(date -d "$iso" +%s 2>/dev/null) \
+    || then_secs=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) \
+    || then_secs=""
   [[ -z "$then_secs" ]] && { echo ""; return; }
   now_secs=$(date +%s)
   echo $(( (now_secs - then_secs) / 86400 ))
@@ -123,7 +134,11 @@ mapfile -t USES < <(
     | sort -u
 )
 
-stale_threshold_days=$(( STALENESS_MONTHS * 30 ))
+# Use calendar-accurate days/month (~30.44) instead of a flat 30. For a
+# 12-month threshold the old math gave 360 days, so an action released
+# 361 days ago could be flagged when it's still within the calendar year.
+# Octopus finding #13998.
+stale_threshold_days=$(( (STALENESS_MONTHS * 3044 + 50) / 100 ))
 flagged=()
 report_rows=()
 json_rows=()


### PR DESCRIPTION
## Summary

From the Octopus dump triage — Tier 1 is the bugs that actually break things on real input. UI-engine findings (#14069/14070/14071 on `scripts/ui-creation-engine.js`) were already fixed by PR #14103 (merged); this PR addresses the remaining live findings on `audit-third-party-actions.sh` + its workflow.

## 6 fixes, 6 Octopus findings closed

| # | File | Bug | Octopus |
|---|---|---|---|
| 1 | `scripts/audit-third-party-actions.sh` | `contains()` case-sensitive → `BeksOmega` vs `beksomega` silently mis-tier → false single-author warnings | #14004 |
| 2 | `scripts/audit-third-party-actions.sh` | `date -d` GNU-only → silently empty on macOS → demoted from `flag` to `warn` for all single-author actions locally | #14000 |
| 3 | `scripts/audit-third-party-actions.sh` | `STALENESS_MONTHS * 30` → 12mo = 360d (off by 5 days). Now `(N * 3044 + 50) / 100` → 365d. Verified: 6mo→183d, 1mo→30d. | #13998 |
| 4 | `third-party-action-audit.yml` | `actions/checkout@v4` unpinned → would fail repo's own `workflow-action-ref-audit.yml` policy | #14002 |
| 5 | `third-party-action-audit.yml` | `actions/github-script@v7` unpinned (same reason) | #14003 |
| 6 | `third-party-action-audit.yml` | `cat "${{ steps.audit.outputs.report_file }}"` + `fs.readFileSync('${{ ... }}', …)` — expression substitutes BEFORE shell parsing. Today runner-trusted, but a future refactor that lets the value come from user input is a shell-injection vector. Both moved to env-var pass (`REPORT_FILE`). | #13996 |

## Verified locally

- `bash -n` clean on the script
- `python3 -c "import yaml; yaml.safe_load(...)"` clean on the workflow
- Threshold-math sanity-checked: `STALENESS_MONTHS=12 → 365`, `=6 → 183`, `=1 → 30`

## Out of scope (next PRs)

- **Tier 2**: `wr/scripts/generate-wr.sh` fix — single-source bug producing scaffolding leak + unfilled `{STARS}` placeholders + issue body in table cell, across ~30 PRs
- **Tier 3**: Coder prompt that produces tracking WR docs instead of actual code fixes — needs investigation of openrouter-coder.yml

docs-freshness: bugfix to existing standards (`THIRD_PARTY_ACTION_AUDIT.md` already covers this lane). No new standard introduced.

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/midnghtsapphire/revvel-standards/pull/14219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes six bugs discovered by the Octopus audit tool in the third-party action audit script and workflow. The changes address critical issues including case-sensitive string matching causing false warnings, macOS compatibility failures, incorrect staleness calculations (12 months calculated as 360 days instead of 365), unpinned GitHub actions violating the repo's own policy, and potential shell injection vulnerabilities in expression substitution. Each fix includes detailed inline comments explaining the bug and referencing the corresponding Octopus finding number.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/audit-third-party-actions.sh` |
| 2 | `.github/workflows/third-party-action-audit.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes six bugs in the third‑party actions audit script and workflow to improve accuracy, macOS compatibility, and security. Adds a safe guard in the job summary step to avoid errors when the audit is skipped.

- **Bug Fixes**
  - Case-insensitive owner matching to avoid false single-author warnings.
  - BSD `date` fallback for macOS; age checks no longer fail locally.
  - Calendar-correct month→day math (12m=365d, 6m=183d, 1m=30d).
  - Prevented shell injection by reading the report path via `REPORT_FILE` env var in both shell and `github-script`.
  - Guarded the job summary step when `REPORT_FILE` is empty or missing to prevent `cat` errors under `if: always()`.

- **Dependencies**
  - Pinned `actions/checkout@v4.2.2` to an immutable ref.
  - Pinned `actions/github-script@v7.0.1` to an immutable ref.

<sup>Written for commit b166f36bcc91451abf171124adeaefea82475724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

