### PR TITLE
docs(agents): fleet-architecture directions (400+ via composition, not canned) + one-iteration builds

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -347,6 +347,12 @@ let it do the work. Match the agent to the asset, and stack them:
   `agent-factory/` (commands, hooks, plugins, settings), the Copilot coding
   agent (`.github/workflows/copilot-setup-steps.yml`), and `swe-agent.yml`.
   See `docs/Master_Inventory/AGENT_FACTORY_STANDARD.md`.
+- **Jules (Google) — best at orchestration & PR rewrites.** Hand Jules the
+  refine/rewrite-the-PR job: it restructures and refines the WR doc and the PR
+  itself, and orchestrates the work. Wired via `jules-invoke.yml`,
+  `jules-coding-agent.yml`, and the review/feedback lane
+  (`jules-pr-reviewer.yml`, `jules-feedback.yml`, `jules-pr-comment.yml`).
+  Route PR rewriting/refinement and multi-step orchestration to Jules by default.
 - **OpenRouter swarms / sub-agents / on-demand agents** (above) for fan-out and
   model routing across the 3 LLMs.
 - **Specialist skills** in the vault (`skills/REGISTRY.md`) — e.g.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -309,6 +309,39 @@ When a task is complex:
 - **Synthesize results** — combine outputs into cohesive whole
 - **Verify quality** — ensure all pieces work together
 
+### Agent Fleet Architecture — how the 400+ agents are composed
+
+The fleet is **400+ agents, but they are NOT 400 massive pre-canned agent
+definitions.** Do not build or expect a giant static roster of hardcoded
+agents. The count is reached by **dynamic composition** at run time:
+
+- **Sub-agents** — spawned per task to handle independent subtasks, then retired.
+- **On-demand agents** — created when a task needs one and torn down after;
+  never persisted as a permanent canned agent.
+- **OpenRouter routing across 3 LLMs** — model selection (not 400 separate
+  brains) is what gives each agent its capability; route via
+  `scripts/openrouter-routing.js` / the `openrouter-swarms` skill.
+- **~300 swarms** — parallel micro-agent groups for large fan-out work. Keep
+  each swarm small (≤10 agents without explicit approval, per
+  `skills/openrouter-swarms/SKILL.md`); scale by spawning more swarms, not by
+  inflating a single one.
+
+**Rule of thumb:** reach for the lightest topology that works — single agent →
+sub-agents → MAS → swarm — and compose on demand. A new permanent "canned"
+agent is the exception, not the default; prefer a sub-agent, an on-demand
+agent, or a swarm. See `skills/openrouter-swarms/SKILL.md` for the topology
+decision tree and spawn protocol.
+
+### Build Methodology — one iteration, multiple PRs (every project, every size)
+
+**This applies to big builds too.** Every project — no matter how large — ships
+in a **single iteration** (no "Phase 1 / MVP-first / 30-day"; see
+`docs/DEFINITION_OF_DONE.md`). When the work spans multiple surfaces
+(app / cli / api / pdf / mcp / docs), **fan out into multiple PRs** — one per
+surface — rather than one monster PR or a partial patch. The bundle defined by
+the WR is the deliverable; do not silently defer parts of it. A large build is
+still one iteration: many parallel agents/swarms, many PRs, one shipped outcome.
+
 ### The Bottom Line
 
 **You do not wait. You do not escalate. You do not accept "I don't know" as an answer.**

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -358,6 +358,10 @@ let it do the work. Match the agent to the asset, and stack them:
 - **Specialist skills** in the vault (`skills/REGISTRY.md`) — e.g.
   `ui-creation-engine`, `content-automation`, video/music publishing — pick the
   one that already does the asset type instead of reinventing it.
