### PR TITLE
fix(wr): stop concurrency from cancelling the run that creates the PR

### DIFF
--- a/.github/workflows/research-engine.yml
+++ b/.github/workflows/research-engine.yml
@@ -37,8 +37,15 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+# The concurrency group is split by event/action so that label-churn on a WR
+# issue (sibling workflows tag it with ~6 routing labels right after `opened`)
+# does NOT share a lane with — and therefore cannot cancel — the meaningful
+# `opened` / `workflow_dispatch` / `issue_comment` run that actually performs
+# research and dispatches PR creation. Previously every labeled event piled into
+# `research-engine-<issue>` and, because runs sit pending under heavy queue load,
+# each new labeled run cancelled the still-pending research run.
 concurrency:
-  group: research-engine-${{ github.event.issue.number || github.event.inputs.issue_number || github.event.inputs.research_query || github.run_id }}
+  group: research-engine-${{ github.event.issue.number || github.event.inputs.issue_number || github.event.inputs.research_query || github.run_id }}-${{ github.event_name }}-${{ github.event.action }}
   cancel-in-progress: false
 jobs:
   route:
@@ -82,7 +89,13 @@ jobs:
             const hasAgentMention = /@copilot|@cursoragent|@openhands-agent|@imgbotapp/i.test(commentBody);
             const hasResearchIntent = /research engine|deep research|create a product|ship to market|implement|research|wr/i.test(commentBody);
             const commentTriggered = hasResearchIntent && (hasAgentMention || /research engine|deep research|wr/i.test(commentBody));
-            const issueEventTriggered = labelTriggered || titleTriggered;
+            // On a `labeled` event only a *specific* trigger label should start
+            // a research run. Otherwise every sibling workflow that tags a WR
+            // issue (work-request, weekly-research, openrouter, area:*,
+            // priority:* …) re-fires a full research run. Title matching still
+            // applies to opened/reopened so a fresh `[WR]` issue still triggers.
+            const isLabeledEvent = context.eventName === 'issues' && context.payload.action === 'labeled';
+            const issueEventTriggered = isLabeledEvent ? labelTriggered : (labelTriggered || titleTriggered);
             const issueCommentTriggered = isIssueComment && !isPullRequestComment && (commentTriggered || issueEventTriggered);
             const shouldRun = dispatch || issueCommentTriggered || (!isIssueComment && issueEventTriggered);
             const querySource = isIssueComment ? commentBody : title;

--- a/.github/workflows/research-engine.yml
+++ b/.github/workflows/research-engine.yml
@@ -192,6 +192,6 @@ jobs:
                 `Check: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/${workflowId}`
               );
             }
-    timeout-minutes: 45
+    timeout-minutes: 60
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/wr-pr-creation.yml
+++ b/.github/workflows/wr-pr-creation.yml
@@ -18,8 +18,14 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+# Split the concurrency group by event/action so that label-churn `issues`
+# runs cannot cancel the `workflow_dispatch` run that research-engine fires to
+# actually create the PR. Previously all of them shared `wr-pr-<issue>`, and
+# because runs sit pending under heavy queue load, each new labeled event
+# cancelled the still-pending PR-creation run — so recent WR issues normalized
+# their labels but never got a PR.
 concurrency:
-  group: wr-pr-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  group: wr-pr-${{ github.event.issue.number || github.event.inputs.issue_number }}-${{ github.event_name }}-${{ github.event.action }}
   cancel-in-progress: false
 jobs:
   detect-completion:
@@ -57,6 +63,23 @@ jobs:
               core.notice('No issue number found');
               skip('no_issue_number', { notify: false });
               return;
+            }
+
+            // Ignore label-churn from sibling workflows AND from this job's own
+            // normalization step below (it adds work-request, weekly-research,
+            // wr:in-progress, deep-research, openrouter, role:orchestrator —
+            // each firing a fresh `labeled` event). Reacting to every one of
+            // them piles redundant runs into the concurrency group and cancels
+            // the real PR-creation run. Only labels that genuinely signal
+            // research/WR completion should advance here; `opened`,
+            // `issue_comment`, and `workflow_dispatch` paths are unaffected.
+            if (context.eventName === 'issues' && context.payload.action === 'labeled') {
+              const triggerLabel = context.payload.label?.name || '';
+              const COMPLETION_LABELS = new Set(['research:complete', 'wr:complete', 'wr:research']);
+              if (!COMPLETION_LABELS.has(triggerLabel)) {
+                skip(`labeled_noise:${triggerLabel}`, { notify: false });
+                return;
+              }
             }
 
             const commentBody = context.payload.comment?.body || '';


