### PR TITLE
WR/PR gate v3: allowlist-based lint, gate fixes, full test suite

### DIFF
--- a/.github/workflows/wr-lint.yml
+++ b/.github/workflows/wr-lint.yml
@@ -1,9 +1,21 @@
 name: WR Lint
 on:
   pull_request:
-    paths: ["wr/issues/**.md"]
+    paths:
+      - "wr/issues/**.md"
+      # Audit finding C.1: when the linter or template itself changes,
+      # re-run lint (including the golden-sample suite below).
+      - "wr/scripts/**"
+      - "wr/WR_TEMPLATE_*.md"
+      - ".github/workflows/wr-*.yml"
+      - "wr/tests/fixtures/**.md"
   push:
-    paths: ["wr/issues/**.md"]
+    paths:
+      - "wr/issues/**.md"
+      - "wr/scripts/**"
+      - "wr/WR_TEMPLATE_*.md"
+      - ".github/workflows/wr-*.yml"
+      - "wr/tests/fixtures/**.md"
 permissions:
   contents: read
 jobs:
@@ -22,13 +34,59 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
+          set -u
+          # Audit finding C.2: previously `2>&1` redirected stderr into the
+          # `files` variable, which would then be passed to node as bogus
+          # filenames. Redirect stderr to /dev/null instead, and detect git
+          # errors via the exit status.
           if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-            files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" -- 'wr/issues/*.md' 2>&1) || files=""
+            files=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" -- 'wr/issues/*.md' 2>/dev/null) || files=""
+            linter_changes=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" -- 'wr/scripts/*' 'wr/WR_TEMPLATE_*.md' 2>/dev/null) || linter_changes=""
           else
             files=""
+            linter_changes=""
           fi
-          if [ -z "$files" ]; then
-            echo "no WR files changed (or diff unavailable); skipping lint"
-            exit 0
+
+          fail=0
+
+          # Audit finding C.3: feed file list via xargs -d '\n' so paths
+          # with spaces / globs don't fall apart under word splitting.
+          if [ -n "$files" ]; then
+            echo "Linting changed WR files:"
+            printf '%s\n' "$files"
+            printf '%s\n' "$files" | xargs -d '\n' -r node wr/scripts/wr-lint.mjs || fail=1
+          else
+            echo "no WR files under wr/issues/ changed"
           fi
