### PR TITLE
feat: add production specs for all video, image, and merchandise outputs

### DIFF
--- a/docs/specs/MERCHANDISE_SPECS.md
+++ b/docs/specs/MERCHANDISE_SPECS.md
@@ -1,0 +1,181 @@
+# Merchandise Design System
+
+Logo specifications, merchandise templates, and print-on-demand requirements.
+
+## Logo Specifications
+
+### Primary Logo
+- **File formats**: SVG (primary), PNG, PSD, AI
+- **Minimum size**: 100px height
+- **Color modes**: Full color, white, black
+- **Clear space**: 0.25" all sides
+
+### Logo Variations
+| Variation | Use Case | File |
+|-----------|----------|------|
+| **Full logo** | Main branding | logo-full.svg |
+| **Icon only** | Small applications | logo-icon.svg |
+| **Horizontal** | Apparel, headers | logo-horizontal.svg |
+| **Vertical** | Special placements | logo-vertical.svg |
+| **White** | Dark backgrounds | logo-white.png |
+| **Black** | Light backgrounds | logo-black.png |
+
+### Logo Storage
+```
+logos/
+├── primary/              # Main logo files
+│   ├── logo.svg         # Vector source
+│   ├── logo.ai          # Adobe Illustrator
+│   └── logo.psd         # Photoshop with layers
+├── variations/           # Logo variations
+│   ├── horizontal/
+│   ├── vertical/
+│   └── icon/
+├── color-versions/        # Color variants
+│   ├── full-color/
+│   ├── white/
+│   └── black/
+└── mockups/              # Logo in context
+    ├── tshirt-mockup.png
+    ├── mug-mockup.png
+    └── web-mockup.png
+```
+
+---
+
+## Print-on-Demand Specifications
+
+### T-Shirts
+
+#### Garment Specs
+| Size | Chest Width | Length | Sleeve |
+|------|------------|--------|--------|
+| **XS** | 18" | 28" | 7.5" |
+| **S** | 19" | 29" | 8" |
+| **M** | 20" | 30" | 8.5" |
+| **L** | 21" | 31" | 9" |
+| **XL** | 22.5" | 32" | 9.5" |
+| **2XL** | 24" | 33" | 10" |
+| **3XL** | 25.5" | 34" | 10.5" |
+
+#### Print Areas
+| Area | Dimensions | Max DPI | Position |
+|------|------------|---------|----------|
+| **Front Center** | 12" × 14" | 300 | Center chest |
+| **Front Left Chest** | 4" × 4" | 300 | Over heart |
+| **Back Full** | 12" × 16" | 300 | Center back |
+| **Back Top** | 11" × 11" | 300 | Below collar |
+| **Sleeve Left** | 4" × 4" | 300 | Left sleeve |
+| **Sleeve Right** | 4" × 4" | 300 | Right sleeve |
+
+#### Design Guidelines
+- **File format**: PNG with transparent background (preferred) or PSD
+- **Color mode**: RGB (screen) or CMYK (print)
+- **Resolution**: 300 DPI minimum
+- **Color profile**: sRGB for print-on-demand
+- **File size**: Under 25MB per design
+
+### Mugs
+
+#### Types
+| Type | Capacity | Print Area | Dimensions |
+|------|----------|------------|------------|
+| **Classic 11oz** | 11 oz | 8.5" × 3.5" | 4.5" diameter |
+| **Classic 15oz** | 15 oz | 9.5" × 3.75" | 4.5" diameter |
+| **All-over** | 11oz/15oz | Full wrap | 9.5" × 4" |
+
+#### Design Guidelines
+- **File format**: PNG (transparent background) or PSD
+- **Resolution**: 300 DPI
+- **Color mode**: RGB
+- **Print area**: Include bleed for all-over prints
+
+### Other Merchandise
+
+| Item | Print Area | Dimensions | File Format |
+|------|-----------|------------|-------------|
+| **Tote Bag** | 14" × 16" | Full front | PNG/PSD 300 DPI |
+| **Hoodie Front** | 12" × 12" | Center chest | PNG/PSD 300 DPI |
+| **Hoodie Back** | 12" × 14" | Full back | PNG/PSD 300 DPI |
+| **Pillow Case** | 16" × 16" | Full cover | PNG/PSD 300 DPI |
+| **Phone Case** | 3.5" × 6.5" | Curved area | PNG 300 DPI |
+| **Tapestry** | 34" × 44" | Full | PNG/PSD 300 DPI |
+| **Canvas Print** | Various | Full | PNG 300 DPI |
+
+---
+
+## Print-on-Demand Platforms
+
+### Redbubble
+| Product | File Requirements | Notes |
+|---------|------------------|-------|
+| **T-Shirts** | 300 DPI, RGB | Auto-sizing |
+| **Stickers** | 300 DPI, transparent PNG | Die-cut |
+| **Mugs** | 300 DPI | Dishwasher safe |
+| **Hoodies** | 300 DPI | Unisex sizing |
+| **Canvas** | 300 DPI | Gallery wrap |
+
+### Printful
+| Product | File Requirements | Notes |
+|---------|------------------|-------|
+| **All Products** | 300 DPI, RGB | Size guide per item |
+| **DTG Shirts** | 300 DPI, PNG | No background |
+| **Embroidery** | 150 DPI, PNG | Limited colors |
+
+### Teespring (Spring)
+| Product | File Requirements | Notes |
+|---------|------------------|-------|
+| **T-Shirts** | 300 DPI, RGB | No background |
+| **Hoodies** | 300 DPI | Unisex |
+| **Accessories** | 300 DPI | Various |
+
+---
+
+## Merchandise Workflow
+
+```
+1. DESIGN
+   ├── Create logo variations
+   ├── Design merchandise graphics
+   └── Prepare print-ready files
+
+2. UPLOAD TO POD
+   ├── Redbubble (global reach)
+   ├── Printful (integration options)
+   └── Teespring (community)
+   
+3. PRODUCT CREATION
+   ├── Select base products
+   ├── Position designs
+   └── Set pricing
+
+4. LISTING
+   ├── Write product descriptions
+   ├── Add tags for SEO
+   └── Set categories
+
+5. PROMOTION
+   ├── Link from website
+   ├── Social media posts
+   └── Email marketing
+```
+
+---
+
+## Branding Guidelines for Merchandise
+
+### Color Usage
+- Primary colors for main branding
+- White logo on dark garments
+- Black logo on light garments
+- Full color for premium products
+
+### Typography
+- Clear, readable at small sizes
+- Sans-serif for modern look
+- Serif for classic feel
+
+### Imagery
+- High contrast for visibility
+- Test on actual garment colors
+- Consider fabric texture effects

