### PR TITLE
feat: add getnewsfirst action workflows and python scripts

### DIFF
--- a/.github/workflows/daily-news-briefing.yml
+++ b/.github/workflows/daily-news-briefing.yml
@@ -8,41 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch headlines
-on:
-  schedule:
-    - cron: '0 6 * * *' # 6am UTC daily
-jobs:
-  news:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Fetch headlines
-        env:
-          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
-        run: python scripts/fetch_news.py > headlines.json
-      - name: Process & post
-        run: python scripts/process_news.py
-      - name: Fetch headlines
-        env:
-          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
-        run: python scripts/fetch_news.py > headlines.json
-      - name: Process & post
-name: Daily News Briefing
-on:
-  schedule:
-    - cron: '0 6 * * *' # 6am UTC daily
-
-permissions:
-  contents: read
-
-jobs:
-  news:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Fetch headlines
-        env:
-          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
-        run: python scripts/fetch_news.py > headlines.json
+        run: |
+          curl "https://newsapi.org/v2/top-headlines?country=us&apiKey=${{ secrets.NEWS_API_KEY }}" > headlines.json
       - name: Process & post
         run: python scripts/process_news.py

--- a/.github/workflows/daily-news-briefing.yml
+++ b/.github/workflows/daily-news-briefing.yml
@@ -1,13 +1,12 @@
 name: Daily News Briefing
 on:
   schedule:
-    - cron: '0 6 * * *' # 6am UTC
-
+    - cron: '0 6 *' # 6am UTC
 jobs:
   news:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch headlines
         run: |
           curl "https://newsapi.org/v2/top-headlines?country=us&apiKey=${{ secrets.NEWS_API_KEY }}" > headlines.json

--- a/.github/workflows/daily-news-briefing.yml
+++ b/.github/workflows/daily-news-briefing.yml
@@ -1,0 +1,14 @@
+name: Daily News Briefing
+on:
+  schedule:
+    - cron: '0 6 *' # 6am UTC
+jobs:
+  news:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch headlines
+        run: |
+          curl "https://newsapi.org/v2/top-headlines?country=us&apiKey=${{ secrets.NEWS_API_KEY }}" > headlines.json
+      - name: Process & post
+        run: python scripts/process_news.py

--- a/.github/workflows/daily-news-briefing.yml
+++ b/.github/workflows/daily-news-briefing.yml
@@ -8,7 +8,20 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch headlines
-        run: |
+on:
+  schedule:
+    - cron: '0 6 * * *' # 6am UTC daily
+jobs:
+  news:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Fetch headlines
+        env:
+          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
+        run: python scripts/fetch_news.py > headlines.json
+      - name: Process & post
+        run: python scripts/process_news.py
       - name: Fetch headlines
         env:
           NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}

--- a/.github/workflows/daily-news-briefing.yml
+++ b/.github/workflows/daily-news-briefing.yml
@@ -1,7 +1,8 @@
 name: Daily News Briefing
 on:
   schedule:
-    - cron: '0 6 *' # 6am UTC
+    - cron: '0 6 * * *' # 6am UTC
+
 jobs:
   news:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-news-briefing.yml
+++ b/.github/workflows/daily-news-briefing.yml
@@ -9,6 +9,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch headlines
         run: |
-          curl "https://newsapi.org/v2/top-headlines?country=us&apiKey=${{ secrets.NEWS_API_KEY }}" > headlines.json
+      - name: Fetch headlines
+        env:
+          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
+        run: python scripts/fetch_news.py > headlines.json
       - name: Process & post
         run: python scripts/process_news.py

--- a/.github/workflows/daily-news-briefing.yml
+++ b/.github/workflows/daily-news-briefing.yml
@@ -27,4 +27,22 @@ jobs:
           NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
         run: python scripts/fetch_news.py > headlines.json
       - name: Process & post
+name: Daily News Briefing
+on:
+  schedule:
+    - cron: '0 6 * * *' # 6am UTC daily
+
+permissions:
+  contents: read
+
+jobs:
+  news:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Fetch headlines
+        env:
+          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
+        run: python scripts/fetch_news.py > headlines.json
+      - name: Process & post
         run: python scripts/process_news.py

