### PR TITLE
WR gate Tier-2: tighten checklist rule, require Tracks: ref, block root junk

### DIFF
--- a/.github/workflows/fix-wr-gate.yml
+++ b/.github/workflows/fix-wr-gate.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Enforce fix-WR includes a real fix or is labeled tracking-only
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY:  ${{ github.event.pull_request.body }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           # Use event-payload SHAs — `origin/${BASE}` is unreliable when
           # actions/checkout uses the PR merge ref. Per Copilot review on
@@ -26,5 +27,6 @@ jobs:
           CHANGED="$(git diff --name-only --diff-filter=AM "${BASE_SHA}...${HEAD_SHA}")"
           node wr/scripts/fix-wr-gate.mjs \
             --title "$PR_TITLE" \
+            --body  "$PR_BODY" \
             --labels "$PR_LABELS" \
             --changed "$CHANGED"

--- a/.github/workflows/no-root-junk.yml
+++ b/.github/workflows/no-root-junk.yml
@@ -1,0 +1,38 @@
+name: No Root Junk
+# Catches the #14119-class defect: throwaway development scripts
+# (plan.md, finish_clean.js, fix_boilerplate.js, update_wr.js, tmp_*, scratch*)
+# committed to the repo root. Per Octopus review of the recent WR-PR cluster.
+#
+# Runs on every PR, regardless of paths — junk can land anywhere.
+# If a file legitimately needs one of these names, add an exception to
+# JUNK_ALLOW below with a comment explaining why.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+jobs:
+  no-root-junk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with: { fetch-depth: 0 }
+      - name: Scan diff for throwaway files at repo root
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Repo-root only — depth-1 entries that match the throwaway pattern.
+          # Subdir files (scripts/finish_clean.js, etc.) are out of scope here;
+          # those have legitimate places to live.
+          CHANGED="$(git diff --name-only --diff-filter=AM "${BASE_SHA}...${HEAD_SHA}")"
+          JUNK="$(printf '%s\n' "$CHANGED" \
+            | grep -E '^(plan|finish_clean|fix_boilerplate|update_wr|tmp[_-].*|scratch.*|temp[_-].*|throwaway.*|notes)\.(js|mjs|ts|md|sh|py|txt)$' \
+            || true)"
+          if [ -n "$JUNK" ]; then
+            echo "::error::Throwaway dev files at repo root are not allowed. Move them under scripts/, docs/, or wr/ — or delete them before merge."
+            printf '  • %s\n' $JUNK
+            exit 1
+          fi
+          echo "✓ no throwaway files at repo root"

--- a/.github/workflows/no-root-junk.yml
+++ b/.github/workflows/no-root-junk.yml
@@ -4,8 +4,8 @@ name: No Root Junk
 # committed to the repo root. Per Octopus review of the recent WR-PR cluster.
 #
 # Runs on every PR, regardless of paths — junk can land anywhere.
-# If a file legitimately needs one of these names, add an exception to
-# JUNK_ALLOW below with a comment explaining why.
+# If a file legitimately needs one of these names, edit the grep -E
+# pattern below to add an exception (and leave a comment explaining why).
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -26,7 +26,10 @@ jobs:
           # Repo-root only — depth-1 entries that match the throwaway pattern.
           # Subdir files (scripts/finish_clean.js, etc.) are out of scope here;
           # those have legitimate places to live.
-          CHANGED="$(git diff --name-only --diff-filter=AM "${BASE_SHA}...${HEAD_SHA}")"
+          # AMR filter: Added | Modified | Renamed. Without R, renaming a
+          # legitimate file into a forbidden root name would bypass the gate.
+          # Per Copilot review.
+          CHANGED="$(git diff --name-only --diff-filter=AMR "${BASE_SHA}...${HEAD_SHA}")"
           JUNK="$(printf '%s\n' "$CHANGED" \
             | grep -E '^(plan|finish_clean|fix_boilerplate|update_wr|tmp[_-].*|scratch.*|temp[_-].*|throwaway.*|notes)\.(js|mjs|ts|md|sh|py|txt)$' \
             || true)"

--- a/docs/process/SYSTEM_MAP.md
+++ b/docs/process/SYSTEM_MAP.md
@@ -114,6 +114,9 @@ security findings, a11y/SEO gaps).
 | `agent-fallback.yml` | Picks up repair issues when the primary agent fails |
 | `stuck-label-watchdog.yml` | Turns stuck PRs into agent repair issues |
 | `automation-doctor.js` | Validates workflows + labels (`npm run automation:doctor`) |
