### PR TITLE
fix(project-v2): name the specific missing App credential in preflight notice

### DIFF
--- a/.github/workflows/set-default-project-v2-fields.yml
+++ b/.github/workflows/set-default-project-v2-fields.yml
@@ -39,7 +39,10 @@ jobs:
           # event never hard-fails over optional project automation. List what is
           # missing so a human can wire it up later.
           missing=""
-          { [ -z "${APP_ID}" ] || [ -z "${APP_PRIVATE_KEY}" ]; } && missing="${missing} PROJECTS_APP_ID/PROJECTS_APP_PRIVATE_KEY"
+          # Name each credential separately so the notice tells a human EXACTLY
+          # which one to set (e.g. half-configured App auth) rather than a vague pair.
+          [ -z "${APP_ID}" ] && missing="${missing} PROJECTS_APP_ID(var)"
+          [ -z "${APP_PRIVATE_KEY}" ] && missing="${missing} PROJECTS_APP_PRIVATE_KEY(secret)"
           for v in PROJECT_ID PRIORITY_FIELD_ID STATUS_FIELD_ID RESEARCH_MODE_FIELD_ID \
                    PRIORITY_MEDIUM_OPTION_ID STATUS_INBOX_OPTION_ID RESEARCH_MODE_STANDARD_OPTION_ID; do
             [ -z "${!v}" ] && missing="${missing} ${v}(var)"


### PR DESCRIPTION
## What

Follow-up to a **Devin** Info-level review note on #14668: the App-variant preflight in `set-default-project-v2-fields.yml` reported `PROJECTS_APP_ID/PROJECTS_APP_PRIVATE_KEY` as a single unit even when only one of the two was missing, so the skip `::notice::` didn't tell a human which credential to set.

## Fix

Check each credential separately and append the exact missing one (`PROJECTS_APP_ID(var)` / `PROJECTS_APP_PRIVATE_KEY(secret)`) to the notice — human-first diagnostics, matching the per-field listing already used for the project IDs.

Behavior is unchanged (job still skips cleanly when anything is missing); only the diagnostic message is more precise.

The other two Devin notes need no change: the `set -e`/`&&`-in-for-loop pattern was verified safe, and the `workflow_dispatch` gating change is intentional/documented.

Validated: YAML parse + `scripts/check-workflow-yaml.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wp1LuALPG9x7AaPahXyCgi)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves diagnostic messaging in a GitHub workflow by checking `PROJECTS_APP_ID` and `PROJECTS_APP_PRIVATE_KEY` credentials separately. Previously, when either credential was missing, the preflight notice reported both as a single unit, making it unclear which specific credential needed to be set. The fix now appends each missing credential individually to the notice message, providing clearer guidance for developers configuring the workflow.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/set-default-project-v2-fields.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Project V2 preflight notice in `set-default-project-v2-fields.yml` to name the exact missing App credential, making setup guidance clear. Behavior is unchanged; the job still skips when anything is missing.

- **Bug Fixes**
  - Check `PROJECTS_APP_ID` and `PROJECTS_APP_PRIVATE_KEY` separately.
  - Append `(var)` or `(secret)` to the notice to show exactly what to set.

<sup>Written for commit 515a1343311783160662f41603b0110ae5aa1036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

