### PR TITLE
fix(wr): close the timing gap that strands completed WRs without a PR

### DIFF
--- a/.github/workflows/stuck-wr-detector.yml
+++ b/.github/workflows/stuck-wr-detector.yml
@@ -2,6 +2,12 @@ name: Stuck WR Detector & Auto-Healer
 on:
   schedule:
     - cron: "*/30 * * * *"
+  # GitHub throttles the cron above (observed ~50–70 min apart), which can
+  # strand a just-completed WR. Sweep the moment research completes too, so a
+  # ready WR with no PR is healed within minutes instead of waiting for cron.
+  workflow_run:
+    workflows: ["Research Engine Orchestrator"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       max_age_hours:
@@ -40,6 +46,7 @@ jobs:
             const {
               findAssociatedPr,
               getIssueBaseTitle,
+              DEFAULT_MIN_STUCK_AGE_MS,
             } = require(path.join(process.env.GITHUB_WORKSPACE, 'scripts', 'stuck-wr-detector.js'));
 
             const owner = context.repo.owner;
@@ -47,7 +54,7 @@ jobs:
             const maxAgeMs = parseInt(process.env.MAX_AGE_HOURS, 10) * 3600 * 1000;
             const dryRun = process.env.DRY_RUN === 'true';
             const cutoff = Date.now() - maxAgeMs;
-            const minStuckAgeMs = 15 * 60 * 1000;  // 15 minutes
+            const minStuckAgeMs = DEFAULT_MIN_STUCK_AGE_MS;  // shared SSOT (5 min)
 
             core.info(`Scanning open work-request issues younger than ${process.env.MAX_AGE_HOURS}h.`);
             core.info(`Dry-run mode: ${dryRun}`);

--- a/.github/workflows/stuck-wr-detector.yml
+++ b/.github/workflows/stuck-wr-detector.yml
@@ -1,10 +1,29 @@
 name: Stuck WR Detector & Auto-Healer
 on:
+  # ── PREVIOUS APPROACH (kept for the record, intentionally not removed) ──────
+  # Originally this healer relied ONLY on the cron sweep below. That routine was
+  # added back when OpenRouter was live and many agents worked in PARALLEL on
+  # the same WRs at once — label churn and racing runs meant a WR could get its
+  # PR-creation run cancelled/skipped, so a periodic sweep was the safety net
+  # that caught those errors. It worked, but it leaned on two fragile things:
+  #   1. label *timing* — a WR is only "ready" once research:complete lands, and
+  #      the event that set it could race the sweep; and
+  #   2. GitHub's schedule — which is throttled under load (observed ~50–70 min
+  #      between */30 runs), so a just-completed WR could sit ~1h with no PR
+  #      (this is exactly what stranded WR #14545).
+  #
+  # ── NEW APPROACH (why it's better) ─────────────────────────────────────────
+  # We still keep the cron as a backstop, but we no longer DEPEND on it for
+  # timeliness, and we no longer depend on label-churn events for timing. The
+  # `workflow_run` trigger fires the sweep the moment research actually
+  # completes, so a ready WR with no PR is healed within minutes regardless of
+  # how badly GitHub is throttling cron. Labels (research:complete/wr:complete)
+  # are still used — but only as a *completion signal* (a state marker), never
+  # as the timing mechanism. That's the "don't rely on labels" point: relying on
+  # a label to EXIST is fine; relying on label-event timing + a throttled cron
+  # is what burned us.
   schedule:
     - cron: "*/30 * * * *"
-  # GitHub throttles the cron above (observed ~50–70 min apart), which can
-  # strand a just-completed WR. Sweep the moment research completes too, so a
-  # ready WR with no PR is healed within minutes instead of waiting for cron.
   workflow_run:
     workflows: ["Research Engine Orchestrator"]
     types: [completed]
@@ -54,7 +73,15 @@ jobs:
             const maxAgeMs = parseInt(process.env.MAX_AGE_HOURS, 10) * 3600 * 1000;
             const dryRun = process.env.DRY_RUN === 'true';
             const cutoff = Date.now() - maxAgeMs;
-            const minStuckAgeMs = DEFAULT_MIN_STUCK_AGE_MS;  // shared SSOT (5 min)
+            // PREVIOUS: const minStuckAgeMs = 15 * 60 * 1000;  // 15 minutes
+            // The 15-min grace made sense when the cron was the only sweeper —
+            // give the parallel-agent path time to win before re-triggering.
+            // But combined with throttled cron it left a ~1h dead zone (#14545).
+            // Now that `workflow_run` sweeps right after research completes, a
+            // 5-min grace is plenty of headroom for the normal path to win the
+            // race first, and the dead zone is gone. Threshold is a shared SSOT
+            // in scripts/stuck-wr-detector.js so the script and workflow agree.
+            const minStuckAgeMs = DEFAULT_MIN_STUCK_AGE_MS;  // 5 min
 
             core.info(`Scanning open work-request issues younger than ${process.env.MAX_AGE_HOURS}h.`);
             core.info(`Dry-run mode: ${dryRun}`);

--- a/.github/workflows/stuck-wr-detector.yml
+++ b/.github/workflows/stuck-wr-detector.yml
@@ -27,6 +27,7 @@ on:
   workflow_run:
     workflows: ["Research Engine Orchestrator"]
     types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       max_age_hours:

--- a/scripts/stuck-wr-detector.js
+++ b/scripts/stuck-wr-detector.js
@@ -1,5 +1,31 @@
 'use strict';
 
+// How long a freshly-created WR is given to get its PR through the normal
+// event-driven path before the safety-net sweep considers it "stuck".
+//
+// Was 15 min. Tightened to 5: GitHub throttles the detector's `*/30` cron
+// (observed ~50–70 min between runs), so a WR whose research completes right
+// after its own wr-pr-creation runs fired-and-skipped could sit ~1h with no
+// PR. Paired with the `workflow_run: Research Engine Orchestrator` trigger,
+// the sweep now fires within minutes of research completing, and 5 min is
+// enough headroom for the normal labeled-event path to win the race first.
+const DEFAULT_MIN_STUCK_AGE_MS = 5 * 60 * 1000;
+
+// A WR is eligible for PR creation once research/WR completion is signalled.
+function isWrReadyForPr(labels) {
+  const names = labels instanceof Set ? labels : new Set(getLabelNames(labels));
+  return names.has('wr:complete') || names.has('research:complete');
+}
+
+// Verdict on whether a WR is in the "old enough to be stuck, not so old we
+// ignore it" window. Pure + injectable clock so it's unit-testable.
+function stuckAgeVerdict(createdAt, { now = Date.now(), minStuckAgeMs = DEFAULT_MIN_STUCK_AGE_MS, maxAgeMs } = {}) {
+  const ageMs = now - new Date(createdAt).getTime();
+  if (ageMs < minStuckAgeMs) return 'too_young';
+  if (maxAgeMs != null && ageMs > maxAgeMs) return 'too_old';
+  return 'eligible';
+}
+
 function getLabelNames(labels) {
   return (labels || [])
     .map((label) => (typeof label === 'string' ? label : label.name))
@@ -118,6 +144,9 @@ async function findAssociatedPr({ github, owner, repo, issue, core = console }) 
 }
 
 module.exports = {
+  DEFAULT_MIN_STUCK_AGE_MS,
+  isWrReadyForPr,
+  stuckAgeVerdict,
   extractPrNumbersFromText,
   findAssociatedPr,
   getIssueBaseTitle,

--- a/scripts/stuck-wr-detector.js
+++ b/scripts/stuck-wr-detector.js
@@ -20,7 +20,10 @@ function isWrReadyForPr(labels) {
 // Verdict on whether a WR is in the "old enough to be stuck, not so old we
 // ignore it" window. Pure + injectable clock so it's unit-testable.
 function stuckAgeVerdict(createdAt, { now = Date.now(), minStuckAgeMs = DEFAULT_MIN_STUCK_AGE_MS, maxAgeMs } = {}) {
-  const ageMs = now - new Date(createdAt).getTime();
+  if (createdAt == null) return 'invalid';
+  const created = new Date(createdAt).getTime();
+  if (isNaN(created)) return 'invalid';
+  const ageMs = now - created;
   if (ageMs < minStuckAgeMs) return 'too_young';
   if (maxAgeMs != null && ageMs > maxAgeMs) return 'too_old';
   return 'eligible';

--- a/tests/stuck-wr-detector.test.js
+++ b/tests/stuck-wr-detector.test.js
@@ -9,6 +9,9 @@ const {
   hasIssueBranchRef,
   isAssociatedPr,
   referencesIssue,
+  isWrReadyForPr,
+  stuckAgeVerdict,
+  DEFAULT_MIN_STUCK_AGE_MS,
 } = require('../scripts/stuck-wr-detector');
 
 let passed = 0;
@@ -123,6 +126,30 @@ const issue = {
 
     const pr = await findAssociatedPr({ github, owner: 'org', repo: 'repo', issue });
     assert.equal(pr.number, 13461);
+  });
+
+  await test('isWrReadyForPr requires a completion signal', () => {
+    assert.equal(isWrReadyForPr(['work-request', 'research:complete']), true);
+    assert.equal(isWrReadyForPr(['work-request', 'wr:complete']), true);
+    assert.equal(isWrReadyForPr(new Set(['research:complete'])), true);
+    assert.equal(isWrReadyForPr(['work-request', 'wr:in-progress']), false);
+    assert.equal(isWrReadyForPr([]), false);
+  });
+
+  await test('stuck threshold is 5 min so a throttled cron cannot strand a WR', () => {
+    assert.equal(DEFAULT_MIN_STUCK_AGE_MS, 5 * 60 * 1000);
+  });
+
+  await test('stuckAgeVerdict windows a WR by age', () => {
+    const created = '2026-06-13T15:00:00Z';
+    const at = (mins) => new Date('2026-06-13T15:00:00Z').getTime() + mins * 60000;
+    // The exact gap that stranded #14545: completed ~12 min in, the old 15-min
+    // gate called it too young; the new 5-min gate makes it eligible.
+    assert.equal(stuckAgeVerdict(created, { now: at(12) }), 'eligible');
+    assert.equal(stuckAgeVerdict(created, { now: at(3) }), 'too_young');
+    assert.equal(stuckAgeVerdict(created, { now: at(200), maxAgeMs: 60 * 60 * 1000 }), 'too_old');
+    // Old behaviour, asserted for contrast.
+    assert.equal(stuckAgeVerdict(created, { now: at(12), minStuckAgeMs: 15 * 60 * 1000 }), 'too_young');
   });
 
   console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/stuck-wr-detector.test.js
+++ b/tests/stuck-wr-detector.test.js
@@ -152,6 +152,13 @@ const issue = {
     assert.equal(stuckAgeVerdict(created, { now: at(12), minStuckAgeMs: 15 * 60 * 1000 }), 'too_young');
   });
 
+  await test('stuckAgeVerdict returns invalid for malformed timestamps', () => {
+    assert.equal(stuckAgeVerdict(null), 'invalid');
+    assert.equal(stuckAgeVerdict(undefined), 'invalid');
+    assert.equal(stuckAgeVerdict('not-a-date'), 'invalid');
+    assert.equal(stuckAgeVerdict(''), 'invalid');
+  });
+
   console.log(`\n${passed} passed, ${failed} failed`);
   if (failed > 0) process.exit(1);
 })();


