### PR TITLE
fix: add regression tests for red-ocean scoring boundaries (WR #14010)

### DIFF
--- a/products/prompt-generation-app/lib/prompt-generator.d.ts
+++ b/products/prompt-generation-app/lib/prompt-generator.d.ts
@@ -20,6 +20,7 @@ export interface PromptPacket {
   reviewerPrompts: string[];
 }
 
+export function clampScore(score: number): number;
 export function generatePromptPacket(input: { idea: string; audience?: string }): PromptPacket;
 export function packetToMarkdown(packet: PromptPacket): string;
 export interface ResearchSource {

--- a/products/prompt-generation-app/lib/prompt-generator.js
+++ b/products/prompt-generation-app/lib/prompt-generator.js
@@ -14,6 +14,10 @@ function hashString(str) {
   return Math.abs(h);
 }
 
+function clampScore(score) {
+  return Math.min(100, score);
+}
+
 function scoreBlueOcean(idea) {
   const keywords = ['ai', 'osint', 'compliance', 'audit', 'niche', 'vertical', 'b2b'];
   const lower = idea.toLowerCase();
@@ -21,7 +25,7 @@ function scoreBlueOcean(idea) {
   keywords.forEach((k) => {
     if (lower.includes(k)) score += 8;
   });
-  return Math.min(100, score);
+  return clampScore(score);
 }
 
 function scoreRedOcean(idea) {
@@ -31,7 +35,7 @@ function scoreRedOcean(idea) {
   keywords.forEach((k) => {
     if (lower.includes(k)) score += 10;
   });
-  return Math.min(100, score);
+  return clampScore(score);
 }
 
 function marketFacts(idea) {
@@ -178,5 +182,6 @@ function packetToMarkdown(packet) {
 
 module.exports = {
   generatePromptPacket,
-  packetToMarkdown
+  packetToMarkdown,
+  clampScore
 };

--- a/tests/prompt-generation-app.test.js
+++ b/tests/prompt-generation-app.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const {
   generatePromptPacket,
   packetToMarkdown,
+  clampScore,
 } = require(path.join(__dirname, '..', 'products', 'prompt-generation-app', 'lib', 'prompt-generator.js'));
 
 function run(name, fn) {
@@ -99,4 +100,31 @@ run('does not add music-link prompts for non-music social requests', () => {
   const joined = nonMusicPacket.implementationPrompts.join('\n');
   assert.equal(nonMusicPacket.implementationPrompts.length, baseline.implementationPrompts.length);
   assert.ok(!joined.includes('cannot contain clickable hyperlinks'));
+});
+
+run('red-ocean scoring baseline, incremental keyword match, and case-insensitivity', () => {
+  // Base score without any red-ocean keywords
+  const basePacket = generatePromptPacket({ idea: 'A simple utility for organizing files' });
+  assert.equal(basePacket.scores.redOcean, 30);
+
+  // Single keyword match (+10)
+  const singleMatch = generatePromptPacket({ idea: 'A generic utility for organizing files' });
+  assert.equal(singleMatch.scores.redOcean, 40);
+
+  // Two keywords match (+20)
+  const doubleMatch = generatePromptPacket({ idea: 'A generic CRM utility for organizing files' });
+  assert.equal(doubleMatch.scores.redOcean, 50);
+
+  // Case-insensitive match (+10)
+  const caseMatch = generatePromptPacket({ idea: 'A gEnErIc utility for organizing files' });
+  assert.equal(caseMatch.scores.redOcean, 40);
+});
+
+run('red-ocean scoring exact-100 and over-100 clamping', () => {
+  // All 7 keywords match: 30 + (7 * 10) = 100
+  const allKeywords = generatePromptPacket({ idea: 'social chat todo note crm generic crypto utility' });
+  assert.equal(allKeywords.scores.redOcean, 100);
+
+  // clampScore correctly clamps values above 100
+  assert.equal(clampScore(105), 100);
 });


### PR DESCRIPTION
This PR addresses the need for narrowly-defined, precise regression testing for the red-ocean scoring boundaries as detailed in WR #14010. It implements the following:
- Extracts the inline clamping behavior into a module-exported `clampScore` function, making the 100-limit behavior explicitly testable without affecting logic.
- Updates TypeScript definitions to include the new `clampScore`.
- Adds regression tests via `node:test` covering:
  - Base red-ocean scores.
  - Incremental keyword scoring additions.
  - Case-insensitive matching logic.
  - Exact-100 score results.
  - Greater-than-100 inputs accurately clamped by `clampScore`.
No unrelated workflow or token adjustments were included.

---
*PR created automatically by Jules for task [8613993677662092176](https://jules.google.com/task/8613993677662092176) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds regression tests for red-ocean scoring boundaries by extracting the inline clamping logic into a testable `clampScore` function. The function is exported and properly typed, enabling comprehensive tests that verify base scores, incremental keyword matching, case-insensitive behavior, exact 100-score scenarios, and proper clamping of values exceeding 100.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `products/prompt-generation-app/lib/prompt-generator.d.ts` |
| 2 | `products/prompt-generation-app/lib/prompt-generator.js` |
| 3 | `tests/prompt-generation-app.test.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests for red‑ocean scoring boundaries and extracts clamping into an exported `clampScore` to make the 100 cap explicit and testable. Satisfies WR #14010.

- **Refactors**
  - Extracted inline clamp to `clampScore` and reused it in red‑ and blue‑ocean scoring; exported from `prompt-generator.js`.
  - Updated `prompt-generator.d.ts` to include `clampScore`.

- **Bug Fixes**
  - Added `node:test` coverage for red‑ocean: baseline score, per‑keyword increments, and case‑insensitive matches.
  - Verified exact‑100 results and clamping for >100 via `clampScore`.

<sup>Written for commit b492c0ff2575ddbf58ddef45d3cc57bda8a656e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