+- **Octopus Review — best-in-class code review.** Codebase-aware AI review;
+  findings auto-route to the coder via `octopus-route.yml` (with Bito,
+  OpenRouter, and CodeRabbit alongside). Treat Octopus as the default reviewer
+  on every PR, not just research.
 
 **Rule:** if a free or wired-in agent/team can make the asset, route it there
 first; only build by hand when no agent covers it. Cost-rank: free (Roo,
@@ -392,10 +396,11 @@ shallow findings. (Depth-over-speed applies to research; the *build* still
 ships in one iteration — see below.)
 
 **Then review the results.** Research output is **code-reviewed before any
-implementation** — Bito / OpenRouter / CodeRabbit per the *Research Engine
-Review Request* flow — checking factual validation, gaps, fabricated
-references, and implementation risk. No implementation starts on unreviewed
-research.
+implementation** — **Octopus Review** (best-in-class, codebase-aware; findings
+auto-route to the coder via `octopus-route.yml`), Bito, OpenRouter, and
+CodeRabbit per the *Research Engine Review Request* flow — checking factual
+validation, gaps, fabricated references, and implementation risk. No
+implementation starts on unreviewed research.
 
 ### Build Methodology — one iteration, multiple PRs (every project, every size)
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -357,6 +357,40 @@ let it do the work. Match the agent to the asset, and stack them:
 first; only build by hand when no agent covers it. Cost-rank: free (Roo,
 no-key OpenRouter lanes) → wired-in (Agent Factory / Copilot) → paid.
 
+### Research Fleet — the most important phase, best-in-class
+
+**Research is the highest-priority phase of every WR.** Depth wins over speed:
+invest the best agents and tools here, and never truncate or rush research to
+save time or tokens. This is the one place where **paid APIs are justified**
+(unlike the build phase, which prefers FOSS/free).
+
+**Composition — run the best research team available:**
+
+- **Paid research APIs where they win** — Perplexity `sonar-pro` (the
+  *Professor / citer* persona) for sourced, citation-backed facts;
+  `.github/workflows/perplexity-research-agent.yml`.
+- **OpenRouter across the 3 LLMs** for synthesis, cross-validation, and
+  competing takes on the same question.
+- **openclaw skills** — `skills/openclaw-eeat` (E-E-A-T validation) and
+  `skills/openclaw-self-eval` to grade the research before it ships.
+- **Sub-agents + the 4 on-demand agents + swarms** spread across the research
+  lanes: `research:marketing`, `research:seo`, `research:competitors`,
+  `research:chatter`, `research:facts`, `research:technical`,
+  `research:revenue`, `research:reviewer`. Engines: `research-engine.yml`,
+  `weekly-research.yml`, `research-module.yml`.
+
+**Time & PR policy:** research may legitimately run for **hours**, and a single
+WR's research may **fan out into multiple PRs on the same WR** — that is
+encouraged, not a problem. Break it up by lane/surface rather than shipping
+shallow findings. (Depth-over-speed applies to research; the *build* still
+ships in one iteration — see below.)
+
+**Then review the results.** Research output is **code-reviewed before any
+implementation** — Bito / OpenRouter / CodeRabbit per the *Research Engine
+Review Request* flow — checking factual validation, gaps, fabricated
+references, and implementation risk. No implementation starts on unreviewed
+research.
+
 ### Build Methodology — one iteration, multiple PRs (every project, every size)
 
 **This applies to big builds too.** Every project — no matter how large — ships

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -332,6 +332,31 @@ agent is the exception, not the default; prefer a sub-agent, an on-demand
 agent, or a swarm. See `skills/openrouter-swarms/SKILL.md` for the topology
 decision tree and spawn protocol.
 
+### Use every available agent — for every kind of artifact or asset
+
+Do not hand-build what an agent or agent-team can produce. For **every** kind
+of artifact or asset — code, PDF, video, image, slide deck, audio/music, docs,
+data, MCP / CLI / API — reach for the most capable agent or tool available and
+let it do the work. Match the agent to the asset, and stack them:
+
+- **Roo (Roo Code) — free, and a whole team.** It ships a full set of modes
+  (Architect, Code, Debug, Orchestrator, Ask + custom modes). Because it is
+  **free**, use it liberally — especially for coding, testing, and multi-step
+  orchestration. Roo already owns the Testing lane in the reviewer roster.
+- **GitHub Agent Factory — wired in.** Use it to spin up agents on demand:
+  `agent-factory/` (commands, hooks, plugins, settings), the Copilot coding
+  agent (`.github/workflows/copilot-setup-steps.yml`), and `swe-agent.yml`.
+  See `docs/Master_Inventory/AGENT_FACTORY_STANDARD.md`.
+- **OpenRouter swarms / sub-agents / on-demand agents** (above) for fan-out and
+  model routing across the 3 LLMs.
+- **Specialist skills** in the vault (`skills/REGISTRY.md`) — e.g.
+  `ui-creation-engine`, `content-automation`, video/music publishing — pick the
+  one that already does the asset type instead of reinventing it.
+
+**Rule:** if a free or wired-in agent/team can make the asset, route it there
+first; only build by hand when no agent covers it. Cost-rank: free (Roo,
+no-key OpenRouter lanes) → wired-in (Agent Factory / Copilot) → paid.
+
 ### Build Methodology — one iteration, multiple PRs (every project, every size)
 
 **This applies to big builds too.** Every project — no matter how large — ships

--- a/skills/openrouter-swarms/SKILL.md
+++ b/skills/openrouter-swarms/SKILL.md
@@ -17,6 +17,15 @@ This skill defines **when and how to use OpenRouter, Multi-Agent Systems (MAS), 
 
 **Issue reference:** GitHub Issue #41 — *"I need a system of when to use MAS, SWARMs and sub agents. I would like to give them a human name."*
 
+### Fleet scale & composition
+
+The Revvel fleet is **400+ agents reached by dynamic composition — not 400
+pre-canned agents.** It is made of **sub-agents** (spawned per task),
+**on-demand agents** (created when needed, then retired), **OpenRouter routing
+across 3 LLMs** for capability, and **~300 swarms** for fan-out. Scale by
+spawning more swarms, not by inflating one swarm or minting permanent canned
+agents. See `docs/AGENTS.md` → *Agent Fleet Architecture*.
+
 ---
 
 ## What This Skill Does


### PR DESCRIPTION
Gives agents correct directions on **how the fleet is composed** and **how to approach big builds**, so they don't default to building massive pre-canned agents or partial/monolithic PRs.

## Why
`docs/AGENTS.md` and `skills/openrouter-swarms/SKILL.md` mention sub-agents/swarms but never state the fleet's composition or tie builds to one-iteration. That invites the wrong mental model (400 hardcoded agents; one giant PR).

## Changes
**`docs/AGENTS.md`**
- **New "Agent Fleet Architecture" section:** the **400+ agents are reached by dynamic composition — NOT 400 pre-canned agents.** Composed of **sub-agents** (per task), **on-demand agents** (created then retired), **OpenRouter routing across 3 LLMs**, and **~300 swarms**. Scale by spawning more *small* swarms (≤10 each), compose on demand, prefer the lightest topology; a permanent canned agent is the exception.
- **New "Build Methodology" section:** every project — **including big builds** — ships in **one iteration** and **fans out into multiple PRs** (one per surface: app/cli/api/pdf/mcp/docs), never a partial patch. Reinforces `DEFINITION_OF_DONE.md`.

**`skills/openrouter-swarms/SKILL.md`**
- Matching "Fleet scale & composition" note so the 400+/300/3-LLM/on-demand model lives where topology decisions are actually made, cross-linked to AGENTS.md.

## Test plan
- [x] Both files render as valid Markdown; cross-links resolve
- [x] No contradiction with the existing swarm rules (≤10 agents/swarm without approval) — this codifies "scale via more swarms"

docs-freshness: agent-direction standards clarification only (no workflow/tool change).

https://claude.ai/code/session_017B79LoGBgUMf7dLmocUT6R

---
_Generated by [Claude Code](https://claude.ai/code/session_017B79LoGBgUMf7dLmocUT6R)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR clarifies the **agent fleet architecture** and **build methodology** in the documentation to prevent incorrect mental models. It explains that the 400+ agents are achieved through *dynamic composition* (sub-agents, on-demand agents, OpenRouter routing across 3 LLMs, and ~300 swarms) rather than 400 hardcoded pre-built agents. It also reinforces that all projects, including large builds, should ship in **one iteration** fanning out into **multiple PRs** (one per surface) rather than partial patches or phased rollouts. The changes add two new sections to `docs/AGENTS.md` (Agent Fleet Architecture and Build Methodology) and a matching fleet composition note to `skills/openrouter-swarms/SKILL.md` with cross-references between the files.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/AGENTS.md` |
| 2 | `skills/openrouter-swarms/SKILL.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the fleet architecture (400+ via dynamic composition, not pre‑canned), enforces one‑iteration builds with fan‑out PRs, and tightens routing so work goes to the right agents. Adds a depth‑first Research Fleet with a review gate; sets Jules as default for PR rewrite/orchestration and makes Octopus the default code reviewer.

- **New Features**
  - `docs/AGENTS.md`: adds "Agent Fleet Architecture", "Use every available agent", "Research Fleet", and "Build Methodology". Defines composition (sub‑agents, on‑demand agents, OpenRouter across 3 LLMs, ~300 small swarms). One‑iteration builds; multiple PRs per surface. Cost order: free → wired‑in → paid.
  - Routing and defaults: use Roo (free), GitHub Agent Factory (`agent-factory/`, `.github/workflows/copilot-setup-steps.yml`, `swe-agent.yml`), Jules for PR rewrite/orchestration (`jules-invoke.yml`, `jules-coding-agent.yml`, `jules-pr-reviewer.yml`, `jules-feedback.yml`, `jules-pr-comment.yml`), OpenRouter swarms, and vault skills. Set Octopus as the default reviewer on every PR; findings auto‑route via `octopus-route.yml` (with Bito, OpenRouter, CodeRabbit alongside).
  - Research: allow Perplexity `sonar-pro`, use `openclaw-eeat` and `openclaw-self-eval`; research may run for hours and fan out into PRs; require Octopus/Bito/OpenRouter/CodeRabbit review before implementation.
  - `skills/openrouter-swarms/SKILL.md`: adds matching fleet scale/composition note; scale via more small swarms, not bigger swarms or permanent canned agents.

<sup>Written for commit b9d8ca978a579f72452548c153564a290c09c3e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

