### PR TITLE
fix: wire force_recovery into auto-recover job condition

### DIFF
--- a/.github/workflows/secret-persistence-guard.yml
+++ b/.github/workflows/secret-persistence-guard.yml
@@ -148,7 +148,23 @@ jobs:
           # check_secret "MABL_API_KEY"  # PAUSED 2026-05-27 with mabl.yml — uncomment to re-enable.
 
           # Save missing secrets (compact single-line JSON to avoid $GITHUB_OUTPUT multiline issues)
-          if [ ${#MISSING[@]} -gt 0 ]; then
+          FORCE_RECOVERY="${{ github.event.inputs.force_recovery }}"
+          if [ "$FORCE_RECOVERY" == "true" ]; then
+            ALL_SECRETS=(
+              "OPENROUTER_API_KEY"
+              "JULES_API_KEY"
+              "OPENAI_API_KEY"
+              "ADMIN_GITHUB_TOKEN"
+              "DOPPLER_TOKEN"
+              "APP_ID"
+              "APP_PRIVATE_KEY"
+            )
+            MISSING_JSON=$(printf '%s\n' "${ALL_SECRETS[@]}" | jq -R . | jq -sc .)
+            echo "missing_secrets=$MISSING_JSON" >> "$GITHUB_OUTPUT"
+            echo "has_missing=true" >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "⚠️ **Force recovery requested: treating all ${#ALL_SECRETS[@]} secrets as missing**" >> "$GITHUB_STEP_SUMMARY"
+          elif [ ${#MISSING[@]} -gt 0 ]; then
             MISSING_JSON=$(printf '%s\n' "${MISSING[@]}" | jq -R . | jq -sc .)
             echo "missing_secrets=$MISSING_JSON" >> "$GITHUB_OUTPUT"
             echo "has_missing=true" >> "$GITHUB_OUTPUT"
@@ -165,7 +181,7 @@ jobs:
     name: Auto-recover missing secrets
     needs: monitor-secret-health
     runs-on: ubuntu-latest
-    if: needs.monitor-secret-health.outputs.has_missing == 'true'
+    if: needs.monitor-secret-health.outputs.has_missing == 'true' || github.event.inputs.force_recovery == 'true'
     outputs:
       recovered: ${{ steps.recover.outputs.recovered }}
       failed: ${{ steps.recover.outputs.failed }}

--- a/dashboard-data.json
+++ b/dashboard-data.json
@@ -1447,5 +1447,5 @@
       "hasSystemState": true
     }
   ],
-  "lastUpdated": "2026-06-07T20:48:23.646Z"
+  "lastUpdated": "2026-06-09T13:36:09.262Z"
 }

--- a/dashboard.html
+++ b/dashboard.html
@@ -152,7 +152,7 @@
         </div>
         <div class="stat">
           <span class="stat-label">Last Updated:</span>
-          <span class="stat-value">6/7/2026, 8:48:23 PM</span>
+          <span class="stat-value">6/9/2026, 1:36:09 PM</span>
         </div>
       </div>
 
@@ -904,7 +904,7 @@
     </div>
 
     <div class="last-updated">
-      Dashboard generated at 6/7/2026, 8:48:23 PM
+      Dashboard generated at 6/9/2026, 1:36:09 PM
       <br>
       <small>Auto-updates every 4 hours via GitHub Actions cron job</small>
     </div>


### PR DESCRIPTION
Wire in force_recovery into the auto-recover job condition in secret-persistence-guard.yml.

If the `force_recovery` input is set to true on a manual dispatch, the workflow will now correctly force the `has_missing` output to true by pretending that all secrets are missing in the upstream health check job. Furthermore, the downstream `auto-recover` job will run unconditionally if the force_recovery parameter evaluates to true.

---
*PR created automatically by Jules for task [16629209334833374520](https://jules.google.com/task/16629209334833374520) started by @midnghtsapphire*

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary

This PR fixes the `force_recovery` input handling in the secret-persistence-guard workflow. When `force_recovery` is set to true on manual dispatch, the workflow now correctly treats all secrets as missing in the health check job and ensures the auto-recover job runs unconditionally. The changes add conditional logic to simulate missing secrets and update the job condition to respect the force recovery flag.


⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/secret-persistence-guard.yml` |
| 2 | `dashboard-data.json` |
| 3 | `dashboard.html` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `dashboard-data.json` | Timestamp update in dashboard data appears unrelated to the workflow force_recovery fix |
| `dashboard.html` | Dashboard timestamp updates are unrelated to the workflow force_recovery fix |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `force_recovery` handling in `.github/workflows/secret-persistence-guard.yml` so a manual dispatch can force an auto-recovery run. When `force_recovery` is true, the health check marks all secrets as missing (sets `has_missing=true`), and the `auto-recover` job runs unconditionally.

<sup>Written for commit fca7415116a225c59f82d77c499ac8b086eedefb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