+| `wr-lint.yml` + `wr/scripts/wr-lint.mjs` | Catches scaffolding leak, raw `{TOKEN}` substitutions, bracket placeholders, and any `[x]` checklist item flipped on while forbidden placeholders remain |
+| `fix-wr-gate.yml` + `wr/scripts/fix-wr-gate.mjs` | Blocks "documents the fix but doesn't apply it" PRs. Tracking-only escape requires both a tracking-* label AND an explicit `Tracks: #NNNN` reference in the PR body pointing at the follow-up that applies the actual fix |
+| `no-root-junk.yml` | Blocks throwaway dev files at repo root (`plan.md`, `finish_clean.js`, `fix_boilerplate.js`, `update_wr.js`, `tmp_*`, `scratch*`, etc.) on every PR |
 | Procurement BOM | When a credential/API is missing, writes `BOM.md` instead of failing silently |
 
 ---

--- a/wr/scripts/fix-wr-gate.mjs
+++ b/wr/scripts/fix-wr-gate.mjs
@@ -3,11 +3,12 @@
 // A fix-class WR PR must EITHER touch a real (non-wr/) file, OR be explicitly labeled tracking-only.
 // Catches PRs #14186/#14185/#14177/#14138/#14116/#14066 etc. pattern.
 //
-// Usage: node fix-wr-gate.mjs --changed <file-list-newline-or-comma> [--labels <csv>] [--title "<pr title>"]
+// Usage: node fix-wr-gate.mjs --changed <file-list-newline-or-comma> [--labels <csv>] [--title "<pr title>"] [--body "<pr body>"]
 //   exit 0 = pass, 1 = gate violation.
 //
 // "Real fix" = any changed file NOT under wr/ and NOT a pure docs/tracking artifact.
-// Tracking-only escape hatch = PR has a label in TRACKING_LABELS or title starts with a TRACKING_PREFIX.
+// Tracking-only escape hatch = PR has a label in TRACKING_LABELS or title starts with a TRACKING_PREFIX
+// AND the body carries an explicit `Tracks: #NNNN` reference to the follow-up issue/PR that will apply the fix.
 
 const args = process.argv.slice(2);
 const get = (n) => { const i = args.indexOf(`--${n}`); return i >= 0 ? args[i + 1] : ""; };