-          node wr/scripts/wr-lint.mjs $files
+
+          # Audit finding C.4: when the linter or templates change, run the
+          # golden-sample suite so regressions are caught at PR time.
+          if [ -n "$linter_changes" ]; then
+            echo
+            echo "Linter/template changed — running golden-sample suite:"
+            echo "  $linter_changes"
+
+            if compgen -G 'wr/tests/fixtures/golden-good/*.md' > /dev/null; then
+              echo "-- golden-good (must pass) --"
+              for f in wr/tests/fixtures/golden-good/*.md; do
+                if ! node wr/scripts/wr-lint.mjs "$f"; then
+                  echo "REGRESSION: golden-good fixture failed lint: $f" >&2
+                  fail=1
+                fi
+              done
+            fi
+
+            if compgen -G 'wr/tests/fixtures/golden-bad/*.md' > /dev/null; then
+              echo "-- golden-bad (must fail) --"
+              for f in wr/tests/fixtures/golden-bad/*.md; do
+                if node wr/scripts/wr-lint.mjs "$f" > /dev/null 2>&1; then
+                  echo "REGRESSION: golden-bad fixture passed lint when it must fail: $f" >&2
+                  fail=1
+                else
+                  echo "  ok (failed as expected): $f"
+                fi
+              done
+            fi
+          fi
+
+          exit "$fail"

--- a/.github/workflows/wr-lint.yml
+++ b/.github/workflows/wr-lint.yml
@@ -49,12 +49,15 @@ jobs:
 
           fail=0
 
-          # Audit finding C.3: feed file list via xargs -d '\n' so paths
-          # with spaces / globs don't fall apart under word splitting.
+          # Audit finding C.3: feed file list via NUL-separated xargs so
+          # paths with spaces / globs don't fall apart under word splitting.
+          # Uses `tr '\n' '\0' | xargs -0` for portability — `xargs -d` is a
+          # GNU extension and breaks on macOS/BSD. Per Octopus review on
+          # this PR.
           if [ -n "$files" ]; then
             echo "Linting changed WR files:"
             printf '%s\n' "$files"
-            printf '%s\n' "$files" | xargs -d '\n' -r node wr/scripts/wr-lint.mjs || fail=1
+            printf '%s\n' "$files" | tr '\n' '\0' | xargs -0 -r node wr/scripts/wr-lint.mjs || fail=1
           else
             echo "no WR files under wr/issues/ changed"
           fi

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "engine": "node engines/runner-orchestrator/orchestrate.js",
     "test:cov": "c8 --reporter=text --reporter=lcov node --test tests",
     "test:sh": "bash tests/social_post_formatter.test.sh",
+    "test:wr": "node --test wr/tests/wr-lint.test.mjs wr/tests/fix-wr-gate.test.mjs",
     "typecheck": "tsc -p tsconfig.json",
     "build": "npm run typecheck",
     "lint": "npx markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.git\"",

--- a/wr/WR_TEMPLATE_FULL.md
+++ b/wr/WR_TEMPLATE_FULL.md
@@ -33,15 +33,30 @@
 {EXECUTIVE_SUMMARY}
 
 ## Step 1A — Product/Output Selections
+- Primary option: [Option 1]
+- Backup option: [Option 2]
+- Outcome decision required: [Yes/No]
+
 {PRODUCT_SELECTIONS}
 
 ## Step 2 — Deep Web Research
+[Research findings...]
+
+| Primary keyword | Volume | CPC |
+| --- | --- | --- |
+| [primary keyword 1] | [volume] | [$CPC] |
+| [primary keyword 2] | [volume] | [$CPC] |
+
 {DEEP_WEB_RESEARCH}
 
 ## Step 3 — Requirements
 {REQUIREMENTS}
 
 ## Recommendations
+- Pricing: [Pricing]
+- Fix to ship first: [Fix]
+- Last reviewed: [Date and summary]
+
 {RECOMMENDATIONS}
 
 ## Risks

--- a/wr/scripts/fix-wr-gate.mjs
+++ b/wr/scripts/fix-wr-gate.mjs
@@ -6,7 +6,9 @@
 // Usage: node fix-wr-gate.mjs --changed <file-list-newline-or-comma> [--labels <csv>] [--title "<pr title>"] [--body "<pr body>"]
 //   exit 0 = pass, 1 = gate violation.
 //
-// "Real fix" = any changed file NOT under wr/ and NOT a pure docs/tracking artifact.
+// "Real fix" = any changed file outside wr/, OR specific allowlisted wr/ paths
+// (wr/scripts/, wr/WR_TEMPLATE_*.md, wr/README.md) because fixes to the gate
+// itself or the templates are also genuine fixes.
 // Tracking-only escape hatch = PR has a label in TRACKING_LABELS or title starts with a TRACKING_PREFIX
 // AND the body carries an explicit `Tracks: #NNNN` reference to the follow-up issue/PR that will apply the fix.
 
@@ -16,24 +18,52 @@ const get = (n) => { const i = args.indexOf(`--${n}`); return i >= 0 ? args[i + 
 const changedRaw = get("changed");
 const labels = get("labels").split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
 const title = get("title") || "";
-const body  = get("body")  || "";
+const bodyRaw = get("body")  || "";
+
+// Audit finding B.2: `Tracks: #N` regex matched inside fenced code blocks
+// (```...```) and blockquotes (`^>`). Strip those before testing so a
+// quoted/commented-out tracking ref can't satisfy the gate.
+function stripCodeAndQuotes(s) {
+  // strip ```...``` fenced blocks
+  let out = s.replace(/```[\s\S]*?```/g, "");
+  // strip ~~~...~~~ fenced blocks
+  out = out.replace(/~~~[\s\S]*?~~~/g, "");
+  // strip blockquote lines (^>) line-by-line
+  out = out.split("\n").filter((l) => !/^\s{0,3}>/.test(l)).join("\n");
+  return out;
+}
+const body = stripCodeAndQuotes(bodyRaw);
 
 // "Tracks: #1234" or "Tracks #1234" or "Tracking: #1234" — case-insensitive,
 // allows owner/repo qualified forms too ("Tracks: foo/bar#1234").
 const TRACKS_REF = /\btrack(?:s|ing)?\s*[: ]\s*([A-Za-z0-9_.\/-]+)?#\d+/i;
 
 const TRACKING_LABELS = ["tracking-only", "wr-docs", "wr-tracking", "meta-tracking", "docs-only"];
-const TRACKING_PREFIXES = [/^\[wr-docs\]/i, /^\[wr-tracking\]/i, /^track\b/i, /^\[track\]/i];
+// Audit finding B.1: the bare `/^track\b/i` matched legitimate titles like
+// "Track down regression" / "Tracking memory leak". Keep only the bracketed
+// forms which are unambiguous tracking-PR markers.
+const TRACKING_PREFIXES = [/^\[wr-docs\]/i, /^\[wr-tracking\]/i, /^\[track\]/i];
 
 // Title signals this PR claims to FIX something (not just track it).
 const FIX_SIGNAL = /\b(fix|resolve|repair|correct|patch|remove|add (missing|the)|implement)\b/i;
 
 const changed = changedRaw.split(/[\n,]/).map((s) => s.trim()).filter(Boolean);
 
-function isRealFix(path) {
-  if (path.startsWith("wr/")) return false;                 // WR tracking docs don't count
-  if (/^docs\/.*\.md$/i.test(path)) return true;            // a docs FIX (e.g. broken link) IS the fix
-  return true;                                              // any code/config/workflow file counts
+// Audit finding B.3: `wr/` was a blanket "not a real fix", which blocked
+// legitimate fixes to the gate scripts / templates / readme themselves. Add
+// an explicit allowlist for those.
+const WR_REAL_FIX_ALLOWLIST = [
+  /^wr\/scripts\//,
+  /^wr\/WR_TEMPLATE_.*\.md$/,
+  /^wr\/README\.md$/,
+];
+
+function isRealFix(p) {
+  if (p.startsWith("wr/")) {
+    return WR_REAL_FIX_ALLOWLIST.some((re) => re.test(p));
+  }
+  if (/^docs\/.*\.md$/i.test(p)) return true;            // a docs FIX (e.g. broken link) IS the fix
+  return true;                                            // any code/config/workflow file counts
 }
 
 const realFixFiles = changed.filter(isRealFix);

--- a/wr/scripts/generate-wr.sh
+++ b/wr/scripts/generate-wr.sh
@@ -16,7 +16,21 @@ esac; done
 
 [[ -z "$TITLE" ]] && { echo "need --title" >&2; exit 2; }
 HERE="$(cd "$(dirname "$0")/.." && pwd)"   # wr/
-ISSUE_BODY="$( [[ -n "$BODY_FILE" && -f "$BODY_FILE" ]] && cat "$BODY_FILE" || echo "_No issue body provided._" )"
+
+# Audit finding A.5: the original `&&...||...` ternary silently swallowed any
+# `cat` failure (read error, perm error, partial file) and replaced it with the
+# "no issue body" fallback even when --body-file WAS passed. Use an explicit
+# if/then/else so a real read failure aborts the generator.
+if [[ -n "$BODY_FILE" ]]; then
+  if [[ ! -f "$BODY_FILE" ]]; then
+    echo "--body-file '$BODY_FILE' does not exist" >&2; exit 2
+  fi
+  if ! ISSUE_BODY="$(cat "$BODY_FILE")"; then
+    echo "failed to read --body-file '$BODY_FILE'" >&2; exit 2
+  fi
+else
+  ISSUE_BODY="_No issue body provided._"
+fi
 
 # ---- FIX (class 2): select template by issue class instead of always FULL ----
 # ERE doesn't support \b word boundaries — they're matched literally and the
@@ -94,8 +108,9 @@ subst REQUIREMENTS      "$(jq_get requirements)"
 subst RECOMMENDATIONS   "$(jq_get recommendations)"
 subst RISKS             "$(jq_get risks)"
 
-# Any token left unfilled becomes an explicit N/A marker, never a raw {TOKEN} or empty.
-out="$(echo "$out" | sed -E 's/\{[A-Z_]+\}/N\/A/g')"
+# Audit finding A.3: the previous fallback `sed -E 's/\{[A-Z_]+\}/N\/A/g'`
+# papered over missing substitutions and made lint pass on broken generation.
+# REMOVED — the linter (wr-lint.mjs, rule 5) catches missing tokens explicitly.
 # Any empty filled section line -> N/A with reason (basic class has no market sections to worry about).
 out="$(echo "$out" | sed -E 's/^([A-Za-z].*:)[[:space:]]*$/\1 N\/A/')"
 

--- a/wr/scripts/wr-lint.mjs
+++ b/wr/scripts/wr-lint.mjs
@@ -2,8 +2,25 @@
 // wr-lint.mjs — gate for WR/PR markdown. Catches the recurring review failures automatically.
 // Usage: node wr-lint.mjs <file-or-glob...>   |   exit 0 clean, 1 issues found.
 // Wire into CI / review-agent pass so these never reach a human reviewer.
+//
+// v3 (strict-reviewer audit): the bracket-placeholder heuristic and the
+// fixed RAW_TOKENS enum both produced false positives / false negatives.
+// They have been replaced with:
+//   (a) a runtime allowlist of bracket placeholders extracted from the
+//       WR_TEMPLATE_*.md files at startup. Only those exact strings are
+//       forbidden when found in a generated WR — legitimate prose like
+//       "[Closes #123]" or "[TODO: refactor]" no longer false-positives.
+//   (b) a generic uppercase-snake-case curly-token detector
+//       (`/\{[A-Z_][A-Z0-9_]*\}/`) so any new token added to the
+//       generator is caught without code changes here.
 
 import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Templates live at wr/WR_TEMPLATE_*.md; this script lives at wr/scripts/.
+const WR_DIR = path.resolve(__dirname, "..");
 
 const SCAFFOLD_PATTERNS = [
   { re: /^#\s*Otherwise,\s*use\s+WR_TEMPLATE_BASIC\.md/im, msg: "template scaffolding comment ('Otherwise, use WR_TEMPLATE_BASIC.md') left in rendered output" },
@@ -26,17 +43,57 @@ const PRODUCT_SECTIONS = [
   "Product/Output Selections", "Deep Web Research", "Prime Directive"
 ];
 
+// FULL-template headings that signal the WR was generated FROM the full
+// template. If none of these are present, the doc looks like a basic WR
+// (a strong fallback signal when the title verb doesn't classify cleanly).
+const FULL_TEMPLATE_HEADINGS = [
+  "Executive Summary", "Deep Web Research", "BOM",
+  "Step 1A", "Step 2", "Step 3", "Repository Metadata", "Research Checklist"
+];
+
 // Title/type signals that mean BASIC template (no market research).
-const BASIC_SIGNALS = /\b(bug|fix|style|refactor|typo|lint|unreachable|duplicate|docs?-only|chore)\b/i;
+// Audit finding A.4: extend with explicit verbs (remove/delete/fix/patch/
+// chore/docs/refactor/lint/format/typo/style) so titles like
+// "Remove unused MCP route" classify as basic and trigger the wrong-template
+// product-sections check.
+const BASIC_SIGNALS = /\b(bug|fix|style|refactor|typo|lint|unreachable|duplicate|docs?-only|chore|remove|delete|patch|docs?|format)\b/i;
+const BASIC_TITLE_VERBS = /^\s*(remove|delete|fix|patch|chore|docs?|refactor|lint|format|typo|style)\b/i;
 
-// Unsubstituted generator tokens that must never ship.
-const RAW_TOKENS = /\{(STARS|OPEN_ISSUES|IS_PRIVATE|IS_ARCHIVED|DESCRIPTION|REPO|LANGUAGE)\}/;
+// Generic unsubstituted-generator-token detector. Matches any UPPER_SNAKE
+// curly token (`{STARS}`, `{NEW_TOKEN}`, `{REPO_NAME_2}`), so adding a
+// fresh placeholder to the generator no longer silently passes lint.
+const RAW_TOKEN = /\{[A-Z_][A-Z0-9_]*\}/;
 
-// Bracket placeholders the full template leaves behind.
-const BRACKET_PLACEHOLDER = /\[(Yes\/No|engine|notes|Pattern \d|Option \d|primary keyword \d|\$CPC|\$amount[^\]]*|volume|Vercel URL[^\]]*|Complaint \d|Action \d|2-3 sentence summary[^\]]*|Tree structure[^\]]*|Research findings[^\]]*|Fix|Pricing|Date and summary)\]/gi;
+// Load bracket placeholders from the template files at startup.
+// Anything else found in `[…]` in a rendered WR is treated as legitimate prose.
+function loadTemplatePlaceholders() {
+  const placeholders = new Set();
+  const files = ["WR_TEMPLATE_BASIC.md", "WR_TEMPLATE_FULL.md"];
+  for (const f of files) {
+    const p = path.join(WR_DIR, f);
+    if (!fs.existsSync(p)) continue;
+    const txt = fs.readFileSync(p, "utf8");
+    // Capture every `[…]` that looks like a placeholder (no nested brackets,
+    // not a markdown link `[txt](url)`, not a checkbox `[ ]`/`[x]`).
+    const re = /\[([^\]\n]+)\]/g;
+    let m;
+    while ((m = re.exec(txt)) !== null) {
+      const inner = m[1];
+      // skip checkboxes
+      if (/^[ xX]$/.test(inner)) continue;
+      // skip markdown link forms: peek next char
+      const next = txt[m.index + m[0].length];
+      if (next === "(") continue;
+      placeholders.add(`[${inner}]`);
+    }
+  }
+  return placeholders;
+}
 
-function lintFile(path) {
-  const text = fs.readFileSync(path, "utf8");
+const TEMPLATE_PLACEHOLDERS = loadTemplatePlaceholders();
+
+function lintFile(filePath) {
+  const text = fs.readFileSync(filePath, "utf8");
   const lines = text.split("\n");
   const issues = [];
 
@@ -73,17 +130,38 @@ function lintFile(path) {
     issues.push(`line ${ln}: scaffolding '# WR: <owner>/<repo>' header — strip it; the title H1 is the real header`);
   }
 
-  // 3. Raw bracketed placeholders (heuristic: short ALL/Title-case tokens in brackets, not links).
+  // 3. Raw bracketed placeholders.
+  // Audit finding A.1: the old heuristic (any `[A-Za-z][^\]]{2,60}]`) false-
+  // positived on legitimate prose like `[Closes #123]`, `[TODO: refactor]`,
+  // `[RFC 2119]`. Replaced with a strict allowlist: only the exact bracket
+  // strings extracted from the template files are forbidden. Everything
+  // else in brackets is treated as legitimate prose.
   lines.forEach((l, i) => {
     if (inFence[i]) return; // skip code examples
     // ignore markdown links [text](url) and checkboxes [ ]/[x]
     const stripped = l.replace(/\[[ xX]\]/g, "").replace(/\[[^\]]+\]\([^)]+\)/g, "");
-    const m = stripped.match(/\[[A-Za-z][^\]]{2,60}\]/);
-    if (m) issues.push(`line ${i + 1}: raw placeholder ${m[0]} — fill it or mark "N/A — <reason>"`);
+    for (const ph of TEMPLATE_PLACEHOLDERS) {
+      if (stripped.includes(ph)) {
+        issues.push(`line ${i + 1}: raw template placeholder ${ph} — fill it or mark "N/A — <reason>"`);
+        break; // one issue per line is enough
+      }
+    }
   });
 
   // 4. Template/type mismatch: BASIC-signal title but product sections present.
-  const isBasic = BASIC_SIGNALS.test(path) || BASIC_SIGNALS.test(lines[0] || "");
+  // Audit finding A.4: extend classification with verb-prefix on title and
+  // "looks like basic because it has none of the FULL headings" fallback.
+  const titleLine = lines[0] || "";
+  const verbBasic = BASIC_TITLE_VERBS.test(titleLine.replace(/^#\s*WR:\s*/i, ""));
+  const looksFull = FULL_TEMPLATE_HEADINGS.some((h) => {
+    const re = new RegExp(`^#{1,4}\\s+.*${h.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "im");
+    return re.test(text);
+  });
+  const isBasic =
+    BASIC_SIGNALS.test(filePath) ||
+    BASIC_SIGNALS.test(titleLine) ||
+    verbBasic ||
+    !looksFull;
   if (isBasic) {
     for (const sec of PRODUCT_SECTIONS) {
       const re = new RegExp(`^#{1,4}\\s*.*${sec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "im");
@@ -93,45 +171,30 @@ function lintFile(path) {
     }
   }
 
-  // 5. Unsubstituted generator tokens ({STARS} etc.)
-  const RAW_TOKENS_G = new RegExp(RAW_TOKENS.source, "g");
+  // 5. Unsubstituted generator tokens — generic UPPER_SNAKE curly-token detector.
+  // Audit finding A.2: fixed enum (STARS|OPEN_ISSUES|...) silently passed any
+  // new {TOKEN} the generator added. Use a generic regex instead.
+  const RAW_TOKEN_G = new RegExp(RAW_TOKEN.source, "g");
   lines.forEach((l, i) => {
     if (inFence[i]) return; // skip examples
-    const m = l.match(RAW_TOKENS_G);
+    const m = l.match(RAW_TOKEN_G);
     if (m) issues.push(`line ${i + 1}: unsubstituted generator token(s) ${[...new Set(m)].join(", ")} — substitute real value or remove the row`);
   });
 
-  // 6. Full-template bracket placeholders left raw.
-  lines.forEach((l, i) => {
-    if (inFence[i]) return; // skip examples
-    const m = l.match(BRACKET_PLACEHOLDER);
-    if (m) issues.push(`line ${i + 1}: raw template placeholder ${m[0]} — fill or mark "N/A — <reason>"`);
-  });
+  // 6. Removed: covered by the allowlist in rule 3 (BRACKET_PLACEHOLDER no
+  //    longer exists — TEMPLATE_PLACEHOLDERS is the single source of truth).
 
-  // 7. Falsely pre-checked checklist while body has any raw placeholders.
+  // 7. Falsely pre-checked checklist while body has any forbidden patterns.
   // Per Octopus review of #14118/#14138/#14224/#14225: ANY [x] check while
   // ANY forbidden pattern is in the doc is false-completion. The old
-  // threshold (≥5 [x] + narrow placeholder list) lets the worst offenders
+  // threshold (≥5 [x] + narrow placeholder list) let the worst offenders
   // through — a single [x] flipped on while {STARS} is still in the table
   // is the same false-completion signal.
-  // Build the forbidden-pattern detector once from the same rules used above
-  // (excluding code fences via the same inFence mask).
-  const FORBIDDEN_FOR_CHECKLIST = [
-    RAW_TOKENS,
-    // Non-global clone of BRACKET_PLACEHOLDER: the `g` flag makes `.test()`
-    // stateful (lastIndex), which can false-negative on repeat calls and
-    // let forbidden placeholders slip past the rule. Per Copilot review.
-    new RegExp(BRACKET_PLACEHOLDER.source, "i"),
-    /\[Yes\/No\]/i,
-    /\[Option \d+\]/i,
-    /\[Research findings\.\.\.\]/i,
-    /\[\$CPC\]/i,
-    /\[Date and summary\]/i,
-    /\[Fix\]/i,
-  ];
   const hasAnyForbidden = lines.some((l, i) => {
     if (inFence[i]) return false;
-    return FORBIDDEN_FOR_CHECKLIST.some((re) => re.test(l));
+    if (RAW_TOKEN.test(l)) return true;
+    for (const ph of TEMPLATE_PLACEHOLDERS) if (l.includes(ph)) return true;
+    return false;
   });
   const checkedItems = lines.reduce((n, l, i) => {
     if (inFence[i]) return n;

--- a/wr/tests/fix-wr-gate.test.mjs
+++ b/wr/tests/fix-wr-gate.test.mjs
@@ -1,0 +1,47 @@
+// fix-wr-gate.test.mjs — node:test suite for the fix-WR gate.
+// Drives the gate script as a child process for each row in
+// fixtures/fix-wr-gate-cases.json and asserts exit code matches `expect`.
+//
+// Run locally: node --test wr/tests/fix-wr-gate.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, "..", "..");
+const GATE = path.join(REPO, "wr", "scripts", "fix-wr-gate.mjs");
+const CASES = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "fixtures", "fix-wr-gate-cases.json"), "utf8")
+);
+
+function runGate({ title, body, labels, changed }) {
+  const args = [GATE, "--changed", changed, "--title", title, "--body", body];
+  if (labels) args.push("--labels", labels);
+  const r = spawnSync(process.execPath, args, { encoding: "utf8" });
+  return { code: r.status, stdout: r.stdout || "", stderr: r.stderr || "" };
+}
+
+for (const c of CASES) {
+  test(`fix-wr-gate: ${c.name} → ${c.expect} (${c.why})`, () => {
+    const r = runGate(c);
+    const expected = c.expect === "pass" ? 0 : 1;
+    assert.equal(
+      r.code,
+      expected,
+      `case "${c.name}" expected ${c.expect} (exit ${expected}), got exit ${r.code}\n` +
+        `title: ${c.title}\nlabels: ${c.labels}\nchanged: ${c.changed}\n` +
+        `body: ${JSON.stringify(c.body)}\nstdout:\n${r.stdout}\nstderr:\n${r.stderr}`
+    );
+  });
+}
+
+test("tracking-only with Tracks: ref produces note acknowledging acceptance", () => {
+  const c = CASES.find((x) => x.name === "tracking-only-with-tracks-ref");
+  const r = runGate(c);
+  assert.equal(r.code, 0);
+  assert.match(r.stdout, /tracking-only fix WR accepted/);
+});

--- a/wr/tests/fixtures/fix-wr-gate-cases.json
+++ b/wr/tests/fixtures/fix-wr-gate-cases.json
@@ -1,0 +1,92 @@
+[
+  {
+    "name": "tracking-only-with-tracks-ref",
+    "title": "[WR-DOCS] Fix regression in router",
+    "body": "Tracks: #4321\n\nDocuments the bug; fix follows in #4321.",
+    "labels": "wr-docs",
+    "changed": "wr/issues/issue-100-router-bug.md",
+    "expect": "pass",
+    "why": "Labeled tracking + body has explicit Tracks: #NNNN ref."
+  },
+  {
+    "name": "tracking-only-no-ref",
+    "title": "[WR-DOCS] Fix router bug",
+    "body": "Will sort this out later.",
+    "labels": "wr-docs",
+    "changed": "wr/issues/issue-100-router-bug.md",
+    "expect": "fail",
+    "why": "Tracking label without a Tracks: ref is an escape hatch — must fail."
+  },
+  {
+    "name": "tracking-only-tracks-in-codeblock",
+    "title": "[WR-DOCS] Fix router bug",
+    "body": "Example body for docs:\n\n```\nTracks: #4321\n```\n\n(not a real ref)",
+    "labels": "wr-docs",
+    "changed": "wr/issues/issue-100-router-bug.md",
+    "expect": "fail",
+    "why": "B.2 — Tracks ref inside a fenced code block must not satisfy the gate."
+  },
+  {
+    "name": "tracking-only-tracks-in-blockquote",
+    "title": "[WR-DOCS] Fix router bug",
+    "body": "Quoting the original report:\n\n> Tracks: #4321\n\nReal follow-up TBD.",
+    "labels": "wr-docs",
+    "changed": "wr/issues/issue-100-router-bug.md",
+    "expect": "fail",
+    "why": "B.2 — Tracks ref inside a blockquote must not satisfy the gate."
+  },
+  {
+    "name": "title-starts-with-track-prefix",
+    "title": "Track and fix the regression in user-service",
+    "body": "Looking into the regression now; no Tracks ref because this PR is supposed to BE the fix.",
+    "labels": "",
+    "changed": "wr/issues/issue-100-router-bug.md",
+    "expect": "fail",
+    "why": "B.1 — bare `track` prefix no longer counts as tracking-only marker; PR still claims a fix and only touches wr/, so gate must fail."
+  },
+  {
+    "name": "real-fix-in-wr-scripts",
+    "title": "Fix off-by-one in wr-lint.mjs token detector",
+    "body": "Patches the linter itself; no Tracks ref needed.",
+    "labels": "",
+    "changed": "wr/scripts/wr-lint.mjs",
+    "expect": "pass",
+    "why": "B.3 — wr/scripts/ is allowlisted as a real-fix path."
+  },
+  {
+    "name": "real-fix-in-wr-template",
+    "title": "Fix typo in WR_TEMPLATE_FULL.md",
+    "body": "Single character typo fix in the template.",
+    "labels": "",
+    "changed": "wr/WR_TEMPLATE_FULL.md",
+    "expect": "pass",
+    "why": "B.3 — wr/WR_TEMPLATE_*.md is allowlisted as a real-fix path."
+  },
+  {
+    "name": "code-file-changed-no-label",
+    "title": "Fix duplicate return in user-service",
+    "body": "Removes the duplicate `return` and adds a regression test.",
+    "labels": "",
+    "changed": "services/user-service.ts\ntests/user-service.test.ts",
+    "expect": "pass",
+    "why": "Real code files changed — the canonical happy path."
+  },
+  {
+    "name": "wr-only-no-real-fix-no-tracking",
+    "title": "Fix duplicate return in user-service",
+    "body": "Documents the fix.",
+    "labels": "",
+    "changed": "wr/issues/issue-100-router-bug.md",
+    "expect": "fail",
+    "why": "Claims a fix but only touches wr/issues/ with no tracking label or Tracks ref."
+  },
+  {
+    "name": "wr-readme-fix",
+    "title": "Fix broken link in wr/README.md",
+    "body": "Updates a stale link in the WR readme.",
+    "labels": "",
+    "changed": "wr/README.md",
+    "expect": "pass",
+    "why": "B.3 — wr/README.md is allowlisted as a real-fix path."
+  }
+]

--- a/wr/tests/fixtures/golden-bad/checklist-lying.md
+++ b/wr/tests/fixtures/golden-bad/checklist-lying.md
@@ -1,0 +1,45 @@
+# WR: Launch revvel-stack analytics dashboard
+
+**Issue:** #4400  
+**Repository:** midnghtsapphire/revvel-standards  
+**Created:** 2026-06-02  
+**Researcher:** angelreporters@gmail.com  
+**Research Date:** 2026-06-02  
+**WR Status:** 🟡 In Progress
+
+## Issue Context
+Specify the per-project analytics dashboard.
+
+## Repository Metadata
+| Property | Value |
+| --- | --- |
+| Stars | 412 |
+| Open Issues | 27 |
+| Private | false |
+| Archived | false |
+
+## Research Checklist
+- [x] Deep market research
+- [x] BOM
+- [ ] Community chatter
+- [ ] Competitor analysis
+- [ ] Domain strategy
+- [ ] Monetization
+
+## Executive Summary
+We will ship a dashboard. The selected approach is [Option 1].
+
+## Step 1A — Product/Output Selections
+[Option 1]
+
+## Step 2 — Deep Web Research
+Surveyed the market.
+
+## Step 3 — Requirements
+- GitHub App with per-repo install.
+
+## Recommendations
+Launch at $19/user/month.
+
+## Risks
+Stripe disputes.

--- a/wr/tests/fixtures/golden-bad/scaffolding-leak.md
+++ b/wr/tests/fixtures/golden-bad/scaffolding-leak.md
@@ -1,0 +1,28 @@
+# Otherwise, use WR_TEMPLATE_BASIC.md
+# WR: Fix duplicate return in user-service
+
+**Issue:** #4321  
+**Repository:** midnghtsapphire/revvel-standards  
+**Created:** 2026-06-02  
+**WR Status:** 🟢 Ready
+
+## Issue Context
+The `userService.findById` function had a duplicate `return`.
+
+## Summary
+Remove the unreachable second `return`.
+
+## Objective
+Restore green CI.
+
+## Required Bundle
+- `services/user-service.ts`
+
+## Definition of Done
+- Lint passes.
+
+## Validation
+`npm run lint`.
+
+## Blockers
+None.

--- a/wr/tests/fixtures/golden-bad/tokens-left.md
+++ b/wr/tests/fixtures/golden-bad/tokens-left.md
@@ -1,0 +1,35 @@
+# WR: Fix duplicate return in user-service
+
+**Issue:** #4321  
+**Repository:** midnghtsapphire/revvel-standards  
+**Created:** 2026-06-02  
+**WR Status:** 🟡 In Progress
+
+## Repository Metadata
+| Property | Value |
+| --- | --- |
+| Stars | {STARS} |
+| Open Issues | {OPEN_ISSUES} |
+| Private | false |
+| Archived | false |
+
+## Issue Context
+Remove the unreachable second `return` and add a regression test.
+
+## Summary
+Drop the duplicate return.
+
+## Objective
+Restore green CI on `main`.
+
+## Required Bundle
+- `services/user-service.ts`
+
+## Definition of Done
+- `npm run lint` passes.
+
+## Validation
+`npm run lint && npm test`.
+
+## Blockers
+None.

--- a/wr/tests/fixtures/golden-good/bracket-prose-false-positive.md
+++ b/wr/tests/fixtures/golden-good/bracket-prose-false-positive.md
@@ -1,0 +1,35 @@
+# WR: Patch unreachable code in router
+
+**Issue:** #5001  
+**Repository:** midnghtsapphire/revvel-standards  
+**Created:** 2026-06-02  
+**WR Status:** 🟢 Ready
+
+## Issue Context
+Reviewer flagged an unreachable branch in `router.ts` [Closes #4998].
+The original author left a [TODO: refactor] note above it and never
+returned. Per [RFC 2119] the requirement language in our linter spec
+uses MUST/SHOULD/MAY, so this gate change is normative not advisory.
+
+## Summary
+Remove the unreachable branch [Closes #4998] and tighten the
+no-unreachable lint rule from `warn` to `error`.
+
+## Objective
+Make `no-unreachable` a hard gate. See [Closes #4998] for the original
+report and [TODO: refactor] for the original deferred work.
+
+## Required Bundle
+- `src/router.ts` — drop the unreachable branch.
+- `eslint.config.js` — promote `no-unreachable` from warn to error.
+
+## Definition of Done
+- `npm run lint` exits 0.
+- The previously-unreachable branch is gone (verified by test).
+- Reference [RFC 2119] terminology in CHANGELOG entry.
+
+## Validation
+`npm run lint && npm test`.
+
+## Blockers
+None.

--- a/wr/tests/fixtures/golden-good/clean-basic-fix.md
+++ b/wr/tests/fixtures/golden-good/clean-basic-fix.md
@@ -1,0 +1,35 @@
+# WR: Fix duplicate return in user-service
+
+**Issue:** #4321  
+**Repository:** midnghtsapphire/revvel-standards  
+**Created:** 2026-06-02  
+**WR Status:** 🟢 Ready
+
+## Issue Context
+The `userService.findById` function had a duplicate `return` statement
+introduced by a bad merge in #4317. The second `return` was unreachable
+and triggered the `no-unreachable` lint rule on every PR.
+
+## Summary
+Remove the unreachable second `return` and add a regression test that
+exercises both the cache-hit and cache-miss code paths so the same
+merge mistake fails CI next time.
+
+## Objective
+Restore green CI on `main` and stop the lint warning from drowning out
+genuine findings.
+
+## Required Bundle
+- `services/user-service.ts` — remove duplicate return.
+- `tests/user-service.test.ts` — add regression test for both branches.
+
+## Definition of Done
+- `npm run lint` exits 0 with no `no-unreachable` warnings.
+- `npm test -- user-service` covers both branches (cache hit, cache miss).
+- PR description references this WR.
+
+## Validation
+Run `npm run lint && npm test -- user-service` locally; CI must be green.
+
+## Blockers
+None.

--- a/wr/tests/fixtures/golden-good/clean-full-research.md
+++ b/wr/tests/fixtures/golden-good/clean-full-research.md
@@ -1,0 +1,70 @@
+# WR: Launch revvel-stack analytics dashboard
+
+**Issue:** #4400  
+**Repository:** midnghtsapphire/revvel-standards  
+**Created:** 2026-06-02  
+**Researcher:** angelreporters@gmail.com  
+**Research Date:** 2026-06-02  
+**WR Status:** 🟢 Ready
+
+## Issue Context
+Customers have requested a per-project analytics dashboard surfacing
+deploy frequency, lead time, change-failure rate, and MTTR. This WR
+specifies the product, the BOM, the competitive landscape, the
+monetization angle, and the GTM plan so engineering can start in
+sprint 41 without further discovery.
+
+## Repository Metadata
+| Property | Value |
+| --- | --- |
+| Stars | 412 |
+| Open Issues | 27 |
+| Private | false |
+| Archived | false |
+
+## Research Checklist
+- [x] Deep market research
+- [x] BOM
+- [x] Community chatter
+- [x] Competitor analysis
+- [x] Domain strategy
+- [x] Monetization
+
+## Executive Summary
+The DORA-metrics dashboard market is fragmented but the share of
+indie-dev shops with no in-house observability stack is growing 18%
+YoY. A self-serve, single-binary dashboard priced below LinearB but
+above the free-tier of Sleuth captures the segment that is currently
+copy-pasting GitHub Actions output into spreadsheets.
+
+## Step 1A — Product/Output Selections
+Single-binary Go server, SQLite by default, optional Postgres,
+GitHub App for auth, Stripe-managed seats, OpenTelemetry export.
+Ship as a paid SaaS at app.revvel-stack.com plus a self-hosted
+Docker image under a fair-source license.
+
+## Step 2 — Deep Web Research
+Surveyed twelve adjacent products (LinearB, Sleuth, Faros, Allstacks,
+Jellyfish, Code Climate Velocity, Haystack, Logilica, Athenian,
+DX, Swarmia, Uplevel). Identified pricing band $8-$45/user/month,
+median time-to-first-chart 6 minutes, and a universal complaint
+about noisy alerts on small teams.
+
+## Step 3 — Requirements
+- GitHub App with per-repo install.
+- Four DORA charts + one custom-query view.
+- Stripe seat billing.
+- OpenTelemetry export.
+- Single-binary distribution.
+
+## Recommendations
+Launch at $19/user/month with a 14-day trial and a free tier capped
+at five repos. Lean on the developer-tools subreddit and Hacker News
+Show HN for organic launch; budget a $4k AdWords burst on the
+keywords "DORA metrics dashboard" and "deployment frequency tracker"
+in week 3.
+
+## Risks
+Stripe disputes from solo founders downgrading mid-cycle; mitigate
+with a one-click pause. GitHub rate limits on large monorepos;
+mitigate with delta-sync and a Redis cache.

--- a/wr/tests/wr-lint.test.mjs
+++ b/wr/tests/wr-lint.test.mjs
@@ -1,0 +1,111 @@
+// wr-lint.test.mjs — node:test suite for the WR/PR lint gate.
+// Runs the lint script as a child process against the golden-good and
+// golden-bad fixtures and asserts on exit code and emitted issue strings.
+//
+// Run locally: node --test wr/tests/wr-lint.test.mjs
+// (or via the root `npm run test:wr` script).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, "..", "..");
+const LINT = path.join(REPO, "wr", "scripts", "wr-lint.mjs");
+const GOOD = path.join(__dirname, "fixtures", "golden-good");
+const BAD = path.join(__dirname, "fixtures", "golden-bad");
+
+function runLint(file) {
+  const r = spawnSync(process.execPath, [LINT, file], { encoding: "utf8" });
+  return { code: r.status, stdout: r.stdout || "", stderr: r.stderr || "" };
+}
+
+function listMd(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => path.join(dir, f));
+}
+
+test("golden-good: clean-basic-fix.md passes lint", () => {
+  const r = runLint(path.join(GOOD, "clean-basic-fix.md"));
+  assert.equal(r.code, 0, `expected exit 0, got ${r.code}\nstdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
+  assert.match(r.stdout, /All clean/);
+});
+
+test("golden-good: clean-full-research.md passes lint", () => {
+  const r = runLint(path.join(GOOD, "clean-full-research.md"));
+  assert.equal(r.code, 0, `expected exit 0, got ${r.code}\nstdout:\n${r.stdout}`);
+});
+
+test("golden-good: bracket-prose-false-positive.md passes (verifies allowlist rewrite)", () => {
+  // Contains legitimate `[Closes #4998]`, `[TODO: refactor]`, `[RFC 2119]`
+  // prose — none are template placeholders, so the lint MUST accept them.
+  const r = runLint(path.join(GOOD, "bracket-prose-false-positive.md"));
+  assert.equal(
+    r.code,
+    0,
+    `expected exit 0 (bracket prose is not a template placeholder), got ${r.code}\nstdout:\n${r.stdout}`
+  );
+  assert.doesNotMatch(r.stdout, /\[Closes #4998\]/, "must not flag [Closes #4998] as a placeholder");
+  assert.doesNotMatch(r.stdout, /\[TODO: refactor\]/, "must not flag [TODO: refactor] as a placeholder");
+  assert.doesNotMatch(r.stdout, /\[RFC 2119\]/, "must not flag [RFC 2119] as a placeholder");
+});
+
+test("golden-bad: tokens-left.md fails with unsubstituted generator token(s)", () => {
+  const r = runLint(path.join(BAD, "tokens-left.md"));
+  assert.equal(r.code, 1, "expected exit 1");
+  assert.match(r.stdout, /unsubstituted generator token\(s\)/);
+  assert.match(r.stdout, /\{STARS\}/);
+  assert.match(r.stdout, /\{OPEN_ISSUES\}/);
+});
+
+test("golden-bad: checklist-lying.md fails with false-completion signal", () => {
+  const r = runLint(path.join(BAD, "checklist-lying.md"));
+  assert.equal(r.code, 1, "expected exit 1");
+  assert.match(r.stdout, /false-completion signal/);
+  // Also flags the [Option 1] placeholder via the allowlist rule.
+  assert.match(r.stdout, /\[Option 1\]/);
+});
+
+test("golden-bad: scaffolding-leak.md fails with template scaffolding comment", () => {
+  const r = runLint(path.join(BAD, "scaffolding-leak.md"));
+  assert.equal(r.code, 1, "expected exit 1");
+  assert.match(r.stdout, /template scaffolding comment/);
+});
+
+test("generic UPPER_SNAKE token detector catches a never-seen-before token", () => {
+  // Spec A.2: replace the fixed enum with /\{[A-Z_][A-Z0-9_]*\}/ so any
+  // new generator token (e.g. {COMPLETELY_NEW_TOKEN_42}) is caught
+  // without code changes.
+  const tmp = path.join(BAD, ".tmp-novel-token.md");
+  fs.writeFileSync(
+    tmp,
+    `# WR: Fix typo in docs\n\n**Issue:** #1\n\n## Issue Context\nProperty: {COMPLETELY_NEW_TOKEN_42}\n\n## Summary\nx\n`
+  );
+  try {
+    const r = runLint(tmp);
+    assert.equal(r.code, 1, "expected exit 1");
+    assert.match(r.stdout, /\{COMPLETELY_NEW_TOKEN_42\}/);
+    assert.match(r.stdout, /unsubstituted generator token/);
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+});
+
+test("all golden-good fixtures pass lint", () => {
+  for (const f of listMd(GOOD)) {
+    const r = runLint(f);
+    assert.equal(r.code, 0, `golden-good fixture must pass: ${path.basename(f)}\n${r.stdout}`);
+  }
+});
+
+test("all golden-bad fixtures fail lint", () => {
+  for (const f of listMd(BAD)) {
+    const r = runLint(f);
+    assert.equal(r.code, 1, `golden-bad fixture must fail: ${path.basename(f)}\n${r.stdout}`);
+  }
+});


### PR DESCRIPTION
## What this PR closes

The strict-reviewer audit on the WR/PR gate (v2, landed via #14227 / follow-ups) caught five lint regressions, three gate regressions, three workflow regressions, and "no tests exist" — ten findings in total. v2 was a half-fix: it added rules but left heuristics loose enough that real prose tripped them and adversarial bodies slipped past them. This PR tightens every rule into something testable, adds the regression test suite that prevents v2-style drift, and wires the suite into CI via both `npm run test:wr` and a golden-sample re-lint step in the workflow when the linter or templates themselves change.

## Part A — `wr/scripts/wr-lint.mjs` (findings A.1 – A.5)

- **A.1 — bracket placeholder false positives.** The old `/\[[A-Za-z][^\]]{2,60}\]/` heuristic fired on legitimate prose like `[Closes #123]`, `[TODO: refactor]`, `[RFC 2119]`. Replaced with a runtime allowlist: at startup the linter reads `wr/WR_TEMPLATE_FULL.md` and `wr/WR_TEMPLATE_BASIC.md`, extracts every `[…]` they contain (skipping checkboxes and markdown links), and only those exact strings are forbidden when found in a generated WR. Prose-bracket idioms now pass.
- **A.2 — fixed RAW_TOKENS enum.** The old `/\{(STARS|OPEN_ISSUES|IS_PRIVATE|...)\}/` silently passed any new `{TOKEN}` the generator added. Replaced with a generic `/\{[A-Z_][A-Z0-9_]*\}/` so any new UPPER_SNAKE curly token is caught without code changes here.
- **A.3 — silent `{TOKEN}` → `N/A` rewrite removed.** `generate-wr.sh` had a fallback `sed -E 's/\{[A-Z_]+\}/N\/A/g'` that papered over missing substitutions. Deleted — the linter (rule 5) is now the single source of truth for "missing token".
- **A.4 — BASIC classification too narrow.** Titles like "Remove unused MCP route" had no fix/bug/style keyword, so the wrong-template-product-sections check was skipped. Extended `BASIC_SIGNALS` with verbs (remove/delete/fix/patch/chore/docs/refactor/lint/format/typo/style), added a `BASIC_TITLE_VERBS` prefix matcher, and added a "no FULL headings present" fallback so the classification falls open as basic when there's no signal it's a full WR.
- **A.5 — `&&...||...` ternary fallback bug.** `generate-wr.sh:19` fired the `_No issue body provided._` fallback on any cat failure even when `--body-file` was passed. Converted to explicit if/then/else that aborts on a real read failure.

Also: extended `WR_TEMPLATE_FULL.md` with the canonical bracket placeholders (`[Option 1]`, `[Yes/No]`, `[Research findings...]`, `[$CPC]`, `[Fix]`, `[Pricing]`, `[Date and summary]`, etc.) so the runtime allowlist has substance to enforce.

## Part B — `wr/scripts/fix-wr-gate.mjs` (findings B.1 – B.3)

- **B.1 — bare `^track\b` prefix.** Matched legitimate titles like "Track down regression" / "Tracking memory leak", letting real-fix PRs count as tracking-only. Dropped from `TRACKING_PREFIXES`. Only the bracketed forms (`[wr-docs]`, `[wr-tracking]`, `[track]`) remain.
- **B.2 — `Tracks: #N` matched inside code blocks and blockquotes.** A copy-pasted or quoted `Tracks: #4321` inside a fenced code block (```` ``` ````, `~~~`) or a `>` blockquote line could satisfy the gate. Added `stripCodeAndQuotes()` that runs on the body BEFORE `TRACKS_REF.test()`.
- **B.3 — blanket `wr/` block on real-fix paths.** Legitimate fixes to the gate scripts / templates / readme themselves were blocked. Added `WR_REAL_FIX_ALLOWLIST` matching `^wr/scripts/`, `^wr/WR_TEMPLATE_.*\.md$`, `^wr/README\.md$`.

## Part C — `.github/workflows/wr-lint.yml` (findings C.1 – C.4)

- **C.1 — trigger paths too narrow.** `paths: [wr/issues/**.md]` meant editing the linter itself never re-ran it against any sample WR. Extended to include `wr/scripts/**`, `wr/WR_TEMPLATE_*.md`, `.github/workflows/wr-*.yml`, `wr/tests/fixtures/**.md`.
- **C.2 — stderr redirected into the file list.** `files=$(git diff … 2>&1)` polluted the filename list passed to node. Changed to `2>/dev/null`; git errors are detected via exit status.
- **C.3 — unquoted file expansion.** `node wr/scripts/wr-lint.mjs $files` blew up on paths with spaces or globs. Replaced with `printf '%s\n' "$files" | xargs -d '\n' -r node wr/scripts/wr-lint.mjs`.
- **C.4 — golden-sample re-lint when the linter changes.** When the diff touches `wr/scripts/` or `wr/WR_TEMPLATE_*.md`, additionally lint the golden-sample suite: `wr/tests/fixtures/golden-good/*.md` must pass, `wr/tests/fixtures/golden-bad/*.md` must fail. Workflow fails if either set behaves wrong.

## Part D + E — test suite + npm wiring

- `wr/tests/wr-lint.test.mjs` (10 cases) drives the lint script as a child process against the golden fixtures and asserts on exit code + emitted issue strings. Includes a dedicated case that writes a tmp WR with `{COMPLETELY_NEW_TOKEN_42}` to prove the generic detector catches a never-seen-before token.
- `wr/tests/fix-wr-gate.test.mjs` (10+ cases) runs every row in `fixtures/fix-wr-gate-cases.json`: tracking-only-with-Tracks-ref (pass), -no-ref (fail), -tracks-in-codeblock (fail per B.2), -tracks-in-blockquote (fail per B.2), title-starts-with-track-prefix (fail per B.1), real-fix-in-wr-scripts / wr-template / wr-README (pass per B.3), code-file-changed-no-label (pass), and a wr-only-no-tracking control (fail).
- Fixtures: 6 markdown files under `wr/tests/fixtures/golden-{good,bad}/` plus a 10-case JSON list under `wr/tests/fixtures/fix-wr-gate-cases.json`. `bracket-prose-false-positive.md` is the keystone: it contains `[Closes #4998]`, `[TODO: refactor]`, `[RFC 2119]` and MUST pass — verifies the A.1 allowlist rewrite.
- `package.json`: added `test:wr` script. Only built-ins (`node:test`, `node:assert`), no new dependencies.

Run locally:

```
npm run test:wr
# or:
node --test wr/tests/wr-lint.test.mjs wr/tests/fix-wr-gate.test.mjs
```

All 20 cases pass on this branch.

## Test plan
- [ ] CI: WR Lint workflow triggers (paths now include `wr/scripts/**`, etc.)
- [ ] CI: golden-sample re-lint step runs (linter files are part of this diff)
- [ ] CI: `npm run test:wr` if wired into the main test job
- [ ] Local: `npm run test:wr` → 20/20 pass
- [ ] Local: `node wr/scripts/wr-lint.mjs wr/tests/fixtures/golden-good/*.md` → All clean
- [ ] Local: each golden-bad fixture exits 1 with the expected error string

https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR tightens the Work Record (WR) and Pull Request gate validation system by fixing ten audit findings across linting, gate logic, and CI workflows. Key improvements include replacing heuristic-based bracket placeholder detection with a runtime allowlist extracted from templates (eliminating false positives on prose like `[Closes #123]` and `[RFC 2119]`), switching to a generic UPPER_SNAKE token detector to catch any new unsubstituted generator tokens, fixing the BASIC/FULL template classification to catch titles with verbs like "Remove" or "Fix", stripping code blocks and blockquotes before validating tracking references, allowlisting legitimate WR infrastructure fixes under `wr/scripts/`, `wr/WR_TEMPLATE_*.md`, and `wr/README.md`, and correcting workflow path triggers to re-run lint when the linter or templates change. A comprehensive test suite with 20 cases covering both positive and negative scenarios has been added and wired into CI via `npm run test:wr`, along with a golden-sample re-lint step that validates the linter itself against known-good and known-bad fixtures whenever gate infrastructure changes.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `wr/tests/fixtures/fix-wr-gate-cases.json` |
| 2 | `wr/tests/fixtures/golden-good/clean-basic-fix.md` |
| 3 | `wr/tests/fixtures/golden-good/clean-full-research.md` |
| 4 | `wr/tests/fixtures/golden-good/bracket-prose-false-positive.md` |
| 5 | `wr/tests/fixtures/golden-bad/tokens-left.md` |
| 6 | `wr/tests/fixtures/golden-bad/checklist-lying.md` |
| 7 | `wr/tests/fixtures/golden-bad/scaffolding-leak.md` |
| 8 | `wr/WR_TEMPLATE_FULL.md` |
| 9 | `wr/scripts/wr-lint.mjs` |
| 10 | `wr/scripts/fix-wr-gate.mjs` |
| 11 | `wr/scripts/generate-wr.sh` |
| 12 | `wr/tests/wr-lint.test.mjs` |
| 13 | `wr/tests/fix-wr-gate.test.mjs` |
| 14 | `package.json` |
| 15 | `.github/workflows/wr-lint.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the WR/PR gate with an allowlist-based lint, fixes tracking-only logic, and adds a CI test suite with golden fixtures to prevent regressions. Reduces false positives on real prose and reliably flags missing tokens and placeholders.

- **Bug Fixes**
  - Lint now uses a template-derived allowlist for `[…]` and a generic `{UPPER_SNAKE}` token check; removed the silent `{TOKEN} -> N/A` rewrite.
  - Improved BASIC vs FULL detection (verb prefixes, “no FULL headings” fallback) and fixed body-file read to fail on real errors.
  - Gate fixes: dropped bare “track” title prefix; strip code blocks/quotes before matching “Tracks: #N”; allow real fixes under `wr/scripts/`, `wr/WR_TEMPLATE_*.md`, `wr/README.md`.
  - Workflow robustness: correct stderr redirection and safe file-arg handling.

- **New Features**
  - Golden-sample re-lint runs when the linter or templates change; golden-good must pass, golden-bad must fail.
  - Added `node:test` suites for `wr-lint` and `fix-wr-gate` plus `npm run test:wr`; 20 cases cover core rules and edge cases.
  - `WR_TEMPLATE_FULL.md` now includes canonical placeholders to back the runtime allowlist.

<sup>Written for commit 6e1bc3d3420cc88e2bfccac007095a506c62daf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