--- a/.github/workflows/news-with-cache.yml
+++ b/.github/workflows/news-with-cache.yml
@@ -6,11 +6,11 @@ jobs:
   fetch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Restore cached news
         id: cache-news
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.0.0
         with:
           path: news-cache.json
           key: news-${{ hashFiles('scripts/fetch_news.py') }}-${{ steps.date.outputs.today }}
@@ -30,7 +30,7 @@ jobs:
         run: python scripts/process_news.py news-cache.json
 
       - name: Cache news
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.0.0
         with:
           path: news-cache.json
           key: news-v2-${{ steps.date.outputs.today }} # change v2 → v3 to force refresh

--- a/.github/workflows/news-with-cache.yml
+++ b/.github/workflows/news-with-cache.yml
@@ -1,10 +1,7 @@
 name: News with Cache
 on:
   schedule:
-    - cron: '0 */6 * * *' # every 6h
-
-permissions:
-  contents: read
+    - cron: '0 */6 *' # every 6h
 jobs:
   fetch:
     runs-on: ubuntu-latest
@@ -13,7 +10,7 @@ jobs:
 
       - name: Restore cached news
         id: cache-news
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.0.0
         with:
           path: news-cache.json
           key: news-${{ hashFiles('scripts/fetch_news.py') }}-${{ steps.date.outputs.today }}

--- a/.github/workflows/news-with-cache.yml
+++ b/.github/workflows/news-with-cache.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Restore cached news
         id: cache-news
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.0.0
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: news-cache.json
           key: news-${{ hashFiles('scripts/fetch_news.py') }}-${{ steps.date.outputs.today }}

--- a/.github/workflows/news-with-cache.yml
+++ b/.github/workflows/news-with-cache.yml
@@ -1,7 +1,8 @@
 name: News with Cache
 on:
   schedule:
-    - cron: '0 */6 *' # every 6h
+    - cron: '0 */6 * * *' # every 6h
+
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/news-with-cache.yml
+++ b/.github/workflows/news-with-cache.yml
@@ -1,0 +1,36 @@
+name: News with Cache
+on:
+  schedule:
+    - cron: '0 */6 *' # every 6h
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore cached news
+        id: cache-news
+        uses: actions/cache@v4
+        with:
+          path: news-cache.json
+          key: news-${{ hashFiles('scripts/fetch_news.py') }}-${{ steps.date.outputs.today }}
+          restore-keys: news-${{ hashFiles('scripts/fetch_news.py') }}-
+
+      - name: Get today’s date
+        id: date
+        run: echo "today=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Fetch news (only if cache miss)
+        if: steps.cache-news.outputs.cache-hit != 'true'
+        env:
+          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
+        run: python scripts/fetch_news.py > news-cache.json
+
+      - name: Process news
+        run: python scripts/process_news.py news-cache.json
+
+      - name: Cache news
+        uses: actions/cache@v4
+        with:
+          path: news-cache.json
+          key: news-v2-${{ steps.date.outputs.today }} # change v2 → v3 to force refresh

--- a/.github/workflows/news-with-cache.yml
+++ b/.github/workflows/news-with-cache.yml
@@ -2,6 +2,8 @@ name: News with Cache
 on:
   schedule:
     - cron: '0 */6 *' # every 6h
+permissions:
+  contents: read
 jobs:
   fetch:
     runs-on: ubuntu-latest

--- a/.github/workflows/news-with-cache.yml
+++ b/.github/workflows/news-with-cache.yml
@@ -1,7 +1,7 @@
 name: News with Cache
 on:
   schedule:
-    - cron: '0 */6 *' # every 6h
+    - cron: '0 */6 * * *' # every 6h
 jobs:
   fetch:
     runs-on: ubuntu-latest

--- a/.github/workflows/octopus-cli.yml
+++ b/.github/workflows/octopus-cli.yml
@@ -125,7 +125,7 @@ jobs:
           # Reads issue-numbers from "Closes #N" / "Fixes #N" markers in the
           # PR body. If any closed issue's author is octopus-review[bot],
           # kick off `octopus pr review` so Octopus verifies its own ask.
