### PR TITLE
Rewrite WR for issue 14071

### DIFF
--- a/dashboard-data.json
+++ b/dashboard-data.json
@@ -1447,5 +1447,5 @@
       "hasSystemState": true
     }
   ],
-  "lastUpdated": "2026-05-29T05:01:36.959Z"
+  "lastUpdated": "2026-06-02T05:54:13.074Z"
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -152,7 +152,7 @@
         </div>
         <div class="stat">
           <span class="stat-label">Last Updated:</span>
-          <span class="stat-value">5/29/2026, 5:01:36 AM</span>
+          <span class="stat-value">6/2/2026, 5:54:13 AM</span>
         </div>
       </div>
 
@@ -904,7 +904,7 @@
     </div>
 
     <div class="last-updated">
-      Dashboard generated at 5/29/2026, 5:01:36 AM
+      Dashboard generated at 6/2/2026, 5:54:13 AM
       <br>
       <small>Auto-updates every 4 hours via GitHub Actions cron job</small>
     </div>

--- a/wr/issues/issue-14071-unreachable-code-duplicate-return-in-builduirecomm.md
+++ b/wr/issues/issue-14071-unreachable-code-duplicate-return-in-builduirecomm.md
@@ -1,49 +1,34 @@
 # WR: [WR] Unreachable code: duplicate return in buildUIRecommendationsUserPrompt truncates prompt
 
 **Issue:** #14071  
-**Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
-**Research Date:** 2026-06-02  
-**Researcher:** Jules (Google) + OpenRouter  
-**WR Status:** 🟡 In Progress
-
----
-
-**WR Status:** {STATUS}  
+**Repository:** midnghtsapphire/revvel-standards
+**Created:** 2026-06-02
+**WR Status:** ✅ Complete
 
 ## Issue Context
-{ISSUE_BODY}
+The function `buildUIRecommendationsUserPrompt` contains two consecutive return statements. The first one exits the function early and returns an incomplete prompt string ending in a literal ellipsis (...), causing all downstream prompt content to be discarded at runtime.
 
-## Repository Metadata
-| Property | Value |
-| --- | --- |
-| Stars | {STARS} |
-| Open Issues | {OPEN_ISSUES} |
-| Private | {IS_PRIVATE} |
-| Archived | {IS_ARCHIVED} |
+Because the first return statement is reached unconditionally, the second (correct) return is dead code. As a result, the function always emits a truncated prompt that omits the 'Create detailed UI/UX recommendations including:' body along with the design system, component library, page layout, and differentiation sections. These sections are what make the generated UI recommendations meaningful, so their loss silently degrades the quality of every downstream UI recommendation produced by this engine. This is a critical correctness regression introduced by the MCP master prompt pack injection change.
 
-## Research Checklist
-<!-- Mark [x] ONLY when the matching section below is actually filled. Otherwise [ ] or "N/A — reason". -->
-- [ ] Deep market research
-- [ ] BOM
-- [ ] Community chatter
-- [ ] Competitor analysis
-- [ ] Domain strategy
-- [ ] Monetization
+**Location:** File: `scripts/ui-creation-engine.js`, line 504.
 
-## Executive Summary
-{EXECUTIVE_SUMMARY}
+## Summary
+A duplicate return statement in `buildUIRecommendationsUserPrompt` makes the complete prompt unreachable, causing it to return a truncated prompt instead, losing key UI recommendation sections. The fix is to delete the early truncated return and keep the complete one.
 
-## Step 1A — Product/Output Selections
-{PRODUCT_SELECTIONS}
+## Objective
+Remove the unreachable code block to restore full prompt functionality in UI recommendations. Ensure complete UI design prompts including design system, component library, page layout, and differentiation are returned.
 
-## Step 2 — Deep Web Research
-{DEEP_WEB_RESEARCH}
+## Required Bundle
+N/A — Fixes an existing script.
 
-## Step 3 — Requirements
-{REQUIREMENTS}
+## Definition of Done
+1. Delete the first return statement and its truncated template literal (the one ending in '...').
+2. Keep only the complete return statement that includes the full prompt body with all required sections.
+3. Verify the file parses without SyntaxError and that generated prompts match expectations end-to-end.
+4. Add a unit or snapshot test that asserts the returned prompt contains the key section headers to prevent regressions.
 
-## Recommendations
-{RECOMMENDATIONS}
+## Validation
+Ensure that `buildUIRecommendationsUserPrompt` now returns the full template string, and no trailing `...` or incomplete prompt is emitted. The tests in `tests/ui-creation-engine.test.js` should pass.
 
-## Risks
-{RISKS}
+## Blockers
+N/A — No blockers.


### PR DESCRIPTION
Rewritten WR document for issue 14071 as per the new Basic template rules, removed missing placeholders, and marked it as complete.

---
*PR created automatically by Jules for task [15239032756148951683](https://jules.google.com/task/15239032756148951683) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR rewrites a WR (Work Request) document for issue 14071, which addresses unreachable code caused by duplicate return statements in the `buildUIRecommendationsUserPrompt` function. The document has been reformatted according to new Basic template rules, removing placeholder text and marking the WR as complete. The dashboard files are automatically updated with new timestamps to reflect the changes.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `wr/issues/issue-14071-unreachable-code-duplicate-return-in-builduirecomm.md` |
| 2 | `dashboard-data.json` |
| 3 | `dashboard.html` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the WR for issue #14071 using the new Basic template, removing placeholders and marking it complete, with clear fix/DoD for the duplicate-return bug in `buildUIRecommendationsUserPrompt`. Updated dashboard timestamps to reflect the latest run.

<sup>Written for commit 903250024588eeb149ee527749d765e4c37aac6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

