### PR TITLE
RCE-close on openrouter-coder lane: trigger-side author check + write-path deny-list

### DIFF
--- a/.github/scripts/openrouter_coder.py
+++ b/.github/scripts/openrouter_coder.py
@@ -43,7 +43,32 @@ def extract_json_payload(text: str) -> dict[str, Any]:
         return json.loads(candidate[start : end + 1])
 
 
+# RCE-close per the strict-reviewer audit: the model used to be able to write
+# anywhere inside the repo, including the very workflow and gate scripts that
+# invoke it. Overwriting `.github/workflows/*.yml` or `.github/scripts/*.py`
+# means the next workflow run (which holds `contents: write`) executes
+# attacker-controlled YAML. We therefore deny-list infrastructure paths and
+# executable file types at write time, in addition to the existing traversal
+# and absolute-path checks.
+_DENY_PATH_PREFIXES: tuple[str, ...] = (
+    ".github/",
+    "wr/scripts/",
+    "scripts/openrouter-personas",
+    "scripts/persona-",
+)
+_DENY_SUFFIXES: tuple[str, ...] = (".yml", ".yaml", ".sh")
+
+
 def validate_rel_path(path_value: str) -> Path:
+    """Validate a model-supplied relative repo path before writing to it.
+
+    RCE-close per the strict-reviewer audit: rejects traversal, absolute
+    paths, AND any write that targets the gate infrastructure
+    (`.github/`, `wr/scripts/`, persona scripts) or executable formats
+    (`*.yml`, `*.yaml`, `*.sh`, and `*.mjs` under any `scripts/` dir).
+    Raises ``PermissionError`` when the deny-list matches so the caller
+    can surface a clear, auditable failure to the issue thread.
+    """
     normalized_path = path_value.strip()
     if not normalized_path:
         raise ValueError("File path must not be empty.")
@@ -51,6 +76,38 @@ def validate_rel_path(path_value: str) -> Path:
     rel_path = Path(normalized_path)
     if rel_path == Path(".") or rel_path.is_absolute() or ".." in rel_path.parts:
         raise ValueError(f"Unsafe file path: {path_value}")
+
+    # Normalize to forward slashes for prefix/suffix matching regardless of OS.
+    posix_path = rel_path.as_posix()
+    lowered = posix_path.lower()
+
+    for prefix in _DENY_PATH_PREFIXES:
+        if posix_path.startswith(prefix):
+            raise PermissionError(
+                f"Refusing to write {path_value!r}: path is under the "
+                f"protected prefix {prefix!r} (RCE-close: model must not "
+                "overwrite workflow gates or persona scripts)."
+            )
+
+    for suffix in _DENY_SUFFIXES:
+        if lowered.endswith(suffix):
+            raise PermissionError(
+                f"Refusing to write {path_value!r}: file extension "
+                f"{suffix!r} is denied (RCE-close: workflows and shell "
+                "scripts are not model-writable)."
+            )
+
+    # `*.mjs` is only denied when it lives under a `scripts/` directory —
+    # those are the ones wired into automation lanes.
+    if lowered.endswith(".mjs") and (
+        posix_path.startswith("scripts/") or "/scripts/" in posix_path
+    ):
+        raise PermissionError(
+            f"Refusing to write {path_value!r}: `.mjs` files under a "
+            "`scripts/` directory are denied (RCE-close: would let the "
+            "model replace automation entrypoints)."
+        )
+
     return rel_path
 
 

--- a/.github/scripts/test_openrouter_coder.py
+++ b/.github/scripts/test_openrouter_coder.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Smoke tests for the openrouter_coder write-path deny-list.
+
+These exist to lock down the RCE-close added per the strict-reviewer audit:
+the model-driven coder must not be able to overwrite the very workflow gates
+and persona scripts that invoke it.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from openrouter_coder import validate_rel_path
+
+
+class ValidateRelPathTests(unittest.TestCase):
+    def test_allows_normal_docs_path(self) -> None:
+        self.assertEqual(validate_rel_path("docs/note.md"), Path("docs/note.md"))
+
+    def test_allows_normal_source_path(self) -> None:
+        self.assertEqual(validate_rel_path("src/foo/bar.py"), Path("src/foo/bar.py"))
+
+    def test_denies_github_workflow(self) -> None:
+        with self.assertRaises(PermissionError):
+            validate_rel_path(".github/workflows/foo.yml")
+
+    def test_denies_github_script(self) -> None:
+        with self.assertRaises(PermissionError):
+            validate_rel_path(".github/scripts/openrouter_coder.py")
+
+    def test_denies_wr_scripts(self) -> None:
+        with self.assertRaises(PermissionError):
+            validate_rel_path("wr/scripts/anything.js")
+
+    def test_denies_persona_scripts(self) -> None:
+        with self.assertRaises(PermissionError):
+            validate_rel_path("scripts/openrouter-personas/persona.json")
+        with self.assertRaises(PermissionError):
+            validate_rel_path("scripts/persona-runner.js")
+
+    def test_denies_yaml_anywhere(self) -> None:
+        with self.assertRaises(PermissionError):
+            validate_rel_path("config/thing.yaml")
+
+    def test_denies_shell_scripts(self) -> None:
+        with self.assertRaises(PermissionError):
+            validate_rel_path("tools/setup.sh")
+
+    def test_denies_mjs_under_scripts_dir(self) -> None:
+        with self.assertRaises(PermissionError):
+            validate_rel_path("scripts/runner.mjs")
+
+    def test_allows_mjs_outside_scripts_dir(self) -> None:
+        self.assertEqual(
+            validate_rel_path("src/lib/helper.mjs"),
+            Path("src/lib/helper.mjs"),
+        )
+
+    def test_rejects_traversal(self) -> None:
+        with self.assertRaises(ValueError):
+            validate_rel_path("../etc/passwd")
+
+    def test_rejects_absolute(self) -> None:
+        with self.assertRaises(ValueError):
+            validate_rel_path("/etc/passwd")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/openrouter-coder.yml
+++ b/.github/workflows/openrouter-coder.yml
@@ -31,6 +31,10 @@ jobs:
         github.event.label.name == 'spec-approved')) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.user.login != 'github-actions[bot]' &&