--- a/docs/specs/PRODUCTION_SPECS.md
+++ b/docs/specs/PRODUCTION_SPECS.md
@@ -1,0 +1,211 @@
+# Production Specs - Image Sizes, Video Lengths, and Output Formats
+
+Complete technical specifications for all video production artifacts across all platforms.
+
+## Video Specifications
+
+### Social Media Videos
+
+| Platform | Aspect Ratio | Resolution | Duration | File Format | Max File Size |
+|----------|-------------|------------|----------|-------------|---------------|
+| **LinkedIn** | 16:9 | 1920x1080 | 30sec - 3min | MP4 | 5GB |
+| **LinkedIn** | 1:1 | 1080x1080 | 30sec - 3min | MP4 | 5GB |
+| **Facebook Feed** | 16:9 | 1920x1080 | 1-5min | MP4 | 4GB |
+| **Facebook Reels** | 9:16 | 1080x1920 | 30sec - 10min | MP4 | 4GB |
+| **Instagram Feed** | 1:1 or 4:5 | 1080x1080 or 1080x1350 | 60sec | MP4 | 4GB |
+| **Instagram Reels** | 9:16 | 1080x1920 | 15sec - 10min | MP4 | 4GB |
+| **Instagram Stories** | 9:16 | 1080x1920 | 15sec | MP4/JPG | 30MB |
+| **YouTube Shorts** | 9:16 | 1080x1920 | 15sec - 60sec | MP4 | 2GB |
+| **YouTube Video** | 16:9 | 3840x2160 (4K) or 1920x1080 | 1min - 12hrs | MP4 | 256GB |
+| **TikTok** | 9:16 | 1080x1920 | 15sec - 10min | MP4 | 287MB |
+| **Twitter/X** | 16:9 | 1920x1080 | 140sec | MP4 | 512MB |
+| **Pinterest** | 2:3 | 1000x1500 | 60sec max | MP4 | 2GB |
+
+### CLE Training Videos
+
+| Type | Duration | Credit Hours | Resolution | Requirements |
+|------|----------|--------------|------------|--------------|
+| **Colorado CLE** | 50 min instruction | 1 CLE unit | 1080p min | Attendance verification, captions |
+| **Multi-Unit Course** | 50 min × units | 1-12 units | 1080p min | Quiz per unit, certificate |
+| **Ethics** | 50 min | 1 ETHICS | 1080p min | Interactive checkpoints |
+
+### Music Videos
+
+| Type | Duration | Resolution | Format | Platforms |
+|------|----------|------------|--------|-----------|
+| **Lyric Video** | 3-5 min | 1920x1080 | MP4 | YouTube, Spotify |
+| **Music Video** | 3-5 min | 3840x2160 | ProRes/MP4 | All streaming |
+| **Spotify Canvas** | 8-30 sec | 1080x1920 | MP4 | Spotify |
+| **Apple Music Visual** | 3-5 min | 3840x2160 | MP4 | Apple Music |
+| **TikTok Clip** | 15-60 sec | 1080x1920 | MP4 | TikTok |
+
+### Movie/Long-Form
+
+| Type | Duration | Resolution | Aspect Ratio | Format |
+|------|----------|------------|--------------|--------|
+| **Short Film** | 20-40 min | 4K (3840x2160) | 16:9 | ProRes |
+| **Feature Film** | 90-120 min | 4K | 16:9 | DCP/ProRes |
+| **Documentary** | 60-90 min | 4K | 16:9 | ProRes |
+
+---
+
+## Image Specifications
+
+### Social Media Images
+
+| Platform | Dimensions (px) | Aspect Ratio | File Type | Max Size |
+|----------|-----------------|--------------|-----------|----------|
+| **LinkedIn Post** | 1200x1200 | 1:1 | JPG/PNG | 8MB |
+| **LinkedIn Cover** | 1128x191 | 5.9:1 | JPG | 2MB |
+| **Facebook Event Cover** | 1920x1004 | 1.91:1 | JPG/PNG | 8MB |
+| **Facebook Ad** | 1200x628 | 1.91:1 | JPG/PNG | 30MB |
+| **Instagram Post** | 1080x1080 | 1:1 | JPG/PNG | 8MB |
+| **Instagram Portrait** | 1080x1350 | 4:5 | JPG/PNG | 8MB |
+| **Instagram Story** | 1080x1920 | 9:16 | JPG/PNG | 8MB |
+| **YouTube Thumbnail** | 1280x720 | 16:9 | JPG | 2MB |
+| **YouTube Channel Banner** | 2560x1440 | 16:9 | JPG | 6MB |
+| **TikTok Profile** | 200x200 | 1:1 | JPG/PNG | 1MB |
+| **Twitter Header** | 1500x500 | 3:1 | JPG/PNG | 5MB |
+
+### Gumroad Product Images
+
+| Type | Dimensions | Aspect Ratio | File Type | Max Size |
+|------|------------|--------------|-----------|----------|
+| **Cover Image** | 1200x630 | 1.91:1 | JPG/PNG | 10MB |
+| **Product Gallery** | 1200x1200 | 1:1 | JPG/PNG | 8MB |
+| **Thumbnail** | 400x400 | 1:1 | JPG/PNG | 2MB |
+| **Preview Image** | 1920x1080 | 16:9 | JPG/PNG | 5MB |
+| **PDF Preview** | 1200x1600 | 3:4 | JPG/PNG | 3MB |
+| **Ebook Cover** | 1400x2100 | 3:2 | JPG/PNG | 5MB |
+
+### Merchandise Design Specs
+
+#### T-Shirts
+| Area | Dimensions | DPI | Color Mode | File Type |
+|------|-----------|-----|------------|-----------|
+| **Front Design** | 12" × 14" | 300 | CMYK | PSD/PNG |
+| **Back Design** | 12" × 16" | 300 | CMYK | PSD/PNG |
+| **Left Chest** | 4" × 4" | 300 | CMYK | PSD/PNG |
+| **Print Area** | 14" × 16" max | 300 | CMYK | PSD |
+
+#### Mugs
+| Type | Print Area | DPI | Color Mode | File Type |
+|------|------------|-----|------------|-----------|
+| **11oz Mug Wrap** | 9" × 3.5" | 300 | CMYK | PSD/PNG |
+| **15oz Mug Wrap** | 11" × 4" | 300 | CMYK | PSD/PNG |
+| **Sublimation** | Full wrap | 300 | CMYK | PSD |
+
+#### Other Merchandise
+| Item | Dimensions | DPI | File Type |
+|------|------------|-----|-----------|
+| **Tote Bag** | 14" × 16" | 300 | PSD |
+| **Phone Case** | 3.5" × 6.5" | 300 | PSD |
+| **Stickers** | 3" × 3" | 300 | PNG (transparent) |
+| **Hoodie Front** | 12" × 12" | 300 | PSD/PNG |
+
+---
+
+## PDF Specifications
+
+### Gumroad PDF Products
+
+| Type | Page Size | Dimensions | Margins | Resolution |
+|------|-----------|------------|---------|------------|
+| **Ebook** | US Letter | 8.5" × 11" | 0.75" all sides | 300 DPI images |
+| **Ebook** | A4 | 210mm × 297mm | 20mm all sides | 300 DPI images |
+| **Workbook** | US Letter | 8.5" × 11" | 0.5" all sides | 300 DPI images |
+| **Guide** | US Letter | 8.5" × 11" | 0.75" all sides | 300 DPI images |
+| **Report** | US Letter | 8.5" × 11" | 0.75" all sides | 300 DPI images |
+| **Template** | Various | As needed | 0.5" all sides | 300 DPI images |
+
+### PDF Cover Specifications
+
+| Type | Dimensions | Bleed | Color Profile | File Type |
+|------|------------|-------|--------------|-----------|
+| **Ebook Cover** | 6" × 9" (body) + 0.125" bleed | 0.125" | RGB (screen) or CMYK (print) | PDF |
+| **KDP Book Cover** | Per KDP specs | 0.125" | CMYK | PDF |
+| **Paperback** | Calculate from page count | 0.125" | CMYK | PDF |
+
+### PDF Content Specifications
+
+- **Font embedding**: All fonts embedded or converted to outlines
+- **Image quality**: 300 DPI for print, 150 DPI for screen
+- **Color profile**: sRGB for digital, CMYK for print
+- **File size**: Under 50MB for digital delivery
+- **Compression**: Not lossy for text/images
+
+---
+
+## Website Specifications
+
+### Landing Pages
+| Element | Dimensions | File Type | Notes |
+|---------|------------|-----------|-------|
+| **Hero Image** | 1920×1080 | JPG/WebP | Compress to <200KB |
+| **Product Images** | 1200×1200 | JPG/WebP | Lazy load |
+| **Video Background** | 1920×1080 | MP4/WebM | <10MB |
+| **Favicon** | 32×32, 16×16 | PNG/ICO | |
+| **OG Image** | 1200×630 | JPG/PNG | For social sharing |
+
+### Portfolio/Showcase
+| Element | Dimensions | File Type | Notes |
+|---------|------------|-----------|-------|
+| **Project Thumbnail** | 800×600 | JPG/WebP | |
+| **Project Hero** | 1920×1080 | JPG/WebP | |
+| **Gallery Item** | 1200×900 | JPG/WebP | Lightbox enabled |
+
+---
+
+## Chrome Extension
+
+### Icons
+| Size | Use Case | File Type |
+|------|----------|-----------|
+| **16×16** | Toolbar/favicon | PNG |
+| **19×19** | Toolbar (retina) | PNG |
+| **32×32** | Extension page | PNG |
+| **38×38** | Extension page (retina) | PNG |
+| **48×48** | Chrome Web Store | PNG |
+| **128×128** | Chrome Web Store (retina) | PNG |
+
+### Manifest Requirements
+```json
+{
+  "icons": {
+    "16": "images/icon16.png",
+    "32": "images/icon32.png",
+    "48": "images/icon48.png",
+    "128": "images/icon128.png"
+  }
+}
+```
+
+---
+
+## Quick Reference Cheat Sheet
+
+### Video Frame Sizes
+```
+4K:      3840 × 2160
+1080p:   1920 × 1080
+720p:    1280 × 720
+9:16:    1080 × 1920 (vertical)
+1:1:     1080 × 1080 (square)
+4:5:     1080 × 1350 (portrait)
+```
+
+### Social Media Image Sizes
+```
+Square (Instagram): 1080 × 1080
+Portrait (Instagram): 1080 × 1350
+Story (All): 1080 × 1920
+YouTube Thumb: 1280 × 720
+OG Image: 1200 × 630
+```
+
+### Print Sizes (at 300 DPI)
+```
+Letter (8.5×11"): 2550 × 3300 px
+A4 (210×297mm): 2480 × 3508 px
+Business Card: 1050 × 600 px
+```


