### PR TITLE
fix: add GH_TOKEN env var for gh cli in reset-self-heal-issue

### DIFF
--- a/.github/workflows/reset-self-heal-issue.yml
+++ b/.github/workflows/reset-self-heal-issue.yml
@@ -134,6 +134,8 @@ jobs:
 
       - name: Trigger OpenRouter Assignee workflow
         if: steps.validate.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Triggering openrouter-assignee workflow..."
           gh workflow run openrouter-assignee.yml \


### PR DESCRIPTION
## Summary

Fix the `reset-self-heal-issue.yml` workflow - the gh CLI needs `GH_TOKEN` environment variable in GitHub Actions.

## What

Added `GH_TOKEN: ${{ github.token }}` to the step that triggers `openrouter-assignee.yml`.

## Test

The workflow runs successfully without GH CLI authentication errors.

@midnghtsapphire can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bee7429e-1538-426e-b623-f744995988fb)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes an authentication issue in the `reset-self-heal-issue.yml` GitHub Actions workflow by adding the required `GH_TOKEN` environment variable to enable the GitHub CLI (`gh`) to successfully trigger the `openrouter-assignee.yml` workflow.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/reset-self-heal-issue.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `reset-self-heal-issue.yml` workflow by passing `GH_TOKEN` to the `gh` CLI. This lets the job trigger `openrouter-assignee.yml` without authentication errors.

<sup>Written for commit 5f7b6445eb516806b68ea0d819816a3138c64567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

