### PR TITLE
fix(project-v2): skip default-field setters when unconfigured instead of exit 1

### DIFF
--- a/.github/workflows/default-project-v2-fields-pat.yml
+++ b/.github/workflows/default-project-v2-fields-pat.yml
@@ -23,19 +23,42 @@ jobs:
       - id: check
         env:
           PAT: ${{ secrets.PROJECTS_PAT }}
+          PROJECT_ID: ${{ vars.PROJECT_ID }}
+          PRIORITY_FIELD_ID: ${{ vars.PRIORITY_FIELD_ID }}
+          STATUS_FIELD_ID: ${{ vars.STATUS_FIELD_ID }}
+          RESEARCH_MODE_FIELD_ID: ${{ vars.RESEARCH_MODE_FIELD_ID }}
+          PRIORITY_MEDIUM_OPTION_ID: ${{ vars.PRIORITY_MEDIUM_OPTION_ID }}
+          STATUS_INBOX_OPTION_ID: ${{ vars.STATUS_INBOX_OPTION_ID }}
+          RESEARCH_MODE_STANDARD_OPTION_ID: ${{ vars.RESEARCH_MODE_STANDARD_OPTION_ID }}
         run: |
           set -euo pipefail
-          if [ -n "${PAT}" ]; then
-            echo "has_creds=true" >> "$GITHUB_OUTPUT"
-            echo "Classic PAT configured (PROJECTS_PAT)."
-          else
+          # Graceful degradation (fail over, don't dead-end): setting default
+          # Project v2 fields is OPTIONAL polish. If the PAT or ANY required
+          # Project field/option ID isn't configured, SKIP cleanly — never hard-fail
+          # a new-issue event over optional project automation. We list exactly what
+          # is missing so a human can wire it up later (repo Settings → Secrets and
+          # variables → Actions). Previously a missing var made the setter exit 1 on
+          # every opened issue.
+          missing=""
+          [ -z "${PAT}" ] && missing="${missing} PROJECTS_PAT(secret)"
+          for v in PROJECT_ID PRIORITY_FIELD_ID STATUS_FIELD_ID RESEARCH_MODE_FIELD_ID \
+                   PRIORITY_MEDIUM_OPTION_ID STATUS_INBOX_OPTION_ID RESEARCH_MODE_STANDARD_OPTION_ID; do
+            [ -z "${!v}" ] && missing="${missing} ${v}(var)"
+          done
+          if [ -n "${missing}" ]; then
             echo "has_creds=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::PROJECTS_PAT not configured; skipping PAT default-field setter."
