### PR TITLE
WR backfill: strip leftover scaffolding from 14 pre-gate WR files

### DIFF
--- a/wr/issues/issue-13834-assign-codeql-to-api-endpoints-and-everything-with.md
+++ b/wr/issues/issue-13834-assign-codeql-to-api-endpoints-and-everything-with.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -918,14 +909,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-24  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-13863-create-process-that-flags-off-duplicate-wr-and-pr.md
+++ b/wr/issues/issue-13863-create-process-that-flags-off-duplicate-wr-and-pr.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -918,14 +909,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-24  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-13872-consolidate-standards-files-into-standards-directo.md
+++ b/wr/issues/issue-13872-consolidate-standards-files-into-standards-directo.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -961,14 +952,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-24  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-13882-build-a-full-stack-emergency-intelligence-platform.md
+++ b/wr/issues/issue-13882-build-a-full-stack-emergency-intelligence-platform.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -1075,14 +1066,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-25  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-13886-social-agent-ecosystem-wr-working-requirements-pro.md
+++ b/wr/issues/issue-13886-social-agent-ecosystem-wr-working-requirements-pro.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -228,18 +219,13 @@ The system operates using the following reasoning architecture:
 
 1. UNDERSTAND
 
-
 2. ANALYZE
-
 
 3. REASON
 
-
 4. SYNTHESIZE
 
-
 5. CONCLUDE
-
 
 6. SELF-HEAL
 
@@ -453,7 +439,6 @@ TypeScript
 
 Framer Motion
 
-
 Deploy:
 
 Vercel
@@ -496,7 +481,6 @@ Azure SQL
 
 SQL Server
 
-
 Reason: Existing SQL knowledge and enterprise reporting compatibility.
 
 ---
@@ -531,7 +515,6 @@ Claude Sonnet
 
 Gemini Pro
 
-
 Critics / Red-team
 
 DeepSeek
@@ -539,7 +522,6 @@ DeepSeek
 Qwen
 
 Kimi
-
 
 Coding / repo automation
 
@@ -653,9 +635,7 @@ Messenger Webhooks
 
 FastAPI endpoints
 
-
 Workflow: Message → webhook → agent router → AI response → reply
-
 
 ---
 
@@ -672,7 +652,6 @@ excellent bot support
 stable APIs
 
 low friction
-
 
 Use:
 
@@ -709,7 +688,6 @@ aggressive automation
 spam commenting
 
 high-frequency scraping
-
 
 Preferred:
 
@@ -822,9 +800,7 @@ preview deployments
 
 rollback orchestration
 
-
 GitHub Actions should remain lightweight.
-
 
 ---
 
@@ -908,7 +884,6 @@ enterprise orchestration,
 
 and autonomous multi-agent collaboration frameworks.
 
-
 The platform should eventually function as:
 
 an emergency intelligence layer,
@@ -935,7 +910,6 @@ build simple agent router
 
 add Supabase auth/database
 
-
 Week 2
 
 add image upload analysis
@@ -948,7 +922,6 @@ add GitHub issue generation
 
 add workflow generation
 
-
 Week 3
 
 add Discord integration
@@ -958,7 +931,6 @@ add Facebook Messenger integration
 add MCP tools
 
 add environmental modules
-
 
 Week 4+
 
@@ -973,8 +945,6 @@ add enterprise reporting
 add CircleCI
 
 add Azure SQL migration layer
-
-
 
 ---
 
@@ -995,7 +965,6 @@ source-verified,
 correction-first,
 
 and progressively scalable.
-
 
 The goal is not one giant omniscient AI.
 
@@ -1038,7 +1007,6 @@ enterprise direction
 UX philosophy
 
 long-term autonomous ecosystem vision
-
 
 It’s structured so you can hand it to:
 
@@ -1850,14 +1818,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-25  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-13894-music-video-generation-website.md
+++ b/wr/issues/issue-13894-music-video-generation-website.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -928,14 +919,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-25  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-13995-fix-out-of-scope-mcppromptpack-variable-causing-mc.md
+++ b/wr/issues/issue-13995-fix-out-of-scope-mcppromptpack-variable-causing-mc.md
@@ -8,13 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
 <!-- Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended) -->
 
 # WR: midnghtsapphire/revvel-standards
@@ -864,14 +857,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-30  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-13997-add-test-coverage-for-audit-third-party-actions-sh.md
+++ b/wr/issues/issue-13997-add-test-coverage-for-audit-third-party-actions-sh.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -865,14 +856,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-30  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-14010-remove-redundant-red-ocean-100-cap-test-or-clarify.md
+++ b/wr/issues/issue-14010-remove-redundant-red-ocean-100-cap-test-or-clarify.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -863,14 +854,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-30  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-14012-separate-generated-dashboard-html-artifact-from-fe.md
+++ b/wr/issues/issue-14012-separate-generated-dashboard-html-artifact-from-fe.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -864,14 +855,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-30  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-14024-add-source-citations-for-seo-keyword-volume-and-cp.md
+++ b/wr/issues/issue-14024-add-source-citations-for-seo-keyword-volume-and-cp.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -874,14 +865,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-30  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-14027-nppes-test-incorrectly-rejects-valid-empty-results.md
+++ b/wr/issues/issue-14027-nppes-test-incorrectly-rejects-valid-empty-results.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -863,14 +854,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-30  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-14028-replace-fragile-marketing-copy-assertion-in-landin.md
+++ b/wr/issues/issue-14028-replace-fragile-marketing-copy-assertion-in-landin.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -864,14 +855,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-30  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────

