### PR TITLE
fix(ci): GIT_ACCESS_TOKEN -> ADMIN_GITHUB_TOKEN/github.token fallback

### DIFF
--- a/.github/workflows/auto-approve-clean-prs.yml
+++ b/.github/workflows/auto-approve-clean-prs.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/github-script@v9.0.0
         with:
-          github-token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          github-token: ${{ secrets.ADMIN_GITHUB_TOKEN || github.token }}
           script: |
             const { owner, repo } = context.repo;
 

--- a/.github/workflows/bito-ai.yml
+++ b/.github/workflows/bito-ai.yml
@@ -115,7 +115,7 @@ jobs:
         id: verify-secrets
         env:
           BITO_ACCESS_KEY: ${{ secrets.BITO_ACCESS_KEY }}
-          GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
+          GIT_ACCESS_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN || github.token }}
         run: |
           echo "=========================================="
           echo "BITO AI Secret Verification"
@@ -208,7 +208,7 @@ echo "BITO_SKIP=true" >> "$GITHUB_ENV"
           OPTIONS+=" --dependency_check.enabled=False"
           OPTIONS+=" --bee.path=/automation-platform"
           OPTIONS+=" --bee.actn_dir=/automation-platform/default_bito_ad/bito_modules"
-          OPTIONS+=" --git.access_token=${{ secrets.GIT_ACCESS_TOKEN }}"
+          OPTIONS+=" --git.access_token=${{ secrets.ADMIN_GITHUB_TOKEN || github.token }}"
           OPTIONS+=" --bito_cli.bito.access_key=${{ secrets.BITO_ACCESS_KEY }}"
           
           # Optional configurations from repo variables


### PR DESCRIPTION
Replaces removed `GIT_ACCESS_TOKEN` in all active workflow refs with `(secrets.ADMIN_GITHUB_TOKEN || github.token)`. Supersedes the 9 redundant token-fix PRs; close them after merge.

⚠️ Add repo secret `ADMIN_GITHUB_TOKEN` (fine-grained PAT: Pull requests write + Contents write) for auto-approve to fully work — `github.token` cannot self-approve.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates GitHub workflow files to replace the deprecated `GIT_ACCESS_TOKEN` secret with a fallback pattern using `ADMIN_GITHUB_TOKEN` (when available) or `github.token` (as a default). This ensures workflows continue to function while maintaining the ability to auto-approve PRs when the proper token is configured. The change affects two workflow files: the auto-approve workflow and the Bito AI workflow.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/auto-approve-clean-prs.yml` |
| 2 | `.github/workflows/bito-ai.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced removed `GIT_ACCESS_TOKEN` in CI workflows with `${{ secrets.ADMIN_GITHUB_TOKEN || github.token }}` to keep jobs running and enable auto-approve when a PAT is set.

- **Migration**
  - Add repo secret `ADMIN_GITHUB_TOKEN` (fine‑grained PAT) with Pull requests: write and Contents: write.
  - Note: `github.token` cannot self-approve; auto-approve works only when `ADMIN_GITHUB_TOKEN` is configured.

<sup>Written for commit 72e6efad8c7352a0302e510e43df8bc0014aaff1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