+            echo "::notice::Skipping PAT default-field setter — not fully configured. Missing:${missing}. Configure these to enable; ignore to keep it disabled."
+          else
+            echo "has_creds=true" >> "$GITHUB_OUTPUT"
+            echo "PROJECTS_PAT + all Project v2 field/option IDs configured."
           fi
   set-project-defaults:
     name: Add issue to Project v2 and set default fields
     needs: preflight
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.preflight.outputs.has_creds == 'true' }}
+    # Run only when fully configured (preflight verified PAT + all field/option
+    # IDs). Manual workflow_dispatch no longer bypasses this — without the IDs the
+    # job cannot do anything but fail, so it skips cleanly instead.
+    if: ${{ needs.preflight.outputs.has_creds == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -48,31 +71,6 @@ jobs:
       STATUS_INBOX_OPTION_ID: ${{ vars.STATUS_INBOX_OPTION_ID }}
       RESEARCH_MODE_STANDARD_OPTION_ID: ${{ vars.RESEARCH_MODE_STANDARD_OPTION_ID }}
     steps:
-      - name: Validate configuration
-        run: |
-          set -euo pipefail
-
-          missing=0
-
-          for var_name in \
-            GH_TOKEN \
-            PROJECT_ID \
-            PRIORITY_FIELD_ID \
-            STATUS_FIELD_ID \
-            RESEARCH_MODE_FIELD_ID \
-            PRIORITY_MEDIUM_OPTION_ID \
-            STATUS_INBOX_OPTION_ID \
-            RESEARCH_MODE_STANDARD_OPTION_ID
-          do
-            if [ -z "${!var_name}" ]; then
-              echo "Missing required secret or variable: ${var_name}"
-              missing=1
-            fi
-          done
-
-          if [ "${missing}" -ne 0 ]; then
-            exit 1
-          fi
       - name: Resolve issue node ID
         id: issue
         env:

--- a/.github/workflows/set-default-project-v2-fields.yml
+++ b/.github/workflows/set-default-project-v2-fields.yml
@@ -24,22 +24,40 @@ jobs:
         env:
           APP_ID: ${{ vars.PROJECTS_APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.PROJECTS_APP_PRIVATE_KEY }}
+          PROJECT_ID: ${{ vars.PROJECT_ID }}
+          PRIORITY_FIELD_ID: ${{ vars.PRIORITY_FIELD_ID }}
+          STATUS_FIELD_ID: ${{ vars.STATUS_FIELD_ID }}
+          RESEARCH_MODE_FIELD_ID: ${{ vars.RESEARCH_MODE_FIELD_ID }}
+          PRIORITY_MEDIUM_OPTION_ID: ${{ vars.PRIORITY_MEDIUM_OPTION_ID }}
+          STATUS_INBOX_OPTION_ID: ${{ vars.STATUS_INBOX_OPTION_ID }}
+          RESEARCH_MODE_STANDARD_OPTION_ID: ${{ vars.RESEARCH_MODE_STANDARD_OPTION_ID }}
         run: |
           set -euo pipefail
-          if [ -n "${APP_ID}" ] && [ -n "${APP_PRIVATE_KEY}" ]; then
-            echo "has_creds=true" >> "$GITHUB_OUTPUT"
-            echo "App credentials configured (PROJECTS_APP_ID + PROJECTS_APP_PRIVATE_KEY)."
-          elif [ -n "${APP_ID}" ] || [ -n "${APP_PRIVATE_KEY}" ]; then
+          # Graceful degradation (fail over, don't dead-end): default-field setting
+          # is OPTIONAL polish. Run ONLY when App auth AND every Project v2
+          # field/option ID is configured; otherwise SKIP cleanly so a new-issue
+          # event never hard-fails over optional project automation. List what is
+          # missing so a human can wire it up later.
+          missing=""
+          { [ -z "${APP_ID}" ] || [ -z "${APP_PRIVATE_KEY}" ]; } && missing="${missing} PROJECTS_APP_ID/PROJECTS_APP_PRIVATE_KEY"
+          for v in PROJECT_ID PRIORITY_FIELD_ID STATUS_FIELD_ID RESEARCH_MODE_FIELD_ID \
+                   PRIORITY_MEDIUM_OPTION_ID STATUS_INBOX_OPTION_ID RESEARCH_MODE_STANDARD_OPTION_ID; do
+            [ -z "${!v}" ] && missing="${missing} ${v}(var)"
+          done
+          if [ -n "${missing}" ]; then
             echo "has_creds=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::App auth is half-configured: only one of PROJECTS_APP_ID / PROJECTS_APP_PRIVATE_KEY is set. Skipping default-field setter; configure both to enable, or unset both to silence this warning."
+            echo "::notice::Skipping App default-field setter — not fully configured. Missing:${missing}. Configure these to enable; ignore to keep it disabled."
           else
-            echo "has_creds=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::PROJECTS_APP_ID and PROJECTS_APP_PRIVATE_KEY not configured; skipping App default-field setter."
+            echo "has_creds=true" >> "$GITHUB_OUTPUT"
+            echo "App credentials + all Project v2 field/option IDs configured."
           fi
   set-project-defaults:
     name: Add issue to Project v2 and set default fields
     needs: preflight
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.preflight.outputs.has_creds == 'true' }}
+    # Run only when fully configured (App auth + all field/option IDs). Manual
+    # workflow_dispatch no longer bypasses this — without the IDs the job can only
+    # fail, so it skips cleanly instead of dead-ending.
+    if: ${{ needs.preflight.outputs.has_creds == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:


### PR DESCRIPTION
## What

Both Project v2 "default fields" workflows run on every `issues: opened`. The **PAT** variant (`default-project-v2-fields-pat.yml`) hard-failed with `exit 1` — `Missing required secret or variable: STATUS_FIELD_ID` … — whenever `PROJECTS_PAT` was set but the Project field/option IDs weren't configured as repo variables (the red X in the screenshot). The **App** variant had the same `workflow_dispatch ||` bypass that could reach a failing GraphQL call when IDs are missing.

## Fix (fail over, don't dead-end)

- Moved the **full** config check into `preflight` (auth + `PROJECT_ID` + all 5 field/option IDs). When anything is missing, `has_creds=false` and the setter job **skips cleanly** (success) with a `::notice::` listing exactly what to configure.
- Dropped the `workflow_dispatch` bypass — without the IDs a manual run can only fail, so it skips too.
- Removed the redundant hard-fail "Validate configuration" step in the PAT variant.

Setting default Project v2 fields is optional polish; a missing optional integration must never fail a new-issue event. Matches the graceful-degradation pattern used for `OPENROUTER_API_KEY`.

Validated: YAML parse + `scripts/check-workflow-yaml.js` (all workflows valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wp1LuALPG9x7AaPahXyCgi)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes two GitHub Project v2 workflows that were hard-failing when partially configured, replacing the `exit 1` errors with graceful skips. The preflight job now validates **all** required credentials and Project field/option IDs upfront, emitting a helpful `::notice::` listing what's missing and cleanly skipping the setter job when anything is unconfigured. The `workflow_dispatch` bypass was removed since manual runs without required IDs can only fail. This ensures that optional Project automation never breaks the new-issue event flow.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/default-project-v2-fields-pat.yml` |
| 2 | `.github/workflows/set-default-project-v2-fields.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Project v2 default-field workflows skip cleanly when unconfigured instead of failing new-issue events. Preflight now checks all required creds and IDs, and prints a notice listing what’s missing.

- **Bug Fixes**
  - Preflight validates PAT/App auth plus `PROJECT_ID` and all field/option IDs; if anything’s missing, set `has_creds=false` and skip with a `::notice::`.
  - Removed `workflow_dispatch` bypass; jobs run only when fully configured.
  - Dropped the hard-fail validation step in the PAT workflow.

<sup>Written for commit 1b86f2bf2ae0ee5b6d9f32d9a03d96f3ac1564b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

