### PR TITLE
fix: green the test suite (58/58) — repair 3 dup-key workflows + force_recovery gate

### DIFF
--- a/.github/workflows/api-rate-limit-handler.yml
+++ b/.github/workflows/api-rate-limit-handler.yml
@@ -1,16 +1,6 @@
 name: API Rate Limit Handler
 
 on:
-
-permissions:
-  contents: read
-on:
-  workflow_run:
-    types: [completed]
-    workflows: ["*"]
-
-permissions:
-  contents: read
   workflow_run:
     types: [completed]
     workflows: ["*"]
@@ -24,6 +14,8 @@ permissions:
       agent_used:
         required: true
 
+permissions:
+  contents: read
 jobs:
   handle-rate-limit:
     runs-on: ubuntu-latest

--- a/.github/workflows/flow-chart-sync.yml
+++ b/.github/workflows/flow-chart-sync.yml
@@ -1,14 +1,6 @@
 name: Flow Chart Sync
-on:
-permissions:
-name: Flow Chart Sync
-on:
-  push:
-    branches:
-      - main
 
-permissions:
-  contents: write  # required because <reason>
+on:
   push:
     branches:
       - main
@@ -27,6 +19,9 @@ permissions:
         options:
           - "false"
           - "true"
+
+permissions:
+  contents: write  # required because flow-chart sync commits regenerated diagrams
 concurrency:
   group: flow-chart-sync-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/noimosai.yml
+++ b/.github/workflows/noimosai.yml
@@ -1,15 +1,6 @@
 name: NoimosAI — Autonomous Marketing
-on:
-permissions:
-name: NoimosAI — Autonomous Marketing
-on:
-  workflow_dispatch:
-    inputs:
-      prompt:
-        ...
 
-permissions:
-  contents: read  # change to write only if the job pushes commits, and document why
+on:
   workflow_dispatch:
     inputs:
       prompt:
@@ -39,6 +30,9 @@ permissions:
       - reopened
   schedule:
     - cron: 0 8 * * *
+
+permissions:
+  contents: read  # change to write only if the job pushes commits, and document why
 concurrency:
   group: noimosai-${{ github.event_name }}-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: false

--- a/.github/workflows/secret-persistence-guard.yml
+++ b/.github/workflows/secret-persistence-guard.yml
@@ -181,7 +181,7 @@ jobs:
     name: Auto-recover missing secrets
     needs: monitor-secret-health
     runs-on: ubuntu-latest
-    if: needs.monitor-secret-health.outputs.has_missing == 'true' || github.event.inputs.force_recovery == 'true'
+    if: needs.monitor-secret-health.outputs.has_missing == 'true' || (github.event_name == 'workflow_dispatch' && inputs.force_recovery)
     outputs:
       recovered: ${{ steps.recover.outputs.recovered }}
       failed: ${{ steps.recover.outputs.failed }}


### PR DESCRIPTION
Makes the full test suite green (58/58) so the real CircleCI test gate in #14539 passes.

## Finding: only 2 of the "6" were real
When I flagged "6 failing tests," **4 were a local-environment artifact** — this sandbox had no `node_modules`, and those 4 tests need `yaml` / `ajv` (both declared deps, `^2.9.0` / `^8.17.1`). After `npm install` (what CircleCI does) they pass. Only **2 were genuine**:

### 1. Three workflows with duplicate YAML keys (`automation-doctor` + `workflow-yaml-validation`)
`api-rate-limit-handler.yml`, `flow-chart-sync.yml`, `noimosai.yml` each had **duplicate `name:` / `on:` / `permissions:` blocks** (a bad-merge concatenation) plus triggers nested under `permissions:`. Python's lenient `safe_load` silently took the last key (so my earlier Python-based audit passed them); the strict JS `yaml` parser these tests use rejects them ("Map keys must be unique"). Rebuilt a single clean header for each — `on:` holds the real triggers, `permissions:` only real scopes — with all jobs preserved:
- `api-rate-limit-handler`: `on: workflow_run, workflow_dispatch`
- `flow-chart-sync`: `on: push, workflow_dispatch`
- `noimosai`: `on: workflow_dispatch, issues, schedule`

### 2. `secret-persistence-guard.yml` force_recovery gating
The `auto-recover` `if:` had drifted to `github.event.inputs.force_recovery == 'true'`. Aligned it to the secure, test-enforced form so a force-recovery override can only come from a manual dispatch:
`needs.monitor-secret-health.outputs.has_missing == 'true' || (github.event_name == 'workflow_dispatch' && inputs.force_recovery)`

## Test plan
- [x] `npm install && npm test` → **58/58 pass, exit 0**
- [x] The 3 rebuilt workflows parse with the strict JS `yaml` parser and retain `on:` triggers + jobs
- [x] `secret-persistence-guard` condition matches the test's expected pattern

This unblocks the real test gate added in #14539.

docs-freshness: bug fixes to malformed workflow YAML + a test-enforced security condition; no new tool/feature.

https://claude.ai/code/session_017B79LoGBgUMf7dLmocUT6R

---
_Generated by [Claude Code](https://claude.ai/code/session_017B79LoGBgUMf7dLmocUT6R)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Fixes all remaining test suite failures by correcting malformed YAML structures in three workflow files that contained duplicate keys (a merge artifact that strict parsers reject), and tightens the security condition in `secret-persistence-guard.yml` to ensure the `force_recovery` override can only be triggered via manual `workflow_dispatch` rather than accepting the input unconditionally. These changes make the entire test suite pass (58/58) and unblock the CircleCI test gate.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/secret-persistence-guard.yml` |
| 2 | `.github/workflows/api-rate-limit-handler.yml` |
| 3 | `.github/workflows/flow-chart-sync.yml` |
| 4 | `.github/workflows/noimosai.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Greens the test suite (58/58) by fixing malformed GitHub Actions workflows and tightening the `force_recovery` gate. Unblocks the main CI test gate.

- **Bug Fixes**
  - Rebuilt single, valid headers for `.github/workflows/api-rate-limit-handler.yml`, `flow-chart-sync.yml`, and `noimosai.yml` to remove duplicate `name`/`on`/`permissions` keys and place triggers under `on`; preserved all jobs.
  - Secured `secret-persistence-guard.yml` by gating force recovery to manual runs: `needs.monitor-secret-health.outputs.has_missing == 'true' || (github.event_name == 'workflow_dispatch' && inputs.force_recovery)`.

<sup>Written for commit 084bea76cd4e28bad7bca9e90491754e438d5fc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