### PR DESCRIPTION
## The symptom

Recent `[WR]` issues run their triage but **never get a WR PR**:

- **#14464–#14469** carry `weekly-research, wr:in-progress, work-request` but have **no `in-review` label** → no PR was created.
- **#14449, #14450, #14452, #14462** carry `wr:retrigger-attempts-*` → the stuck-WR detector retried repeatedly and *still* produced no PR.
- For comparison, **#14441 → PR #14443** and **#14437 → PR #14439** did get PRs (they have `in-review`).

PR #14455 documented the same thing for #14450: *"the automated WR pipeline stalled after label triage — no WR document was generated."*

## Root cause

Both `research-engine.yml` and `wr-pr-creation.yml`:
- trigger on **every** `labeled` event, and
- use a **per-issue concurrency group** with `cancel-in-progress: false`.

When a `[WR]` issue is opened, sibling workflows — and `wr-pr-creation`'s own label-normalization step — slap **~6 routing labels** on it in quick succession. Each label fires a fresh run into the same `wr-pr-<issue>` / `research-engine-<issue>` group. Under this repo's heavy Actions queue, the meaningful run (the `opened` research run, or the `workflow_dispatch` run that creates the PR) sits **pending**, and GitHub's rule is: *a newly-queued run cancels the previously-pending run in the same group.* So each label event **cancels the run that would have created the PR.**

Evidence from the last ~90 minutes: of the 30 most recent runs of *each* workflow, **22 were `cancelled`**, the rest `queued`/`pending`/`skipped` — **0 successes**, and **7–8 runs piled up per single issue**.

## The fix

- **Split both concurrency groups by `event_name` + `action`** so label-churn `issues` runs no longer share a lane with — and can no longer cancel — the `opened` / `workflow_dispatch` / `issue_comment` runs that actually do the work.
- **`research-engine`**: on a `labeled` event, only a *specific* trigger label starts a research run (title matching still applies to `opened`/`reopened`).
- **`wr-pr-creation`**: ignore `labeled` events unless the added label is a real completion signal (`research:complete` / `wr:complete` / `wr:research`), breaking the self-fed label-churn fan-out.

No behaviour change for the `opened` / `workflow_dispatch` / `issue_comment` / completion-label paths that actually create PRs. This both restores PR creation and sharply cuts the redundant run volume (currently 17.5k + 23.5k runs) that was saturating the queue.

## Validation

- Both workflow files parse as valid YAML.
- Change is additive/guard-only on the trigger paths; the create-PR logic is untouched.

## Suggested manual verification after merge

Open a throwaway `[WR] test` issue and confirm exactly one research-engine run and one `wr-pr-creation` `workflow_dispatch` run survive (not cancelled), and a WR PR appears.

🤖 Draft for review — opened by an automated session.

---
_Generated by [Claude Code](https://claude.ai/code/session_015tsYrdhB6XUioi4qDjTiV3)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical bug where GitHub Actions workflows were cancelling each other due to label-churn race conditions. When a Work Request (WR) issue was opened, multiple sibling workflows would rapidly add labels to the issue, each label event triggering new workflow runs in the same concurrency group. Under heavy queue load, these newly-queued runs would cancel the pending run that was supposed to create the actual WR PR, resulting in issues stuck in `wr:in-progress` without PRs. The fix splits the concurrency groups by `event_name` and `action`, and adds filtering logic so that only meaningful completion labels (`research:complete`, `wr:complete`, `wr:research`) trigger PR creation workflows, while ignoring label noise from sibling workflows and self-generated normalization labels.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/wr-pr-creation.yml` |
| 2 | `.github/workflows/research-engine.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WR PRs getting skipped by isolating Actions concurrency and filtering label-triggered runs so the PR-creation run is not cancelled. Restores PR creation, cuts redundant runs from label churn, and adds research timeout headroom.

- **Bug Fixes**
  - Split concurrency groups in `research-engine.yml` and `wr-pr-creation.yml` by `${{ github.event_name }}-${{ github.event.action }}` to stop cross-cancellation.
  - `research-engine`: on `labeled`, only a specific trigger label starts research; title match still applies on `opened`/`reopened`.
  - `wr-pr-creation`: ignore `labeled` events unless the label is `research:complete`, `wr:complete`, or `wr:research`.
  - No change to `opened`, `workflow_dispatch`, or `issue_comment` paths that create the PR.
  - `research-engine`: increased job timeout from 45 to 60 minutes for headroom under heavy queue load.

<sup>Written for commit df093b26a29763e3535d6c5a64b68bb4c36e6cb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

