### PR TITLE
WR #14451: gumloop PDF pipeline + stop duplicate/looping WR skeleton PRs

### DIFF
--- a/.github/workflows/gumloop-pdf-pipeline.yml
+++ b/.github/workflows/gumloop-pdf-pipeline.yml
@@ -1,0 +1,69 @@
+name: Gumloop PDF Pipeline
+
+# Executable implementation of workflows/gumloop/pdf-product-creation.md.
+# Generates a sellable PDF + product/campaign manifest from a niche + keywords
+# and uploads them as run artifacts. Uses OPENROUTER_API_KEY for the AI steps
+# when present; falls back to deterministic copy so runs never fail for lack of
+# a key. WR #14451.
+on:
+  workflow_dispatch:
+    inputs:
+      niche:
+        description: Product niche (e.g. "ADHD productivity")
+        required: true
+        type: string
+      keywords:
+        description: Comma-separated keywords
+        required: false
+        default: ""
+        type: string
+      output_name:
+        description: Output directory under the workspace
+        required: false
+        default: artifacts/pdf
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gumloop-pdf-${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    name: Generate PDF product
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install --disable-pip-version-check reportlab
+
+      - name: Run Gumloop PDF pipeline
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          python scripts/gumloop_pdf_pipeline.py \
+            --niche "${{ inputs.niche }}" \
+            --keywords "${{ inputs.keywords }}" \
+            --out "${{ inputs.output_name }}"
+
+      - name: Upload PDF + manifest artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gumloop-pdf-product
+          path: |
+            ${{ inputs.output_name }}/*.pdf
+            ${{ inputs.output_name }}/*.manifest.json
+          if-no-files-found: error
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/wr-pr-creation.yml
+++ b/.github/workflows/wr-pr-creation.yml
@@ -126,6 +126,17 @@ jobs:
               return;
             }
 
+            // Do not (re)create skeleton PRs for finished WRs. A closed issue
+            // — or one explicitly marked `issue:done` — has already been
+            // delivered; re-triggers here only spawn duplicate skeleton PRs
+            // (this is what happened on #14451, which kept generating new
+            // skeleton PRs every time a label changed after it was closed).
+            if (issue.state === 'closed' || labelSet.has('issue:done')) {
+              core.info(`Issue #${issueNumber} is closed/done; not creating a WR PR.`);
+              skip('issue_closed_or_done', { notify: false });
+              return;
+            }
+
             // Skip bot-created issues (defensive — bot-spam should be filtered
             // by the job-level `if:` already).
             if (issue.user && issue.user.login === 'github-actions[bot]') {
@@ -183,13 +194,20 @@ jobs:
             // the dedup is correct even if a different workflow ever
             // applied one of the others.
             //
-            // Search OPEN PRs only — a previously-closed/merged WR-skeleton
-            // PR doesn't block a fresh WR-skeleton PR; that's a re-trigger
-            // of the same WR after the original was abandoned.
+            // Search ALL PRs (open + closed) so we can tell apart the three
+            // cases. An OPEN skeleton means one is already in flight — this
+            // also closes the few-minutes race where two triggers fire before
+            // either PR is visible (#14451 got #14497 and #14502 three minutes
+            // apart this way). A MERGED skeleton means the WR doc already
+            // shipped, so the WR is done — do not spawn another. Only a
+            // CLOSED-but-unmerged skeleton (genuinely abandoned) leaves the
+            // door open for a fresh re-trigger.
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: 'open',
+              state: 'all',
+              sort: 'created',
+              direction: 'desc',
               per_page: 100,
             });
 
@@ -203,7 +221,10 @@ jobs:
                 prLabels.includes('weekly-research') &&
                 prLabels.includes('wr:in-progress');
               const refsThisIssue = pr.body && issueRefRegex.test(pr.body);
-              return isWrSkeleton && refsThisIssue;
+              // Block on an in-flight (open) or already-shipped (merged)
+              // skeleton; allow re-trigger after an abandoned (closed-unmerged) one.
+              const blocks = pr.state === 'open' || Boolean(pr.merged_at);
+              return isWrSkeleton && refsThisIssue && blocks;
             });
 
             if (existingPR) {

--- a/scripts/gumloop_pdf_pipeline.py
+++ b/scripts/gumloop_pdf_pipeline.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Gumloop PDF Product Creation Pipeline — executable implementation.
+
+This is the code equivalent of the no-code Gumloop flow documented in
+``workflows/gumloop/pdf-product-creation.md`` (Webhook -> Research -> AI Title
+-> AI Content -> PDF -> Product/Campaign manifest). It is wired to the repo's
+OpenRouter tooling for the AI steps and renders a real PDF with reportlab.
+
+Definition of Done (WR #14451): given a niche + keywords, produce a sellable
+PDF artifact AND a product/campaign manifest with the metadata downstream
+processes (Gumroad/Canva/Shopify, the PDF shape standard) need.
+
+Best-effort + offline-safe: if ``OPENROUTER_API_KEY`` is absent the AI steps
+fall back to deterministic stub copy, so the pipeline always produces a PDF and
+manifest (useful for CI smoke tests and local runs).
+
+Usage:
+    python scripts/gumloop_pdf_pipeline.py \
+        --niche "ADHD productivity" \
+        --keywords "focus,planner,dopamine" \
+        --out artifacts/pdf
+
+Outputs (in --out, default ``artifacts/pdf``):
+    <slug>.pdf            — the rendered product
+    <slug>.manifest.json  — product + campaign metadata
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+OPENROUTER_HOST = "https://openrouter.ai/api/v1/chat/completions"
+# Ordered best-first; mirrors scripts/openrouter-routing.js model choices.
+MODELS = ["anthropic/claude-sonnet-4", "openai/gpt-5.2-codex"]
+
+
+def slugify(text: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")
+    return s or "pdf-product"
+
+
+def call_openrouter(messages, max_tokens=1500, temperature=0.6):
+    """Single OpenRouter chat call. Returns the content string, or None on failure."""
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        return None
+    payload = json.dumps(
+        {"model": MODELS[0], "models": MODELS, "messages": messages,
+         "max_tokens": max_tokens, "temperature": temperature}
+    ).encode()
+    req = urllib.request.Request(
+        OPENROUTER_HOST,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/midnghtsapphire/revvel-standards",
+            "X-Title": "Revvel Gumloop PDF Pipeline",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read())
+        return data["choices"][0]["message"]["content"]
+    except (urllib.error.URLError, KeyError, json.JSONDecodeError, TimeoutError) as exc:
+        print(f"[warn] OpenRouter call failed, using fallback: {exc}", file=sys.stderr)
+        return None
+
+
+# ── Step 1: Research / validate niche ──────────────────────────────────────
+def prepare_research(niche: str, keywords: list[str]) -> dict:
+    return {
+        "niche": niche or "general productivity",
+        "keywords": [k.strip() for k in keywords if k.strip()],
+        "timestamp": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "step": "trend_research",
+        "ready_for_ai": True,
+    }
+
+
+# ── Step 2: AI title ───────────────────────────────────────────────────────
+def generate_title(research: dict) -> str:
+    prompt = (
+        f"Generate ONE punchy, sellable title for a downloadable PDF guide in the "
+        f"'{research['niche']}' niche. Keywords: {', '.join(research['keywords']) or 'n/a'}. "
+        f"Return only the title, no quotes."
+    )
+    out = call_openrouter([{"role": "user", "content": prompt}], max_tokens=40, temperature=0.8)
+    if out:
+        return out.strip().splitlines()[0].strip().strip('"')
+    kw = research["keywords"][0] if research["keywords"] else research["niche"]
+    return f"The {kw.title()} Blueprint: A Practical {research['niche'].title()} Guide"
+
+
+# ── Step 3: AI content ─────────────────────────────────────────────────────
+def generate_content(research: dict, title: str) -> list[dict]:
+    """Returns a list of {'heading','body'} sections."""
+    prompt = (
+        f"Write the content for a concise, high-value sellable PDF titled '{title}' in the "
+        f"'{research['niche']}' niche (keywords: {', '.join(research['keywords']) or 'n/a'}). "
+        f"Return STRICT JSON: a list of 5-7 objects, each {{\"heading\": str, \"body\": str}}. "
+        f"Each body 2-4 sentences, actionable. No markdown, no commentary outside the JSON."
+    )
+    out = call_openrouter([{"role": "user", "content": prompt}], max_tokens=1800)
+    if out:
+        try:
+            start, end = out.find("["), out.rfind("]")
+            sections = json.loads(out[start:end + 1])
+            cleaned = [
+                {"heading": str(s.get("heading", "")).strip(),
+                 "body": str(s.get("body", "")).strip()}
+                for s in sections if s.get("heading") and s.get("body")
+            ]
+            if cleaned:
+                return cleaned
+        except (json.JSONDecodeError, AttributeError, TypeError) as exc:
+            print(f"[warn] content JSON parse failed, using fallback: {exc}", file=sys.stderr)
+    # Deterministic fallback so the pipeline always yields a usable PDF.
+    return [
+        {"heading": "Introduction", "body": f"Why {research['niche']} matters now and what this guide delivers."},
+        {"heading": "The Core Framework", "body": "A repeatable, step-by-step system you can apply today."},
+        {"heading": "Common Pitfalls", "body": "The mistakes most people make and how to avoid them."},
+        {"heading": "Tools & Resources", "body": "Free and paid tools that accelerate results."},
+        {"heading": "Your 7-Day Quick Start", "body": "A short action plan to see momentum within a week."},
+        {"heading": "Next Steps", "body": "How to go deeper and where to get support."},
+    ]
+
+
+# ── Step 4: Render PDF ─────────────────────────────────────────────────────
+def render_pdf(path: str, title: str, research: dict, sections: list[dict]) -> None:
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.units import inch
+    from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, PageBreak
+
+    styles = getSampleStyleSheet()
+    h1 = ParagraphStyle("CoverTitle", parent=styles["Title"], fontSize=28, leading=34, spaceAfter=24)
+    sub = ParagraphStyle("Sub", parent=styles["Normal"], fontSize=12, textColor="#555555")
+    doc = SimpleDocTemplate(path, pagesize=letter, title=title,
+                            leftMargin=0.9 * inch, rightMargin=0.9 * inch,
+                            topMargin=1.0 * inch, bottomMargin=0.9 * inch)
+    story = [
+        Paragraph(title, h1),
+        Paragraph(f"A practical guide to {research['niche']}.", sub),
+        Spacer(1, 0.3 * inch),
+        Paragraph("Keywords: " + (", ".join(research["keywords"]) or "—"), sub),
+        PageBreak(),
+    ]
+    for sec in sections:
+        story.append(Paragraph(sec["heading"], styles["Heading2"]))
+        story.append(Paragraph(sec["body"], styles["BodyText"]))
+        story.append(Spacer(1, 0.18 * inch))
+    doc.build(story)
+
+
+# ── Step 5: Product / campaign manifest ────────────────────────────────────
+def build_manifest(title: str, slug: str, research: dict, sections: list[dict], pdf_path: str) -> dict:
+    return {
+        "title": title,
+        "slug": slug,
+        "niche": research["niche"],
+        "keywords": research["keywords"],
+        "artifact": {"pdf": os.path.basename(pdf_path), "page_count_estimate": 1 + len(sections)},
+        "product": {
+            "suggested_price_usd": 19,
+            "description": f"A practical, no-fluff {research['niche']} guide you can apply immediately.",
+            "format": "pdf",
+        },
+        # Wiring points for the existing downstream processes (kept declarative
+        # so the same manifest can drive Gumroad / Canva / Shopify nodes).
+        "channels": {
+            "gumroad": {"enabled": True, "category": "self-improvement"},
+            "canva": {"cover_required": True, "status": "todo"},
+            "shopify": {"enabled": False},
+        },
+        "campaign": {
+            "hooks": [f"Master {research['niche']} in a weekend",
+                      f"The {(research['keywords'][0] if research['keywords'] else research['niche'])} system that actually sticks"],
+            "channels": ["x", "reddit", "newsletter"],
+        },
+        "generated_at": research["timestamp"],
+        "pipeline": "gumloop_pdf_pipeline.py",
+        "source_workflow": "workflows/gumloop/pdf-product-creation.md",
+    }
+
+
+def run(niche: str, keywords: list[str], out_dir: str) -> dict:
+    os.makedirs(out_dir, exist_ok=True)
+    research = prepare_research(niche, keywords)
+    title = generate_title(research)
+    slug = slugify(title)
+    sections = generate_content(research, title)
+    pdf_path = os.path.join(out_dir, f"{slug}.pdf")
+    render_pdf(pdf_path, title, research, sections)
+    manifest = build_manifest(title, slug, research, sections, pdf_path)
+    manifest_path = os.path.join(out_dir, f"{slug}.manifest.json")
+    with open(manifest_path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2)
+    print(f"✅ PDF:      {pdf_path}")
+    print(f"✅ Manifest: {manifest_path}")
+    return {"pdf": pdf_path, "manifest": manifest_path, "title": title}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Gumloop PDF product creation pipeline")
+    ap.add_argument("--niche", default=os.environ.get("PDF_NICHE", "general productivity"))
+    ap.add_argument("--keywords", default=os.environ.get("PDF_KEYWORDS", ""),
+                    help="comma-separated keywords")
+    ap.add_argument("--out", default=os.environ.get("PDF_OUT", "artifacts/pdf"))
+    args = ap.parse_args(argv)
+    run(args.niche, [k for k in args.keywords.split(",")], args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflows/gumloop/pdf-product-creation.md
+++ b/workflows/gumloop/pdf-product-creation.md
@@ -470,3 +470,32 @@ For better tracking, add an Airtable node after Step 8:
   - Campaign Ready: Yes
 
 This gives you a centralized dashboard to track all products created by the automation.
+
+---
+
+## Executable Implementation (in-repo, WR #14451)
+
+The no-code Gumloop flow above has a runnable, in-repo equivalent so the same
+pipeline can run in CI without the Gumloop platform:
+
+- **Script:** [`scripts/gumloop_pdf_pipeline.py`](../../scripts/gumloop_pdf_pipeline.py)
+  — Research → AI title → AI content → PDF (reportlab) → product/campaign
+  manifest. Uses `OPENROUTER_API_KEY` for the AI steps (mirrors
+  `scripts/openrouter-routing.js`) and falls back to deterministic copy when no
+  key is set, so it always produces an artifact.
+- **Workflow:** [`.github/workflows/gumloop-pdf-pipeline.yml`](../../.github/workflows/gumloop-pdf-pipeline.yml)
+  — `workflow_dispatch` with `niche` / `keywords` / `output_name` inputs;
+  uploads the `.pdf` and `.manifest.json` as run artifacts.
+
+Run locally:
+
+```bash
+python scripts/gumloop_pdf_pipeline.py --niche "ADHD productivity" \
+  --keywords "focus,planner,dopamine" --out artifacts/pdf
+```
+
+The emitted `*.manifest.json` carries the product price/description plus
+declarative `channels` (Gumroad/Canva/Shopify) and `campaign` metadata, so it
+can drive the same downstream nodes the Gumloop flow targets — i.e. it wires
+into the existing PDF product processes (`standards/shapes/PDF.md`,
+`standards/AUTOMATED_PRODUCT_PIPELINE.md`) rather than replacing them.


### PR DESCRIPTION
Implements WR #14451 ("define and implement gumloop pdf process and/or wire in with existing processes") and fixes the automation that kept re-failing on it.

## Why this PR exists
#14451 kept spawning **duplicate skeleton PRs** (#14497 merged, #14502 closed-`checks-failing`) and re-firing the WR pipeline even after it was closed — and those PRs only ever contained the 49-line WR template, never the actual implementation or artifacts.

## Part 1 — Stop the recurrence / duplicates (root cause)
`wr-pr-creation.yml`:
- **Skips WR issues that are closed or labeled `issue:done`** — a finished WR no longer generates fresh skeleton PRs on every label change.
- **Dedup now searches all PRs** and blocks on an **open** (in-flight) *or* **merged** (already-shipped) skeleton. This also closes the few-minutes race that produced the #14497/#14502 duplicates. A closed-unmerged (abandoned) skeleton still allows a legitimate re-trigger.

## Part 2 — Implement the gumloop PDF process (executable)
The repo only had a *no-code* setup doc (`workflows/gumloop/pdf-product-creation.md`). This adds a runnable, in-repo equivalent of that flow:
- **`scripts/gumloop_pdf_pipeline.py`** — Research → AI title → AI content → **PDF (reportlab)** → **product/campaign manifest**. Uses `OPENROUTER_API_KEY` for the AI steps (mirrors `scripts/openrouter-routing.js`); deterministic offline fallback so it always produces an artifact. ✅ Verified locally: emits a real multi-page PDF + `manifest.json`.
- **`.github/workflows/gumloop-pdf-pipeline.yml`** — `workflow_dispatch` (`niche` / `keywords` / `output_name`) that runs the pipeline and **uploads the `.pdf` and `.manifest.json` as run artifacts** (so the run carries all artifacts).
- Wired into the existing gumloop doc + PDF product standards (`standards/shapes/PDF.md`, `standards/AUTOMATED_PRODUCT_PIPELINE.md`) rather than replacing them — the manifest's declarative `channels` (Gumroad/Canva/Shopify) + `campaign` metadata drive the same downstream nodes.

## Test plan
- [x] `gumloop_pdf_pipeline.py` compiles and produces a real 2-page PDF + manifest offline (stub path)
- [x] Both workflows are valid YAML with correct `on:` triggers
- [x] `wr-pr-creation.yml` parses with the closed-issue guard + all-PR dedup
- [ ] Manual `workflow_dispatch` of the pipeline uploads artifacts (will verify on first run)

docs-freshness: new pipeline workflow + script for WR #14451; the executable mirrors an already-documented gumloop process and existing PDF standards.

https://claude.ai/code/session_017B79LoGBgUMf7dLmocUT6R

---
_Generated by [Claude Code](https://claude.ai/code/session_017B79LoGBgUMf7dLmocUT6R)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a recurring automation issue where work request (WR) #14451 kept spawning duplicate skeleton PRs after being closed, and implements the actual gumloop PDF generation pipeline that was missing. The workflow fix adds guards to skip closed or `issue:done` WRs and deduplicates across all PRs (open and merged) to prevent race conditions. The implementation adds a runnable Python script (`gumloop_pdf_pipeline.py`) that performs research → AI title generation → AI content generation → PDF rendering → product manifest creation, plus a GitHub Actions workflow that can be manually triggered with niche/keywords inputs and uploads the resulting PDF and manifest as artifacts. The script gracefully falls back to deterministic stub content when the OpenRouter API key is unavailable, ensuring it always produces usable output for testing and CI.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/wr-pr-creation.yml` |
| 2 | `scripts/gumloop_pdf_pipeline.py` |
| 3 | `.github/workflows/gumloop-pdf-pipeline.yml` |
| 4 | `workflows/gumloop/pdf-product-creation.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an executable Gumloop PDF pipeline and fixes WR PR automation to stop duplicate/looping skeleton PRs. Delivers WR #14451 by generating a sellable PDF and manifest from a niche and keywords and preventing re-triggers for finished WRs.

- **New Features**
  - `scripts/gumloop_pdf_pipeline.py`: niche → title → content → PDF (reportlab) → `manifest.json`. Uses `OPENROUTER_API_KEY` when set, deterministic fallback otherwise.
  - `.github/workflows/gumloop-pdf-pipeline.yml`: `workflow_dispatch` with `niche`, `keywords`, `output_name`; uploads the `.pdf` and `.manifest.json` as artifacts.
  - Updates `workflows/gumloop/pdf-product-creation.md` to point to the executable and align with existing PDF product standards.

- **Bug Fixes**
  - `.github/workflows/wr-pr-creation.yml`: skips WR issues that are closed or labeled `issue:done`.
  - Dedup now searches all PRs and blocks when an open or merged WR skeleton exists; allows re-trigger only after a closed-unmerged skeleton.

<sup>Written for commit 4da39e92ea7b8886349b5b4188e464027214a146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

