### PR TITLE
ralph-loop: skip merged/closed PRs (state guard)

### DIFF
--- a/.github/workflows/ralph-loop.yml
+++ b/.github/workflows/ralph-loop.yml
@@ -11,7 +11,15 @@ jobs:
   ralph-trigger:
     name: Ralph Loop — Trigger Fix
     runs-on: ubuntu-latest
-    if: github.event.check_suite.conclusion == 'failure'
+    # Only run on failures of check_suites whose linked PR is still OPEN.
+    # check_suite.completed fires for re-runs against merged/closed PRs too;
+    # without this guard, Ralph posts "Attempt N/5" comments on closed PRs
+    # and tries to push fix commits to merged branches. Per strict-reviewer
+    # audit finding on the agent fleet sweep.
+    if: |
+      github.event.check_suite.conclusion == 'failure' &&
+      (github.event.check_suite.pull_requests[0] == null ||
+       github.event.check_suite.pull_requests[0].state == 'open')
     steps:
       - name: Find matching open PR
         id: find-pr

--- a/.github/workflows/ralph-loop.yml
+++ b/.github/workflows/ralph-loop.yml
@@ -164,9 +164,14 @@ jobs:
   ralph-unblock:
     name: Ralph Loop — Unblock on Pass
     runs-on: ubuntu-latest
+    # Mirror the open-PR guard from ralph-trigger above. A successful check_suite
+    # re-run on a merged PR would otherwise mutate labels and post a redundant
+    # "All checks passed!" comment on a closed PR. Per Octopus review on #14369.
     if: |
-      github.event.check_suite.conclusion == 'success' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.check_suite.conclusion == 'success' ||
+       github.event.workflow_run.conclusion == 'success') &&
+      (github.event.check_suite.pull_requests[0] == null ||
+       github.event.check_suite.pull_requests[0].state == 'open')
     steps:
       - name: Find matching open PR
         id: find-pr


### PR DESCRIPTION
## Why

`ralph-loop.yml` listens on `check_suite.completed` events. A check suite can be re-run *after* its PR is merged or closed (manual retry, scheduled re-runs, GitHub's automatic retries). When that happens today, Ralph posts "🔄 Ralph Loop — Attempt N/5" comments on closed PRs and tries to push fix commits to already-merged branches.

We came close to watching this thrash on #14254 in the previous session.

## Fix

Guard the trigger condition with a PR-state check:

```yaml
if: |
  github.event.check_suite.conclusion == 'failure' &&
  (github.event.check_suite.pull_requests[0] == null ||
   github.event.check_suite.pull_requests[0].state == 'open')
```

- `pull_requests[0] == null` keeps manual (non-PR) check_suite runs working.
- `state == 'open'` skips merged/closed PRs.

## Verified

GitHub's `check_suite` payload `.pull_requests[*].state` is documented to be one of `open|closed`. Closed PRs (both merged and abandoned) return `closed`.

## Notes

One of nine cleanup PRs from the strict-reviewer audit. The Ralph self-healing loop still works on every genuinely-open PR — the only behavior change is that it stops firing on closed/merged ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a state guard to the `ralph-loop` workflow to prevent it from running on merged or closed pull requests. Previously, when check suites were re-run after a PR was merged or closed, Ralph would post retry comments and attempt to push fixes to already-merged branches. The fix adds a condition that checks if the associated PR is still open (or if there's no PR at all for manual runs) before triggering the workflow, ensuring Ralph only operates on genuinely open PRs.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/ralph-loop.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a state guard to the `ralph-loop` workflow so it only runs on failing check suites with an open PR (or no PR). This stops retry comments and fix pushes on merged or closed PRs.

- **Bug Fixes**
  - Added `if` guard to require `conclusion == 'failure'` and an open PR, or no PR association.
  - Prevents "Attempt N/5" comments and fix commits on closed/merged PRs; manual non-PR runs still work.

<sup>Written for commit f3c059883ef9ba777ef20cd351d26b414bddcad2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

