### PR TITLE
docs(agents): orchestrator-discipline guardrail — delegate + record, don't do the work yourself

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ RECORD — not to do the task.** Specifically:
    job and compounds.
 3. **Record provenance for everything:** who proposed the idea, who executed,
    which model/route was used, how long it took, and how it scored. That ledger
-   (`logs/agent-audit/`, the scorecard, `decisions.jsonl`) IS the product.
+   (`logs/agent-audit/`, the scorecard, `wr/memory/decisions.jsonl`) IS the product.
 4. **Re-anchor often.** If you notice yourself writing code/content that belongs
    to another agent's lane, **stop, hand it off, and log it.** Re-read this
    section — it's the sticky note. Everyone forgets this under load; the reminder

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,35 @@ Every change should be evaluated against this north star. Prefer work that:
 2. **OSINT tools** — Productized intelligence utilities
 3. **Automated product pipeline** — Templates, scaffolding, CI/CD
 
+## ⛔ ORCHESTRATOR DISCIPLINE — stay in your lane (read this every time)
+
+> **The #1 failure mode, learned the hard way:** a capable agent (e.g. Manus)
+> kept *doing the work itself* instead of assigning it out and recording who did
+> what. It reverted to "I'll just do it" every time it wasn't reminded — because
+> it *could*. That destroys the two things that matter most: **parallelism** and
+> **provenance** (the record of who proposed what, who executed, which LLM/route
+> performed — the data we actually measure and monetize).
+
+**If you are an orchestrator / controller / overseer, your job is to DELEGATE and
+RECORD — not to do the task.** Specifically:
+
+1. **Do only YOUR job.** The moment you hit a *specialty task* or a *roadblock*,
+   **immediately delegate** it to the right agent/LLM (via OpenRouter / the
+   fallback chain / a sub-agent) — and **do not come back to do it yourself**.
+2. **"You can do it" is not "you should do it."** Capability is the trap. Even
+   when doing it yourself looks faster right now, delegating + measuring is the
+   job and compounds.
+3. **Record provenance for everything:** who proposed the idea, who executed,
+   which model/route was used, how long it took, and how it scored. That ledger
+   (`logs/agent-audit/`, the scorecard, `decisions.jsonl`) IS the product.
+4. **Re-anchor often.** If you notice yourself writing code/content that belongs
+   to another agent's lane, **stop, hand it off, and log it.** Re-read this
+   section — it's the sticky note. Everyone forgets this under load; the reminder
+   is what snaps the behavior back.
+
+Exception: a task explicitly *scoped to you* (you are the assigned specialist) —
+then do it well, fast, and hand the result + provenance back to the orchestrator.
+
 ## Conventional Commits
 
 All commits and PR titles must use [Conventional Commits](https://www.conventionalcommits.org/):
@@ -53,7 +82,7 @@ in this repository. Keep this section updated as the layout evolves.
 This is a **monorepo** that combines repo-wide standards with individual
 revenue-generating products:
 
-```
+```text
 /                       # Root: standards, shared tooling, CI workflows
 ├── .github/            # GitHub Actions workflows and issue templates
 ├── AGENTS.md           # This file
@@ -76,15 +105,15 @@ dependencies, build, and deploy pipeline.
 When running multiple products locally, use the assigned ports below to avoid
 collisions:
 
-| Product                  | Path                                  | Dev port | Notes                                                                 |
-| ------------------------ | ------------------------------------- | -------- | --------------------------------------------------------------------- |
-| Music Video Creator      | `products/music-video-creator`        | 3000     | Next.js. Requires API keys for full functionality (see product README). |
-| Affiliate Hub            | `products/affiliate-hub`              | 3001     | Next.js. May require `npm install --legacy-peer-deps` (see gotchas).  |
-| AI Video Toolkit         | `products/ai-video-toolkit`           | 3002     | Next.js.                                                              |
-| Screen Recorder Finder   | `products/screen-recorder-finder`     | 3003     | Next.js.                                                              |
-| Revvel Skill Runner      | `products/revvel-skill-runner`        | 3004     | Next.js. Needs `OPENROUTER_API_KEY` for live skill execution.         |
-| Creator Payout Tracker   | `products/creator-payout-tracker`     | 3005     | Next.js. Shippable deep-research product for creator payout rankings. |
-| CLI Engine               | `products/cli-engine`                 | 3008     | Next.js. Glassmorphic CLI agent terminal UI with PDF export and Stripe billing. |
+| Product | Path | Dev port | Notes |
+| --- | --- | --- | --- |
+| Music Video Creator | `products/music-video-creator` | 3000 | Next.js. Requires API keys for full functionality (see product README). |
+| Affiliate Hub | `products/affiliate-hub` | 3001 | Next.js. May require `npm install --legacy-peer-deps` (see gotchas). |
+| AI Video Toolkit | `products/ai-video-toolkit` | 3002 | Next.js. |
+| Screen Recorder Finder | `products/screen-recorder-finder` | 3003 | Next.js. |
+| Revvel Skill Runner | `products/revvel-skill-runner` | 3004 | Next.js. Needs `OPENROUTER_API_KEY` for live skill execution. |
+| Creator Payout Tracker | `products/creator-payout-tracker` | 3005 | Next.js. Shippable deep-research product for creator payout rankings. |
+| CLI Engine | `products/cli-engine` | 3008 | Next.js. Glassmorphic CLI agent terminal UI with PDF export and Stripe billing. |
 
 Start a specific product on its assigned port:
 


### PR DESCRIPTION
## The Manus lesson, encoded as a rule

You found the highest-value insight of the session: a capable agent (Manus) kept **doing the work itself** instead of **delegating to the right agent/LLM and recording who did what**. It reverted to "I'll just do it" every time it wasn't reminded — because it *could* — and that destroys the two things that matter most:

- **Parallelism** — 500 experts can't work if one agent hogs the task.
- **Provenance** — who proposed what, who executed, which LLM/route performed, how it scored. *That ledger is the product* (the valuable, sellable data).

Your fix was exactly right: a **"code sticky note"** that re-asserts the rule, because the failure mode is *forgetting mid-task* — a reminder snaps the behavior back.

## What this PR does

Adds a prominent **⛔ ORCHESTRATOR DISCIPLINE — stay in your lane** section to `AGENTS.md`, right under the Prime Directive where every agent reads it first:

1. **Do only YOUR job.** The moment you hit a specialty task or roadblock, **delegate immediately** and **don't come back to do it yourself**.
2. **"You can do it" is not "you should do it."** Capability is the trap.
3. **Record provenance for everything** (`logs/agent-audit/`, the scorecard, `decisions.jsonl`).
4. **Re-anchor often** — if you catch yourself in another agent's lane, stop, hand off, log. Re-read the sticky note.

Plus a scoped exception for assigned specialists, so it doesn't paralyze the agent that's *supposed* to do the work.

## Also
Fixed pre-existing `MD040`/`MD060` lint in `AGENTS.md` (fence language + table style) so the changed file is clean.

## Context (Auditor role)
This is the first act of the **Auditor/Controller** role you green-lit — the Auditor's job is to wire fixes in at the *source* so agents follow them permanently. Authority you set: full controller, but bias to permanent root-cause fixes, then verify by re-running. Next up per your direction: a careful **root-directory cleanup** (reusing `repo-organizer.yml` + the existing `fieldwork-extraction` proposal) — planned, not a reckless mass-move.

docs-freshness: agent-directions guidance only; no workflow/tool change.

https://claude.ai/code/session_017B79LoGBgUMf7dLmocUT6R

---
_Generated by [Claude Code](https://claude.ai/code/session_017B79LoGBgUMf7dLmocUT6R)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new **"Orchestrator Discipline"** guardrail section to the agent documentation to prevent capable orchestrator agents from doing work themselves instead of delegating tasks and recording provenance. The rule addresses a failure pattern where agents would directly complete tasks rather than assigning them to specialists and tracking the execution metadata (which LLM performed the work, how long it took, scores, etc.). The documentation emphasizes that delegating and recording provenance is the actual job of orchestrator agents, not performing the tasks themselves, as this enables both parallelism and the creation of valuable audit data. Minor markdown linting fixes (code fence language tags and table formatting) are also included.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `AGENTS.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a clear “orchestrator discipline” rule to `AGENTS.md` so controllers delegate work and record provenance instead of doing tasks themselves. Also cleans up Markdown lint in the file.

- **New Features**
  - New section under the Prime Directive: “⛔ ORCHESTRATOR DISCIPLINE — stay in your lane.”
  - Core rules: delegate immediately (OpenRouter/fallback chain/sub-agent), don’t do the task yourself, record provenance (`logs/agent-audit/`, scorecard, `wr/memory/decisions.jsonl`), and re-anchor as needed.
  - Explicit exception for tasks scoped to a specialist.

- **Bug Fixes**
  - Fixes `MD040` (adds `text` to fenced code blocks) and `MD060` (table style) in `AGENTS.md`.

<sup>Written for commit 266ee6b666818be39b926e514f3f4f112e2cd72e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