### PR DESCRIPTION
## Summary

Hardens the `stuck-wr-detector` self-healer so completed Work Requests are no longer stranded without a PR due to timing gaps between research completion and a throttled cron-based sweep.

**Root cause (diagnosed from WR #14545):** WR #14545 sat ~1 hour with no PR because its `wr-pr-creation` runs fired before `research:complete` was set (correctly skipped), the 15-min stuck threshold meant the subsequent detector sweep saw it as "too young" (~12 min old), and the `*/30` cron is throttled by GitHub to ~50–70 min between actual runs — leaving a dead zone.

**Fix (defense in depth):**
- **`workflow_run` trigger** on `Research Engine Orchestrator` completion (restricted to `main` branch) — the sweep fires within minutes of research completing, eliminating the cron-throttle dead zone without generating unnecessary sweeps from non-default branches.
- **Stuck threshold 15 min → 5 min** via shared constant `DEFAULT_MIN_STUCK_AGE_MS` (single source of truth between `scripts/stuck-wr-detector.js` and the workflow).
- **`stuckAgeVerdict` invalid-date guard** — `null`, `undefined`, or unparseable `createdAt` values now return `'invalid'` instead of falling through to `'eligible'`, preventing false-positive retriggers on malformed timestamps.
- **Extracted `isWrReadyForPr` + `stuckAgeVerdict`** as pure, injectable-clock helpers for unit-testability.

The detector is idempotent (dedup on associated-PR + `wr:retrigger-attempts-N` cap + its own concurrency group), so extra `workflow_run` invocations are safe.

## Changes

- `.github/workflows/stuck-wr-detector.yml` — added `workflow_run` trigger (restricted to `branches: [main]`); imports `DEFAULT_MIN_STUCK_AGE_MS` from script instead of hardcoded 15 min.
- `scripts/stuck-wr-detector.js` — exports `DEFAULT_MIN_STUCK_AGE_MS` (5 min), `isWrReadyForPr`, and `stuckAgeVerdict`; added `null`/NaN guard in `stuckAgeVerdict`.
- `tests/stuck-wr-detector.test.js` — **10 tests (4 new)**: age-window scenarios including the exact 12-min gap that stranded #14545, and the invalid-timestamp guard.

## Validation

- `tests/stuck-wr-detector.test.js`: **10/10 pass**.
- Workflow YAML parses cleanly with the strict `js-yaml` parser; triggers = `schedule`, `workflow_run` (`branches: [main]`), `workflow_dispatch`.
- Full suite: 56/58 — the 2 failures (`workflow-yaml-validation`/`AutomationDoctor`) are pre-existing on `main`, unrelated to this change.
- CodeQL scan: 0 alerts.

## Checklist

- [x] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above