### PR DESCRIPTION
## Summary

Complete production specifications for all video, image, PDF, and merchandise outputs.

## What's Included

### Production Specs (PRODUCTION_SPECS.md)
| Category | Details |
|----------|---------|
| **Video Specs** | All platforms: LinkedIn, Facebook, Instagram, YouTube, TikTok, Twitter |
| **CLE Videos** | Colorado compliant, 50min = 1 credit hour |
| **Music Videos** | Lyric, narrative, performance, Spotify Canvas |
| **Movies** | Short film (20-40min), Feature (90-120min), Documentary |
| **Social Images** | All platform sizes (1200x1200, 1080x1920, etc.) |
| **Gumroad Images** | Cover (1200x630), Gallery (1200x1200), Preview (1920x1080) |
| **PDF Specs** | US Letter, A4, margins, 300 DPI, ebook covers |
| **Website** | Hero images, thumbnails, favicons, OG images |
| **Chrome Extension** | 16, 32, 48, 128px icons |

### Merchandise Specs (MERCHANDISE_SPECS.md)
| Item | Print Area | Specs |
|------|------------|-------|
| **T-Shirts** | Front 12x14", Back 12x16", Chest 4x4" | 300 DPI, PNG/PSD |
| **Mugs** | 11oz: 8.5x3.5", 15oz: 9.5x3.75" | 300 DPI |
| **Tote Bags** | 14x16" full front | 300 DPI |
| **Hoodies** | Front 12x12", Back 12x14" | 300 DPI |
| **Phone Cases** | 3.5x6.5" | 300 DPI |

