### PR TITLE
fix(triage): hourly sweep auto-recovers failed/needs-key WRs via keyless lane

### DIFF
--- a/.github/workflows/openrouter-triage.yml
+++ b/.github/workflows/openrouter-triage.yml
@@ -94,51 +94,73 @@ jobs:
         run: node scripts/openrouter-triage.js
     timeout-minutes: 30
   sweep-discover:
-    name: Discover triage:new items needing routing
+    name: Discover items needing routing or triage-recovery
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.collect.outputs.matrix }}
       count: ${{ steps.collect.outputs.count }}
     steps:
-      - name: Collect open triage:new items missing openrouter label
+      - name: Collect triage:new items + previously-failed triage for recovery
         id: collect
         uses: actions/github-script@v9.0.0
         with:
           script: |
-            const items = await github.paginate(github.rest.issues.listForRepo, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'triage:new',
-              per_page: 100,
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // 1) Fresh items awaiting first routing: triage:new without openrouter.
+            const fresh = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: 'triage:new', per_page: 100,
             });
 
-            const triageTargets = [];
-            for (const item of items) {
+            // 2) SELF-HEALING RECOVERY — re-triage items whose triage previously
+            // failed or skipped for lack of a key. Now that triage always falls
+            // back to the keyless Perplexity lane, these can succeed. Without this,
+            // an item keeps the `openrouter` label forever and the fresh-sweep above
+            // (which skips anything labelled `openrouter`) can NEVER retry it — a
+            // permanent dead-end. On success, scripts/openrouter-triage.js clears
+            // the `openrouter:triage-failed` / `openrouter:needs-key` labels itself.
+            const failed = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: 'openrouter:triage-failed', per_page: 100,
+            });
+            const needsKey = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: 'openrouter:needs-key', per_page: 100,
+            });
+
+            const byNumber = new Map();
+
+            for (const item of fresh) {
               const labels = (item.labels || []).map((l) => typeof l === 'string' ? l : l.name);
               if (labels.includes('openrouter') || labels.includes('no-triage')) continue;
 
               for (const label of ['openrouter', 'role:orchestrator', 'triage:new']) {
                 try {
-                  await github.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: item.number,
-                    labels: [label],
-                  });
+                  await github.rest.issues.addLabels({ owner, repo, issue_number: item.number, labels: [label] });
                 } catch (error) {
                   core.notice(`Could not add label "${label}" to #${item.number}: ${error.message}`);
                 }
               }
-
-              triageTargets.push({
-                issue_number: String(item.number),
-                issue_title: item.title || '',
-                issue_body: item.body || '',
-                event_kind: item.pull_request ? 'pull_request' : 'issue',
-              });
+              byNumber.set(item.number, item);
             }
+
+            // Recovery items: re-queue regardless of the openrouter label (that label
+            // is exactly why they were stranded); only `no-triage` opts out.
+            for (const item of [...failed, ...needsKey]) {
+              const labels = (item.labels || []).map((l) => typeof l === 'string' ? l : l.name);
+              if (labels.includes('no-triage')) continue;
+              byNumber.set(item.number, item);
+            }
+
+            // GitHub Actions hard-caps a matrix at 256 jobs; stay safely under it.
+            // Any overflow is picked up on the next hourly sweep (idempotent).
+            const MAX_PER_SWEEP = 200;
+            const triageTargets = [...byNumber.values()].slice(0, MAX_PER_SWEEP).map((item) => ({
+              issue_number: String(item.number),
+              issue_title: item.title || '',
+              issue_body: item.body || '',
+              event_kind: item.pull_request ? 'pull_request' : 'issue',
+            }));
 
             core.setOutput('count', String(triageTargets.length));
             core.setOutput('matrix', JSON.stringify({ include: triageTargets }));


### PR DESCRIPTION
## Self-healing follow-up to #14663

#14663 made triage always fall back to the keyless Perplexity lane. But the stuck WRs (#14664, #14665, #14662, #14657, #14627, …) still carry `openrouter:triage-failed` / `openrouter:needs-key` from *before* that fix and **can't self-recover**, because the hourly sweep:

- filters on `triage:new`, and
- **skips anything already labelled `openrouter`** — which every failed item is.

So once triage stamped `openrouter`, the item was stranded forever. That's the opposite of "fail over and keep working."

### Fix

`sweep-discover` now also collects open items labelled `openrouter:triage-failed` or `openrouter:needs-key` and re-queues them for triage **regardless of the `openrouter` label** (only `no-triage` opts out), deduped with the fresh `triage:new` set. Because triage now cascades to the keyless lane, these re-attempts succeed and `scripts/openrouter-triage.js` clears the failure labels itself on success — so the fleet recovers within the hour, no manual relabeling.

Capped at 200 targets/sweep (Actions matrix limit is 256; overflow rolls to the next hourly run, idempotent).

### Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` → OK
- `node scripts/check-workflow-yaml.js` → all workflows valid
- Extracted the embedded `github-script` body → `node --check` passes

Once merged, #14664/#14665 and the rest auto-recover on the next hourly sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wp1LuALPG9x7AaPahXyCgi)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a self-healing gap in the triage workflow where work requests that previously failed with `openrouter:triage-failed` or `openrouter:needs-key` labels became permanently stuck. The hourly sweep now actively recovers these failed items by re-queueing them for triage through the new keyless Perplexity fallback lane (introduced in PR #14663), allowing them to succeed on retry and automatically clear their failure labels. The sweep is capped at 200 items to stay within GitHub Actions matrix limits, with overflow handled in subsequent hourly runs.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/openrouter-triage.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-recovers previously failed or needs-key triage items during the hourly sweep by re-queuing them through the keyless lane. This unsticks items labeled `openrouter:triage-failed` or `openrouter:needs-key` so they clear on retry and proceed.

- **Bug Fixes**
  - Sweep now includes open items with `openrouter:triage-failed` or `openrouter:needs-key`, re-queued even if they already have `openrouter`; only `no-triage` opts out.
  - Dedupes with `triage:new` and caps to 200 per run; overflow rolls to the next hour.
  - Leverages the fallback from #14663 (keyless Perplexity lane) so successful retries automatically remove failure labels.

<sup>Written for commit 7f3b872fa2d51dc264c6b55e28af16f92c39fa7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

