### PR TITLE
fix(wr-gate): exempt initial weekly-research PRs from the fix-WR gate

### DIFF
--- a/wr/scripts/fix-wr-gate.mjs
+++ b/wr/scripts/fix-wr-gate.mjs
@@ -22,6 +22,10 @@ const body  = get("body")  || "";
 // allows owner/repo qualified forms too ("Tracks: foo/bar#1234").
 const TRACKS_REF = /\btrack(?:s|ing)?\s*[: ]\s*([A-Za-z0-9_.\/-]+)?#\d+/i;
 
+// GitHub issue-closing keywords ("Closes #1234", "Fixes owner/repo#12", …).
+// Used to confirm a research WR links its originating issue (the follow-up tracker).
+const CLOSES_REF = /\b(?:clos(?:e|es|ed)|fix(?:e|es|ed)?|resolv(?:e|es|ed))\s+(?:[A-Za-z0-9_.\/-]+)?#\d+/i;
+
 const TRACKING_LABELS = ["tracking-only", "wr-docs", "wr-tracking", "meta-tracking", "docs-only"];
 const TRACKING_PREFIXES = [/^\[wr-docs\]/i, /^\[wr-tracking\]/i, /^track\b/i, /^\[track\]/i];
 
@@ -48,9 +52,19 @@ const trackingLabeled =
 const hasTracksRef = TRACKS_REF.test(body);
 const isTrackingOnly = trackingLabeled && hasTracksRef;
 
+// The INITIAL WR research PR (auto-created by wr-pr-creation.yml, labeled
+// `weekly-research`) is the research deliverable itself: a wr/issues/*.md doc
+// that links its originating issue with "Closes #N". It is NOT a fix-class WR
+// claiming to apply a fix — the implementation lands later against that issue —
+// so the "must include a real (non-wr/) fix" rule does not apply. We still
+// require a closing/tracking reference so a reviewer can find the originating
+// issue; that keeps this from being a blanket bypass for genuine fix WRs.
+const linksIssue = hasTracksRef || CLOSES_REF.test(body);
+const isResearchWR = labels.includes("weekly-research") && linksIssue;
+
 const issues = [];
 
-if (claimsFix && wrOnly && !isTrackingOnly) {
+if (claimsFix && wrOnly && !isTrackingOnly && !isResearchWR) {
   if (trackingLabeled && !hasTracksRef) {
     issues.push(
       `PR is labeled tracking-only but the body has no "Tracks: #NNNN" reference. ` +
@@ -66,6 +80,11 @@ if (claimsFix && wrOnly && !isTrackingOnly) {
       `"Tracks: #NNNN" to the PR body pointing at the follow-up that applies the fix.`
     );
   }
+}
+
+// Research WR accepted: surface it so a reviewer knows the fix is tracked, not applied here.
+if (claimsFix && wrOnly && !isTrackingOnly && isResearchWR) {
+  console.log(`note: weekly-research WR accepted (research deliverable that links its originating issue). The fix lands in a follow-up against that issue.`);
 }
 
 // Secondary: a fix WR that is tracking-only should SAY so, to avoid a future reviewer thinking it's resolved.


### PR DESCRIPTION
## What

The **fix-WR gate** (`fix-wr-gate.yml` → `wr/scripts/fix-wr-gate.mjs`) runs on every `wr/issues/**.md` PR and fails any whose **title** contains a fix word (`correct`, `add`, `fix`, `resolve`, …) while the diff is **wr-only**, unless it carries a tracking label + `Tracks: #N`.

That mis-fires on the **initial WR research PRs** auto-created by `wr-pr-creation.yml`: they are *inherently* wr-only — the `wr/issues/*.md` research doc **is** the deliverable, and the implementation lands later against the linked issue. So legitimate research PRs get blocked, e.g. **#14653** ("…go live correct all clickable links…") which only touches its own WR doc (the failure in the screenshot the owner sent).

## Fix

Exempt a PR labeled **`weekly-research`** that **links its originating issue** via a GitHub closing keyword (`Closes/Fixes/Resolves #N`) or a `Tracks: #N` ref. Added `CLOSES_REF` to recognize closing keywords.

The issue-link requirement keeps this from being a blanket bypass. Verified:

| Case | Result |
| --- | --- |
| WR research PR #14653 (weekly-research + `Closes #14567`, wr-only) | ✅ passes |
| Genuine fix-class WR, no `weekly-research`, wr-only | ❌ still fails |
| `weekly-research` but no issue link in body | ❌ still fails |

Once merged, the stuck WR research PRs (#14645–14654) clear this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wp1LuALPG9x7AaPahXyCgi)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes the fix-WR gate to stop incorrectly blocking initial weekly-research PRs. The gate currently fails PRs that have fix-related words in the title but only touch WR documentation files, which was mis-firing on auto-created weekly research PRs where the research document itself is the deliverable. The fix adds an exemption for PRs labeled `weekly-research` that link their originating issue via GitHub closing keywords (`Closes/Fixes/Resolves #N`) or `Tracks: #N` references, ensuring legitimate research PRs can pass while maintaining safeguards against genuine fix-class PRs that should include non-WR changes.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `wr/scripts/fix-wr-gate.mjs` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the fix-WR gate from blocking initial weekly-research PRs that only touch `wr/issues/*.md`. PRs labeled `weekly-research` that link their originating issue now pass while real fix-only WRs still fail.

- **Bug Fixes**
  - Updated `wr/scripts/fix-wr-gate.mjs` to add `CLOSES_REF` and detect `Closes/Fixes/Resolves #N` or `Tracks: #N`.
  - Exempt `weekly-research` PRs with an issue link; keep failing non-research WRs or research PRs without a link, and log a note when exempted.

<sup>Written for commit 602615cdfee4bf09fbe87c568ee525972a7577b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