--- a/wr/issues/issue-14060-standardize-blockquote-attributions-in-caveat-note.md
+++ b/wr/issues/issue-14060-standardize-blockquote-attributions-in-caveat-note.md
@@ -8,15 +8,6 @@
 
 ---
 
-
-# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
-
-#
-
-# ─────────────────────────────────────────────────────────────────────────────
-
-#
-
 # WR: midnghtsapphire/revvel-standards
 
 **Repository:** [midnghtsapphire/revvel-standards](https://github.com/midnghtsapphire/revvel-standards)  
@@ -864,14 +855,9 @@ This prevents copy/paste execution of low-quality or conflicting ideas and keeps
 **Last Updated:** 2026-05-30  
 **Next Review:** [Date in YYYY-MM-DD format or "After implementation"]
 
-# ─────────────────────────────────────────────────────────────────────────────
-
 # END ADVANCED TEMPLATE
-
-#
 
 # For advanced users who want full control
 
 # Use WR_TEMPLATE_BASIC.md for simple WRs (recommended)
 
-# ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

14 WR files merged before `wr-lint.yml` / `fix-wr-gate.yml` landed still carry the generator scaffolding that today's lint rejects:

```
# Otherwise, use WR_TEMPLATE_BASIC.md instead (recommended)
#
# ─────────────────────────────────────────────────────────────────
```

Running `wr-lint.mjs` against any of them fails. They're invisible regressions waiting to fire the next time someone touches the file.

## What

Stripped the three scaffolding patterns from each file, collapsed the resulting double-blank lines:

| Files | Change |
|-------|--------|
| 14 files under `wr/issues/` | -217 lines (scaffolding artifacts only) |

No content was lost — only generator boilerplate that should never have shipped to main.

## Files touched

- `issue-13834-assign-codeql...`
- `issue-13863-create-process-that-flags-off-duplicate...`
- `issue-13872-consolidate-standards-files...`
- `issue-13882-build-a-full-stack-emergency-intelligence...`
- `issue-13886-social-agent-ecosystem...`
- `issue-13894-music-video-generation-website`
- `issue-13995-fix-out-of-scope-mcppromptpack...`
- `issue-13997-add-test-coverage...`
- `issue-14010-remove-redundant-red-ocean...`
- `issue-14012-separate-generated-dashboard-html...`
- `issue-14024-add-source-citations-for-seo...`
- `issue-14027-nppes-test-incorrectly-rejects...`
- `issue-14028-replace-fragile-marketing-copy...`
- `issue-14060-standardize-blockquote-attributions...`

## Notes

One of nine cleanup PRs from the strict-reviewer audit (14-day merged-PR sweep finding).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes obsolete generator scaffolding comments from 14 Working Requirements (WR) markdown files that were merged before the `wr-lint.yml` gate was implemented. The scaffolding patterns being removed include template instruction comments and separator lines that current linting rules reject. All 14 files receive identical cleanup: removing three specific comment blocks and collapsing resulting double-blank lines, totaling 217 lines of pure boilerplate removal with no content changes.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `wr/issues/issue-13834-assign-codeql-to-api-endpoints-and-everything-with.md` |
| 2 | `wr/issues/issue-13863-create-process-that-flags-off-duplicate-wr-and-pr.md` |
| 3 | `wr/issues/issue-13872-consolidate-standards-files-into-standards-directo.md` |
| 4 | `wr/issues/issue-13882-build-a-full-stack-emergency-intelligence-platform.md` |
| 5 | `wr/issues/issue-13886-social-agent-ecosystem-wr-working-requirements-pro.md` |
| 6 | `wr/issues/issue-13894-music-video-generation-website.md` |
| 7 | `wr/issues/issue-13995-fix-out-of-scope-mcppromptpack-variable-causing-mc.md` |
| 8 | `wr/issues/issue-13997-add-test-coverage-for-audit-third-party-actions-sh.md` |
| 9 | `wr/issues/issue-14010-remove-redundant-red-ocean-100-cap-test-or-clarify.md` |
| 10 | `wr/issues/issue-14012-separate-generated-dashboard-html-artifact-from-fe.md` |
| 11 | `wr/issues/issue-14024-add-source-citations-for-seo-keyword-volume-and-cp.md` |
| 12 | `wr/issues/issue-14027-nppes-test-incorrectly-rejects-valid-empty-results.md` |
| 13 | `wr/issues/issue-14028-replace-fragile-marketing-copy-assertion-in-landin.md` |
| 14 | `wr/issues/issue-14060-standardize-blockquote-attributions-in-caveat-note.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed leftover WR template scaffolding from 14 pre-gate WR files so `wr-lint.mjs` passes and future edits don’t fail the lint gate. No content changes; only generator boilerplate was deleted.

- **Bug Fixes**
  - Removed generator scaffolding lines across 14 files under `wr/issues/`.
  - Collapsed extra blank lines after removal.
  - Restores compatibility with `wr-lint.mjs` and the current lint gate.

<sup>Written for commit 509fbb31eb646f5311da48734cac89d74537b1ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