+       github.event.comment.user.login != 'github-actions[bot]' &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR') &&
        !startsWith(github.event.issue.title, '[FAILURE]') &&
        !startsWith(github.event.issue.title, '[ALERT]') &&
        contains(github.event.comment.body, 'Research Findings:'))


### PR DESCRIPTION
## Why

Per the strict-reviewer audit, the `openrouter-coder` lane has two RCE-class holes that this PR closes in one commit.

### Attack scenario 1 — drive-by comment trigger (paid burn + repo write)

The workflow runs on every `issue_comment` whose body contains `Research Findings:`. The only author check today is on the *issue* author, not the *comment* author. **Anyone with read access** can drop that string in a comment under any open issue and trigger a paid OpenRouter run that opens a PR back into the repo. With `contents: write` on the job, this is a real RCE primitive.

### Attack scenario 2 — model overwrites its own gates

`validate_rel_path()` rejects `..` and absolute paths but happily lets the model write to `.github/workflows/*.yml`, `.github/scripts/*.py`, `wr/scripts/*`, and the persona automation. A single crafted issue body can ship a JSON payload that rewrites the very workflow that just executed it. Next event → attacker-controlled YAML runs with `contents: write`.

## Fix 1 — trigger gate

**Before** (`.github/workflows/openrouter-coder.yml` L32-36):

```yaml
(github.event_name == 'issue_comment' &&
 github.event.issue.user.login != 'github-actions[bot]' &&
 !startsWith(github.event.issue.title, '[FAILURE]') &&
 !startsWith(github.event.issue.title, '[ALERT]') &&
 contains(github.event.comment.body, 'Research Findings:'))
```

**After**:

```yaml
(github.event_name == 'issue_comment' &&
 github.event.issue.user.login != 'github-actions[bot]' &&
 github.event.comment.user.login != 'github-actions[bot]' &&
 (github.event.comment.author_association == 'OWNER' ||
  github.event.comment.author_association == 'MEMBER' ||
  github.event.comment.author_association == 'COLLABORATOR') &&
 !startsWith(github.event.issue.title, '[FAILURE]') &&
 !startsWith(github.event.issue.title, '[ALERT]') &&
 contains(github.event.comment.body, 'Research Findings:'))
```

Drive-by commenters (`NONE`, `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, `CONTRIBUTOR`, `MANNEQUIN`) no longer trigger. Comment-author bot exclusion now mirrors the issue-author check.

## Fix 2 — write-path deny-list

`validate_rel_path()` in `.github/scripts/openrouter_coder.py` now raises `PermissionError` (clear, path-named message, docstring noting this is the RCE-close per the strict-reviewer audit) when the model tries to write to:

**Denied prefixes**
- `.github/` — workflows and gate scripts
- `wr/scripts/` — work-request automation
- `scripts/openrouter-personas` — persona configs
- `scripts/persona-` — persona runners

**Denied suffixes**
- `*.yml`, `*.yaml` — anywhere in the tree
- `*.sh` — anywhere in the tree
- `*.mjs` — only when under a `scripts/` directory (regular library `.mjs` stays writable)

Existing traversal / absolute-path / empty-path checks are preserved.

## Tests

Added `.github/scripts/test_openrouter_coder.py` with 12 cases — every deny rule plus allow-list smoke tests (`docs/note.md`, `src/foo/bar.py`, `src/lib/helper.mjs`). All pass locally:

```
Ran 12 tests in 0.002s
OK
```

`python -m py_compile` clean. `actionlint` not available in the sandbox.

## Scope

Three files only — workflow, script, test. No other workflows, `wr/scripts/`, or persona code touched. Diff ~95 lines.

## Test plan

- [ ] Verify CI runs the python unit tests (or run `python -m unittest .github/scripts/test_openrouter_coder.py` locally)
- [ ] Confirm a drive-by user (read-only) commenting `Research Findings:` no longer triggers the workflow
- [ ] Confirm an OWNER/MEMBER/COLLABORATOR commenting `Research Findings:` still triggers
- [ ] Confirm an issue whose model output targets `.github/workflows/foo.yml` fails fast with the new `PermissionError`

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_