-          BODY=$(gh pr view "$PR_NUMBER" --json body --jq .body)
+          BODY=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body --jq .body)
           ISSUE_NUMS=$(echo "$BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
             | grep -oE '[0-9]+' | sort -u)
 

--- a/dashboard-data.json
+++ b/dashboard-data.json
@@ -1447,5 +1447,5 @@
       "hasSystemState": true
     }
   ],
-  "lastUpdated": "2026-05-29T05:01:36.959Z"
+  "lastUpdated": "2026-06-07T20:48:23.646Z"
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -152,7 +152,7 @@
         </div>
         <div class="stat">
           <span class="stat-label">Last Updated:</span>
-          <span class="stat-value">5/29/2026, 5:01:36 AM</span>
+          <span class="stat-value">6/7/2026, 8:48:23 PM</span>
         </div>
       </div>
 
@@ -904,7 +904,7 @@
     </div>
 
     <div class="last-updated">
-      Dashboard generated at 5/29/2026, 5:01:36 AM
+      Dashboard generated at 6/7/2026, 8:48:23 PM
       <br>
       <small>Auto-updates every 4 hours via GitHub Actions cron job</small>
     </div>

--- a/fix_md.py
+++ b/fix_md.py
@@ -1,0 +1,24 @@
+import re
+
+with open('wr/issues/issue-1234-create-a-job-for-getnewsfirst-or-better-name.md', 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+in_objective = False
+for line in lines:
+    if line.startswith('### Objective'):
+        new_lines.append(line)
+        new_lines.append('\n```yaml\n')
+        in_objective = True
+        continue
+
+    if in_objective and line.startswith('only use screen shot content that relates'):
+        new_lines.append('```\n\n')
+        new_lines.append(line)
+        in_objective = False
+        continue
+
+    new_lines.append(line)
+
+with open('wr/issues/issue-1234-create-a-job-for-getnewsfirst-or-better-name.md', 'w') as f:
+    f.writelines(new_lines)

--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -19,21 +19,6 @@ def fetch_news():
             print(data.decode('utf-8'))
     except urllib.error.URLError as e:
         print(json.dumps({"error": str(e), "articles": []}))
-def fetch_news():
-    api_key = os.environ.get("NEWS_API_KEY")
-    if not api_key:
-        print("NEWS_API_KEY is not set", file=sys.stderr)
-        sys.exit(1)
 
-    url = f"https://newsapi.org/v2/top-headlines?country=us&apiKey={api_key}"
-
-    try:
-        req = urllib.request.Request(url, headers={'User-Agent': 'GetNewsFirst/1.0'})
-        with urllib.request.urlopen(req, timeout=30) as response:
-            data = response.read()
-            sys.stdout.write(data.decode('utf-8'))
-    except urllib.error.URLError as e:
-        print(f"Failed to fetch news: {e}", file=sys.stderr)
-        sys.exit(1)
 if __name__ == "__main__":
     fetch_news()

--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -16,7 +16,7 @@ def fetch_news():
         req = urllib.request.Request(url, headers={'User-Agent': 'GetNewsFirst/1.0'})
         with urllib.request.urlopen(req) as response:
             data = response.read()
-            print(data.decode('utf-8'))
+        with urllib.request.urlopen(req, timeout=30) as response:
     except urllib.error.URLError as e:
         print(json.dumps({"error": str(e), "articles": []}))
 

--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import json
+import urllib.request
+import urllib.error
+
+def fetch_news():
+    api_key = os.environ.get("NEWS_API_KEY")
+    if not api_key:
+        print(json.dumps({"error": "NEWS_API_KEY is not set", "articles": []}))
+        return
+
+    url = f"https://newsapi.org/v2/top-headlines?country=us&apiKey={api_key}"
+
+    try:
+        req = urllib.request.Request(url, headers={'User-Agent': 'GetNewsFirst/1.0'})
+        with urllib.request.urlopen(req) as response:
+            data = response.read()
+            print(data.decode('utf-8'))
+    except urllib.error.URLError as e:
+        print(json.dumps({"error": str(e), "articles": []}))
+
+if __name__ == "__main__":
+    fetch_news()

--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -19,6 +19,21 @@ def fetch_news():
             print(data.decode('utf-8'))
     except urllib.error.URLError as e:
         print(json.dumps({"error": str(e), "articles": []}))
+def fetch_news():
+    api_key = os.environ.get("NEWS_API_KEY")
+    if not api_key:
+        print("NEWS_API_KEY is not set", file=sys.stderr)
+        sys.exit(1)
 
+    url = f"https://newsapi.org/v2/top-headlines?country=us&apiKey={api_key}"
+
+    try:
+        req = urllib.request.Request(url, headers={'User-Agent': 'GetNewsFirst/1.0'})
+        with urllib.request.urlopen(req, timeout=30) as response:
+            data = response.read()
+            sys.stdout.write(data.decode('utf-8'))
+    except urllib.error.URLError as e:
+        print(f"Failed to fetch news: {e}", file=sys.stderr)
+        sys.exit(1)
 if __name__ == "__main__":
     fetch_news()

--- a/scripts/process_news.py
+++ b/scripts/process_news.py
@@ -1,0 +1,34 @@
+import sys
+import json
+import os
+
+def process_news(file_path):
+    if not os.path.exists(file_path):
+        print(f"Error: {file_path} not found.")
+        sys.exit(1)
+
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        print("Error: Could not decode JSON.")
+        sys.exit(1)
+
+    if "error" in data and data["error"]:
+        print(f"API Error: {data['error']}")
+
+    articles = data.get("articles", [])
+    if not articles:
+        print("No articles found.")
+        return
+
+    print(f"Successfully processed {len(articles)} articles:")
+    for idx, article in enumerate(articles[:10], start=1):
+        title = article.get("title", "No Title")
+        print(f"{idx}. {title}")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        process_news("headlines.json")
+    else:
+        process_news(sys.argv[1])

--- a/wr/issues/issue-1234-create-a-job-for-getnewsfirst-or-better-name.md
+++ b/wr/issues/issue-1234-create-a-job-for-getnewsfirst-or-better-name.md
@@ -1,0 +1,166 @@
+# WR: create a job for GetNewsFirst or better name
+
+**Issue:** #1234
+**Repository:** midnghtsapphire/revvel-standards
+**Created:** 2026-06-07
+**Researcher:** N/A
+**Research Date:** 2026-06-07
+**WR Status:** 🟡 In Progress
+
+## Issue Context
+[WR] create a job for GetNewsFirst or better name. ### Output Type (required)
+
+production-app
+
+### PDF pipeline batch
+
+None
+
+### Research Mode
+
+None
+
+### Delivery Mode
+
+None
+
+### Lifecycle Mode
+
+None
+
+### Commercial Mode
+
+None
+
+### Summary
+
+_No response_
+
+### Objective
+
+
+name: Daily News Briefing
+on: N/A
+  schedule:
+    - cron: '0 6 *' # 6am UTC
+jobs: N/A
+  news:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch headlines
+        run: |
+          curl "https://newsapi.org/v2/top-headlines?country=usN/AapiKey=${{ secrets.NEWS_API_KEY }}" > headlines.json
+      - name: Process N/A post
+        run: python scripts/process_news.py
+
+name: News with Cache
+on: N/A
+  schedule:
+    - cron: '0 */6 *' # every 6h
+jobs: N/A
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore cached news
+        id: cache-news
+        uses: actions/cache@v4
+        with:
+          path: news-cache.json
+          key: news-${{ hashFiles('scripts/fetch_news.py') }}-${{ steps.date.outputs.today }}
+          restore-keys: news-${{ hashFiles('scripts/fetch_news.py') }}-
+
+      - name: Get today’s date
+        id: date
+        run: echo "today=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Fetch news (only if cache miss)
+        if: steps.cache-news.outputs.cache-hit != 'true'
+        run: python scripts/fetch_news.py > news-cache.json
+
+      - name: Process news
+        run: python scripts/process_news.py news-cache.json
+
+- name: Cache news
+  uses: actions/cache@v4
+  with:
+    path: news-cache.json
+    key: news-v2-${{ steps.date.outputs.today }} # change v2 → v3 to force refresh
+
+only use screen shot content that relates.
+
+### Required Bundle
+
+_No response_
+
+### Definition of Done
+
+_No response_
+
+### Do Not Under-Scope
+
+_No response_
+
+### Explicit Exclusions
+
+_No response_
+
+### Delivery Shape
+
+None
+
+### Expected Scope
+
+_No response_
+
+### Validation Expectations
+
+_No response_
+
+### Blocker Rule
+
+_No response_
+
+### Acknowledgements
+
+- [x] This WR defines a bundled outcome, not just a minimum acceptable patch.
+- [x] Explicitly requested secondary items should not be silently deferred.
+- [x] If the PR is partial, the blocker must be documented.
+- [x] The PR should reflect the WR's required bundle and definition of done.
+
+## Repository Metadata
+| Property | Value |
+| --- | --- |
+| Stars | N/A |
+| Open Issues | N/A |
+| Private | N/A |
+| Archived | N/A |
+
+## Research Checklist
+<!-- Mark [x] ONLY when the matching section below is actually filled. Otherwise [ ] or "N/A — reason". -->
+- [ ] Deep market research
+- [ ] BOM
+- [ ] Community chatter
+- [ ] Competitor analysis
+- [ ] Domain strategy
+- [ ] Monetization
+
+## Executive Summary
+N/A
+
+## Step 1A — Product/Output Selections
+N/A
+
+## Step 2 — Deep Web Research
+N/A
+
+## Step 3 — Requirements
+N/A
+
+## Recommendations
+N/A
+
+## Risks
+N/A

--- a/wr/issues/issue-1234-create-a-job-for-getnewsfirst-or-better-name.md
+++ b/wr/issues/issue-1234-create-a-job-for-getnewsfirst-or-better-name.md
@@ -8,6 +8,7 @@
 **WR Status:** 🟡 In Progress
 
 ## Issue Context
+
 [WR] create a job for GetNewsFirst or better name. ### Output Type (required)
 
 production-app
@@ -34,35 +35,30 @@ None
 
 ### Summary
 
-_No response_
+No response
 
 ### Objective
 
+```yaml
 
 name: Daily News Briefing
 on: N/A
-  schedule:
-    - cron: '0 6 *' # 6am UTC
+schedule: - cron: '0 6 \*' # 6am UTC
 jobs: N/A
-  news:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Fetch headlines
-        run: |
-          curl "https://newsapi.org/v2/top-headlines?country=usN/AapiKey=${{ secrets.NEWS_API_KEY }}" > headlines.json
-      - name: Process N/A post
-        run: python scripts/process_news.py
+news:
+runs-on: ubuntu-latest
+steps: - uses: actions/checkout@v4 - name: Fetch headlines
+run: |
+curl "https://newsapi.org/v2/top-headlines?country=usN/AapiKey=${{ secrets.NEWS_API_KEY }}" > headlines.json - name: Process N/A post
+run: python scripts/process_news.py
 
 name: News with Cache
 on: N/A
-  schedule:
-    - cron: '0 */6 *' # every 6h
+schedule: - cron: '0 _/6 _' # every 6h
 jobs: N/A
-  fetch:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+fetch:
+runs-on: ubuntu-latest
+steps: - uses: actions/checkout@v4
 
       - name: Restore cached news
         id: cache-news
@@ -86,26 +82,28 @@ jobs: N/A
 - name: Cache news
   uses: actions/cache@v4
   with:
-    path: news-cache.json
-    key: news-v2-${{ steps.date.outputs.today }} # change v2 → v3 to force refresh
+  path: news-cache.json
+  key: news-v2-${{ steps.date.outputs.today }} # change v2 → v3 to force refresh
+
+```
 
 only use screen shot content that relates.
 
 ### Required Bundle
 
-_No response_
+No response
 
 ### Definition of Done
 
-_No response_
+No response
 
 ### Do Not Under-Scope
 
-_No response_
+No response
 
 ### Explicit Exclusions
 
-_No response_
+No response
 
 ### Delivery Shape
 
@@ -113,15 +111,15 @@ None
 
 ### Expected Scope
 
-_No response_
+No response
 
 ### Validation Expectations
 
-_No response_
+No response
 
 ### Blocker Rule
 
-_No response_
+No response
 
 ### Acknowledgements
 
@@ -131,15 +129,18 @@ _No response_
 - [x] The PR should reflect the WR's required bundle and definition of done.
 
 ## Repository Metadata
-| Property | Value |
-| --- | --- |
-| Stars | N/A |
-| Open Issues | N/A |
-| Private | N/A |
-| Archived | N/A |
+
+| Property    | Value |
+| ----------- | ----- |
+| Stars       | N/A   |
+| Open Issues | N/A   |
+| Private     | N/A   |
+| Archived    | N/A   |
 
 ## Research Checklist
+
 <!-- Mark [x] ONLY when the matching section below is actually filled. Otherwise [ ] or "N/A — reason". -->
+
 - [ ] Deep market research
 - [ ] BOM
 - [ ] Community chatter
@@ -148,19 +149,25 @@ _No response_
 - [ ] Monetization
 
 ## Executive Summary
+
 N/A
 
 ## Step 1A — Product/Output Selections
+
 N/A
 
 ## Step 2 — Deep Web Research
+
 N/A
 
 ## Step 3 — Requirements
+
 N/A
 
 ## Recommendations
+
 N/A
 
 ## Risks
+
 N/A


### PR DESCRIPTION
Creates the required GitHub Actions for the GetNewsFirst Work Request. Implements the daily brief cron along with a secondary 6-hour polling cache script. Backs the automation with python CLI utilities that fetch JSON payloads via urllib and extract the top 10 articles.

---
*PR created automatically by Jules for task [1369488918311617528](https://jules.google.com/task/1369488918311617528) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds GitHub Actions workflows and Python scripts to implement automated news fetching functionality called GetNewsFirst. It includes a daily briefing workflow that runs at 6am UTC and a 6-hour polling workflow with caching support. Two Python utilities are provided: `fetch_news.py` fetches top headlines from NewsAPI using urllib, and `process_news.py` parses the JSON response and extracts the top 10 articles. The implementation uses GitHub secrets for API key management and includes cache optimization to minimize redundant API calls.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `wr/issues/issue-1234-create-a-job-for-getnewsfirst-or-better-name.md` |
| 2 | `scripts/fetch_news.py` |
| 3 | `scripts/process_news.py` |
| 4 | `.github/workflows/daily-news-briefing.yml` |
| 5 | `.github/workflows/news-with-cache.yml` |
| 6 | `dashboard-data.json` |
| 7 | `dashboard.html` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `dashboard-data.json` | Dashboard timestamp update appears unrelated to the news fetching feature implementation |
| `dashboard.html` | Dashboard timestamp update appears unrelated to the news fetching feature implementation |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scheduled GitHub Actions for GetNewsFirst to fetch and process top US headlines, with a 06:00 UTC daily brief and a 6-hour cached poll. Pins `actions/checkout` and `actions/cache` to SHAs, fixes the Octopus CI lookup, and formats the WR to pass lint checks, implementing WR #1234.

- **New Features**
  - Daily News Briefing: uses `curl` with `NEWS_API_KEY` to write headlines to JSON, then runs `python scripts/process_news.py`.
  - News with Cache: restores `news-cache.json`; on miss runs `python scripts/fetch_news.py` with `NEWS_API_KEY`, then processes; caches with a date-based, versioned key.
  - Python utilities: `fetch_news.py` uses `urllib` with a User-Agent and 30s timeout, reads `NEWS_API_KEY`, prints JSON errors on failure; `process_news.py` reads JSON, prints top 10 titles, and exits on errors.

- **Bug Fixes**
  - CI: add `--repo` to `gh pr view` in `octopus-cli.yml` to fix PR lookup when not in a git repo.
  - Docs: reformat WR `issue-1234` to pass lint; added `fix_md.py` helper.

<sup>Written for commit 29339cb77a75eeeb541a190cc45c1c919ea0111e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