@@ -15,6 +16,11 @@ const get = (n) => { const i = args.indexOf(`--${n}`); return i >= 0 ? args[i + 
 const changedRaw = get("changed");
 const labels = get("labels").split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
 const title = get("title") || "";
+const body  = get("body")  || "";
+
+// "Tracks: #1234" or "Tracks #1234" or "Tracking: #1234" — case-insensitive,
+// allows owner/repo qualified forms too ("Tracks: foo/bar#1234").
+const TRACKS_REF = /\btrack(?:s|ing)?\s*[: ]\s*([A-Za-z0-9_.\/-]+)?#\d+/i;
 
 const TRACKING_LABELS = ["tracking-only", "wr-docs", "wr-tracking", "meta-tracking", "docs-only"];
 const TRACKING_PREFIXES = [/^\[wr-docs\]/i, /^\[wr-tracking\]/i, /^track\b/i, /^\[track\]/i];
@@ -33,23 +39,38 @@ function isRealFix(path) {
 const realFixFiles = changed.filter(isRealFix);
 const wrOnly = changed.length > 0 && realFixFiles.length === 0;
 const claimsFix = FIX_SIGNAL.test(title);
-const isTrackingOnly =
+const trackingLabeled =
   labels.some((l) => TRACKING_LABELS.includes(l)) ||
   TRACKING_PREFIXES.some((re) => re.test(title.trim()));
+// Per Octopus review: the label alone became an escape hatch. To count as
+// tracking-only, the PR body must also carry an explicit `Tracks: #NNNN`
+// reference so a future reviewer can find the follow-up that applies the fix.
+const hasTracksRef = TRACKS_REF.test(body);
+const isTrackingOnly = trackingLabeled && hasTracksRef;
 
 const issues = [];
 
 if (claimsFix && wrOnly && !isTrackingOnly) {
-  issues.push(
-    `PR title claims a fix ("${title.trim()}") but the diff only touches wr/ tracking files ` +
-    `(${changed.join(", ")}). Either include the actual fix (a non-wr/ file), OR label the PR ` +
-    `one of [${TRACKING_LABELS.join(", ")}] / prefix the title "[WR-DOCS]" to mark it tracking-only.`
-  );
+  if (trackingLabeled && !hasTracksRef) {
+    issues.push(
+      `PR is labeled tracking-only but the body has no "Tracks: #NNNN" reference. ` +
+      `A tracking-only fix WR must point to the follow-up issue/PR that will apply ` +
+      `the actual fix — add a "Tracks: #1234" line to the PR body, or remove the ` +
+      `tracking label and include the real fix.`
+    );
+  } else {
+    issues.push(
+      `PR title claims a fix ("${title.trim()}") but the diff only touches wr/ tracking files ` +
+      `(${changed.join(", ")}). Either include the actual fix (a non-wr/ file), OR label the PR ` +
+      `one of [${TRACKING_LABELS.join(", ")}] / prefix the title "[WR-DOCS]" AND add ` +
+      `"Tracks: #NNNN" to the PR body pointing at the follow-up that applies the fix.`
+    );
+  }
 }
 
 // Secondary: a fix WR that is tracking-only should SAY so, to avoid a future reviewer thinking it's resolved.
 if (claimsFix && wrOnly && isTrackingOnly) {
-  console.log(`note: tracking-only fix WR accepted (labeled/prefixed). Ensure a follow-up PR applies the actual fix.`);
+  console.log(`note: tracking-only fix WR accepted (labeled + Tracks: ref present). Ensure the referenced follow-up actually applies the fix.`);
 }
 
 if (issues.length) {

--- a/wr/scripts/wr-lint.mjs
+++ b/wr/scripts/wr-lint.mjs
@@ -118,7 +118,10 @@ function lintFile(path) {
   // (excluding code fences via the same inFence mask).
   const FORBIDDEN_FOR_CHECKLIST = [
     RAW_TOKENS,
-    BRACKET_PLACEHOLDER,
+    // Non-global clone of BRACKET_PLACEHOLDER: the `g` flag makes `.test()`
+    // stateful (lastIndex), which can false-negative on repeat calls and
+    // let forbidden placeholders slip past the rule. Per Copilot review.
+    new RegExp(BRACKET_PLACEHOLDER.source, "i"),
     /\[Yes\/No\]/i,
     /\[Option \d+\]/i,
     /\[Research findings\.\.\.\]/i,

--- a/wr/scripts/wr-lint.mjs
+++ b/wr/scripts/wr-lint.mjs
@@ -33,7 +33,7 @@ const BASIC_SIGNALS = /\b(bug|fix|style|refactor|typo|lint|unreachable|duplicate
 const RAW_TOKENS = /\{(STARS|OPEN_ISSUES|IS_PRIVATE|IS_ARCHIVED|DESCRIPTION|REPO|LANGUAGE)\}/;
 
 // Bracket placeholders the full template leaves behind.
-const BRACKET_PLACEHOLDER = /\[(Yes\/No|engine|notes|Pattern \d|Option \d|primary keyword \d|\$CPC|\$amount[^\]]*|volume|Vercel URL[^\]]*|Complaint \d|Action \d|2-3 sentence summary[^\]]*|Tree structure[^\]]*|Research findings[^\]]*|Fix|Pricing)\]/gi;
+const BRACKET_PLACEHOLDER = /\[(Yes\/No|engine|notes|Pattern \d|Option \d|primary keyword \d|\$CPC|\$amount[^\]]*|volume|Vercel URL[^\]]*|Complaint \d|Action \d|2-3 sentence summary[^\]]*|Tree structure[^\]]*|Research findings[^\]]*|Fix|Pricing|Date and summary)\]/gi;
 
 function lintFile(path) {
   const text = fs.readFileSync(path, "utf8");
@@ -108,11 +108,34 @@ function lintFile(path) {
     if (m) issues.push(`line ${i + 1}: raw template placeholder ${m[0]} — fill or mark "N/A — <reason>"`);
   });
 