### Print-on-Demand Platforms
- Redbubble specifications
- Printful integration requirements
- Teespring guidelines

### Quick Reference Cheat Sheet
- Video frame sizes (4K, 1080p, vertical)
- Social media image dimensions
- Print sizes at 300 DPI

## Related Issues
- Closes sessiono#5 (website S2M - now has specs to build against)

@midnghtsapphire can click here to [continue refining the PR](https://app.all-hands.dev/conversations/169c4d88-25ff-43ae-a738-b2760b5fbf15)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds comprehensive production specifications documentation for all output formats across the organization. It introduces two new specification documents: `PRODUCTION_SPECS.md` covering video specifications for social media platforms (LinkedIn, Facebook, Instagram, YouTube, TikTok, Twitter), CLE training videos, music videos, movies, and various image formats for social media, Gumroad products, websites, and Chrome extensions; and `MERCHANDISE_SPECS.md` detailing logo specifications, print-on-demand requirements for t-shirts, mugs, hoodies, tote bags, phone cases, and integration guidelines for platforms like Redbubble, Printful, and Teespring. These specifications provide technical requirements including dimensions, resolutions, file formats, DPI requirements, and platform-specific constraints that teams can reference when creating any digital or physical product outputs.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/specs/PRODUCTION_SPECS.md` |
| 2 | `docs/specs/MERCHANDISE_SPECS.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds comprehensive, platform-by-platform production specs for video, images, PDFs, web assets, Chrome extension icons, and merchandise. Creates a single source of truth for deliverables and unblocks website S2M work (Linear sessiono#5).

- **New Features**
  - Added `docs/specs/PRODUCTION_SPECS.md` and `docs/specs/MERCHANDISE_SPECS.md`.
  - Video specs for LinkedIn, Facebook, Instagram, YouTube, TikTok, X, plus CLE, music, and film.
  - Image/web/PDF specs including social sizes, Gumroad covers/previews, OG images, and favicons.
  - Merchandise specs (shirts, mugs, hoodies, totes, cases) and print-on-demand guidelines (Redbubble, Printful, Teespring).
  - Chrome extension icon sizes and a quick reference for frame sizes and 300 DPI print conversions.

<sup>Written for commit 80129367c4250e737af347ac7ed9b8081a752a29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

