### PR TITLE
🧹 remove unused asyncio import in opentopo.py

### DIFF
--- a/coldtrace/backend/services/opentopo.py
+++ b/coldtrace/backend/services/opentopo.py
@@ -6,7 +6,6 @@ Supports SRTMGL1 (30m global), COP30 (Copernicus 30m), and USGS1m (1m USA).
 
 from __future__ import annotations
 
-import asyncio
 import tempfile
 from pathlib import Path
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `asyncio` import in `coldtrace/backend/services/opentopo.py`.

💡 **Why:** Unused imports clutter the code and can lead to confusion. Removing them improves maintainability and readability.

✅ **Verification:** Verified by running the existing test suite using `PYTHONPATH=. python3 -m pytest coldtrace/backend/tests/`. All tests passed, including those for the modified service.

✨ **Result:** A cleaner and more maintainable `opentopo.py` file.

---
*PR created automatically by Jules for task [8834815507372963297](https://jules.google.com/task/8834815507372963297) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes an unused `asyncio` import from the `opentopo.py` service file to improve code cleanliness and maintainability. The change has been verified by running the existing test suite with all tests passing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `coldtrace/backend/services/opentopo.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `asyncio` import in coldtrace/backend/services/opentopo.py to reduce noise and improve readability.

<sup>Written for commit 6f187806bccf0ae60e1588e873959edf96a60a44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