-  // 7. Falsely pre-checked research checklist while body has raw placeholders.
-  const checkedItems = (text.match(/^- \[x\]/gim) || []).length;
-  const hasRawResearch = RAW_TOKENS.test(text) || /\[(Option \d|primary keyword|\$CPC|Complaint \d|Pattern \d)\]/i.test(text);
-  if (checkedItems >= 5 && hasRawResearch) {
-    issues.push(`research checklist pre-marked complete (${checkedItems} [x]) but body still contains raw placeholders — false-completion signal; uncheck N/A items with a reason or fill the sections`);
+  // 7. Falsely pre-checked checklist while body has any raw placeholders.
+  // Per Octopus review of #14118/#14138/#14224/#14225: ANY [x] check while
+  // ANY forbidden pattern is in the doc is false-completion. The old
+  // threshold (≥5 [x] + narrow placeholder list) lets the worst offenders
+  // through — a single [x] flipped on while {STARS} is still in the table
+  // is the same false-completion signal.
+  // Build the forbidden-pattern detector once from the same rules used above
+  // (excluding code fences via the same inFence mask).
+  const FORBIDDEN_FOR_CHECKLIST = [
+    RAW_TOKENS,
+    BRACKET_PLACEHOLDER,
+    /\[Yes\/No\]/i,
+    /\[Option \d+\]/i,
+    /\[Research findings\.\.\.\]/i,
+    /\[\$CPC\]/i,
+    /\[Date and summary\]/i,
+    /\[Fix\]/i,
+  ];
+  const hasAnyForbidden = lines.some((l, i) => {
+    if (inFence[i]) return false;
+    return FORBIDDEN_FOR_CHECKLIST.some((re) => re.test(l));
+  });
+  const checkedItems = lines.reduce((n, l, i) => {
+    if (inFence[i]) return n;
+    return n + (/^- \[x\]/i.test(l) ? 1 : 0);
+  }, 0);
+  if (checkedItems >= 1 && hasAnyForbidden) {
+    issues.push(`checklist has ${checkedItems} [x] item(s) but the doc still contains forbidden placeholders/tokens — false-completion signal; either fill the placeholders, or uncheck the items (and mark "N/A — <reason>" where genuinely not applicable)`);
   }
 
   // 8. Issue body pasted into a metadata table cell (## heading inside a | ... | row).


### PR DESCRIPTION
## Why

Octopus's review of the recent WR-PR cluster (#14116, #14118, #14138, #14145, #14185, #14119, plus the #14222–#14234 rewrites) shows the same three escape hatches are letting the same defect class through repeatedly. This closes all three.

| PR | Defect class | Hatch | Fix |
|----|--------------|-------|-----|
| #14118, #14138, #14224, #14225 | `[x]` pre-checked but body has `{STARS}` / `[Option N]` / `[$CPC]` | wr-lint rule fired only at ≥5 `[x]` + a narrow placeholder set | Rule fires on **any** `[x]` + **any** forbidden placeholder |
| #14116, #14145, #14185 | Tracking WR claims to fix something, label is "tracking-only," no actual fix lands | `tracking-only` label alone is enough | Body must also carry **`Tracks: #NNNN`** referencing the follow-up |
| #14119 | `plan.md` / `finish_clean.js` / `fix_boilerplate.js` / `update_wr.js` at repo root | No gate enforces depth-1 hygiene | New `no-root-junk.yml` workflow blocks the pattern on every PR |

## What

### 1. `wr/scripts/wr-lint.mjs` — checklist false-completion (rule 7)

Before:
```js
if (checkedItems >= 5 && hasRawResearch) { ... }
```
After:
```js
const hasAnyForbidden = lines.some(...);    // any token, any bracket placeholder
if (checkedItems >= 1 && hasAnyForbidden) { ... }
```

A single `[x]` flipped on while `{STARS}` is still in the table carries the same lie as five. Also added `[Date and summary]` to the bracket-placeholder list.

### 2. `wr/scripts/fix-wr-gate.mjs` — `Tracks: #NNNN` required

Tracking-only is no longer just a label. The PR body must also contain:

```
Tracks: #1234
```

(or `Tracking: #1234`, or `Tracks: foo/bar#1234`). Without it, a fix-claim PR that only touches `wr/` files fails the gate. The workflow now passes `PR_BODY` through.

### 3. `.github/workflows/no-root-junk.yml` — new

Runs on every PR. Blocks new/modified files at repo root matching:
`plan, finish_clean, fix_boilerplate, update_wr, tmp_*, tmp-*, scratch*, temp_*, temp-*, throwaway*, notes` (extensions `.js .mjs .ts .md .sh .py .txt`).

Subdirectory files are unaffected — `scripts/finish_clean.js` is fine, `./finish_clean.js` is not.

## Verified

```
$ node wr/scripts/wr-lint.mjs falsy-wr.md   # 2 [x] + {STARS} + {OPEN_ISSUES}
✗ falsy-wr.md
   - line 8: unsubstituted generator token(s) {STARS} ...
   - line 9: unsubstituted generator token(s) {OPEN_ISSUES} ...
   - checklist has 2 [x] item(s) but the doc still contains forbidden ...
exit=1

$ node wr/scripts/fix-wr-gate.mjs --title "Fix CPC" --labels tracking-only \
    --body "This is a tracking WR." --changed "wr/issues/issue-99.md"
✗ fix-WR gate failed:
   - PR is labeled tracking-only but the body has no "Tracks: #NNNN" reference. ...
exit=1

$ node wr/scripts/fix-wr-gate.mjs --title "Fix CPC" --labels tracking-only \
    --body "Tracks: #14242" --changed "wr/issues/issue-99.md"
note: tracking-only fix WR accepted (labeled + Tracks: ref present). ...
✓ fix-WR gate passed
exit=0
```

## Notes

- Builds on the Tier-1 wiring landed in #14227 (which created `fix-wr-gate.mjs` + `fix-wr-gate.yml` + `wr-lint.mjs`).
- The `no-root-junk.yml` workflow is intentionally separate from the fix-WR gate — junk can land in any PR, not just WR-touching ones.
- Doesn't touch the open #14222–#14234 cluster directly. With these gates merged, the next rewrite attempt of those WRs will fail loudly at CI instead of silently merging another half-template.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR tightens the WR (Weekly Report) quality gates to prevent three recurring defect patterns identified in recent PRs. First, it strengthens the checklist validation rule to catch false completion when *any* checkbox is marked while *any* placeholder token remains (previously only triggered at 5+ checkboxes). Second, it requires tracking-only PRs to include an explicit `Tracks: #NNNN` reference in the body, not just a label. Third, it adds a new workflow that blocks throwaway development files (like `plan.md`, `finish_clean.js`, `tmp_*`, `scratch*`) from being committed to the repository root.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `wr/scripts/wr-lint.mjs` |
| 2 | `wr/scripts/fix-wr-gate.mjs` |
| 3 | `.github/workflows/fix-wr-gate.yml` |
| 4 | `.github/workflows/no-root-junk.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened WR lint and CI gates to stop false-complete checklists, require explicit `Tracks: #NNNN` references, and block throwaway files at the repo root. Also fixes edge cases and documents the new gates so CI fails early and clearly.

- **Bug Fixes**
  - Checklist rule now triggers on any `[x]` if any forbidden token/placeholder remains; added `[Date and summary]` and fixed regex statefulness to avoid false negatives.
  - Tracking-only WRs must include a `Tracks: #NNNN` in the PR body; `PR_BODY` is now passed to `fix-wr-gate.mjs`.
  - New `no-root-junk.yml` blocks throwaway files at repo root; scan now includes renames (AMR) and ignores subdirectories.

- **Docs**
  - Added SYSTEM_MAP entries for `wr-lint.yml`, `fix-wr-gate.yml`, and `no-root-junk.yml`.

<sup>Written for commit 0cb58a704dbc903b3d09c9d670a4cd6acfa22ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

