### PR TITLE
PDF Pipeline: concept generator (20 per niche)

### DIFF
--- a/products/pdf-pipeline/concepts/README.md
+++ b/products/pdf-pipeline/concepts/README.md
@@ -1,0 +1,153 @@
+# PDF Pipeline — Concept Generator
+
+Module path: `products/pdf-pipeline/concepts/`
+
+One stage of the PDF Product Pipeline. Given a niche, this module emits a batch
+of 20 distinct, sellable PDF product concepts that downstream stages (research,
+cover-designer, PDF renderer, uploader) consume.
+
+## Contract
+
+### Input
+
+- `--niche "<niche>"` — a single niche string, OR
+- nothing — the script reads `products/pdf-pipeline/state/top-niches.json` and
+  picks the highest-`score` entry.
+
+`top-niches.json` is expected to look like:
+
+```json
+{
+  "niches": [
+    { "niche": "Bullet journaling for ADHD adults", "score": 0.93 },
+    { "niche": "Macro meal prep for shift workers",  "score": 0.81 }
+  ]
+}
+```
+
+Either `niche`, `name`, or `title` is accepted as the niche field, and a bare
+array (no `niches` wrapper) is also accepted.
+
+### Output (success)
+
+`products/pdf-pipeline/state/concepts-{YYYY-MM-DD}.json`:
+
+```json
+{
+  "niche": "Bullet journaling for ADHD adults",
+  "generated_at": "2026-06-17T12:34:56.000Z",
+  "count": 20,
+  "model_used": "deepseek/deepseek-v3.2",
+  "concepts": [
+    {
+      "title": "The 30-Day ADHD Bullet Journal Reset",
+      "subtitle": "A guided 30-day system to rebuild focus, one spread at a time.",
+      "format": "workbook",
+      "target_buyer": "Adults with ADHD who keep abandoning their bullet journals by week two.",
+      "toc": [
+        "Why ADHD brains quit bullet journals",
+        "The 10-minute morning spread",
+        "Brain-dump rituals that actually finish",
+        "Dopamine-aware habit tracking",
+        "Weekly reviews in five questions",
+        "Recovering from a missed week",
+        "Templates you can copy by hand",
+        "What to keep, what to drop"
+      ],
+      "hook": "If your bullet journal is a graveyard of half-finished spreads, you are not lazy — you are using a system that wasn't built for an ADHD brain. This 30-day workbook walks you through a focus-friendly format that actually sticks. By day 30 you'll have a journal habit that survives bad weeks.",
+      "price_usd": 19,
+      "tags": ["adhd", "bullet journal", "productivity", "focus", "planner", "neurodivergent"],
+      "cover_prompt": "Flat editorial illustration of an open bullet journal on a warm desk with soft morning light, scattered colored pens and a coffee cup, muted dopamine-friendly palette of soft teal, peach, and cream. Centered title block reserved across the top third. Modern, calm, slightly hand-drawn vector style. No text in the image. No real faces."
+    }
+  ]
+}
+```
+
+### Output (failure)
+
+If OpenRouter returns invalid JSON twice (initial attempt + one retry with a
+"JSON only" reminder), the script writes
+`products/pdf-pipeline/state/concepts-failed-{YYYY-MM-DD}.json` containing the
+niche, the last error, the model used, and the raw response text, then exits 1.
+
+## Concept shape
+
+Every concept in the output array contains:
+
+| Field          | Type      | Constraint                                                       |
+|----------------|-----------|------------------------------------------------------------------|
+| `title`        | string    | 3-59 chars; buyer-grabbing                                        |
+| `subtitle`     | string    | 5-200 chars; one-sentence value prop                              |
+| `format`       | enum      | `planner`, `workbook`, `guide`, `checklist`, `ebook`, `template-pack`, `journal`, `course` |
+| `target_buyer` | string    | one-line persona                                                  |
+| `toc`          | string[]  | 6-15 section titles                                               |
+| `hook`         | string    | 30-600 chars; 2-3 sentence Gumroad listing opener, ends with a benefit |
+| `price_usd`    | number    | 1-199                                                             |
+| `tags`         | string[]  | 5-10 SEO tags                                                     |
+| `cover_prompt` | string    | 30-800 chars; text-to-image prompt, no literal title text         |
+
+Full machine-readable schema: [`schema.json`](./schema.json).
+
+The batch is also validated for **format variety** (≥5 distinct formats when the
+batch is ≥10) and **title uniqueness**.
+
+## CLI
+
+```bash
+node products/pdf-pipeline/concepts/generate.mjs --niche "Bullet journaling for ADHD adults"
+node products/pdf-pipeline/concepts/generate.mjs --niche "Macro meal prep" --count 20
+node products/pdf-pipeline/concepts/generate.mjs                  # uses top-niches.json
+node products/pdf-pipeline/concepts/generate.mjs --dry-run --niche "X"   # prints prompts, no API call
+node products/pdf-pipeline/concepts/generate.mjs --out /tmp/concepts.json --niche "X"
+```
+
+### Flags
+
+- `--niche <string>` — niche to generate for. If omitted, reads
+  `state/top-niches.json` and picks the top-ranked entry.
+- `--count <n>` — number of concepts (default 20, max 100).
+- `--out <path>` — override output path. Default: `state/concepts-{YYYY-MM-DD}.json`.
+- `--dry-run` — print resolved system + user prompts and exit; no API call.
+
+### Exit codes
+
+| Code | Meaning                                                                   |
+|------|---------------------------------------------------------------------------|
+| 0    | Success — valid JSON written to the output path.                          |
+| 1    | Generation or validation failed both attempts; failure file written.      |
+| 2    | Usage error (bad flags, missing niche AND missing top-niches.json, etc.). |
+
+## Env vars
+
+| Variable                 | Required?     | Purpose                                                      |
+|--------------------------|---------------|--------------------------------------------------------------|
+| `OPENROUTER_API_KEY`     | yes (unless `--dry-run`) | Auth for the OpenRouter call.                     |
+| `OPENROUTER_HTTP_REFERER`| no            | `HTTP-Referer` header (defaults to repo URL).                |
+| `OPENROUTER_APP_TITLE`   | no            | `X-Title` header.                                            |
+
+## Routing
+
+Uses the `cheap_batch_edits` profile from
+[`scripts/openrouter-routing.js`](../../../scripts/openrouter-routing.js) — a
+single batched prompt returns all 20 concepts at once to keep cost low.
+
+The system prompt (`prompts/system.md`) enforces JSON-only output, format
+variety, and the no-duplicates rule. On a JSON parse failure the script retries
+once with an explicit "JSON only" reminder appended to the user message.
+
+## Downstream contract notes
+
+- The `cover_prompt` field is consumed by the **cover-designer** module. It
+  intentionally does NOT contain the literal title text — the cover-designer
+  composites the title separately.
+- The `toc` field is consumed by the **PDF renderer** as a section outline; the
+  renderer fills each section with body copy generated from `target_buyer` and
+  the niche context.
+- The `hook` field is consumed by the **uploader** as the first paragraph of
+  the Gumroad listing description.
+
+## Stays in lane
+
+This module does **not** do research, PDF rendering, cover image generation,
+upload, pricing optimization, or analytics. It only converts a niche into a
+validated batch of concept specifications. Other modules consume `concepts-{date}.json`.

--- a/products/pdf-pipeline/concepts/generate.mjs
+++ b/products/pdf-pipeline/concepts/generate.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+// products/pdf-pipeline/concepts/generate.mjs
+//
+// Concept Generator — produces a batch of PDF product concepts for one niche.
+//
+// CLI:
+//   node generate.mjs --niche "<niche>" [--count 20] [--out <path>] [--dry-run]
+//
+// If --niche is omitted, reads products/pdf-pipeline/state/top-niches.json and
+// picks the top-ranked entry.
+//
+// Output (success): products/pdf-pipeline/state/concepts-{YYYY-MM-DD}.json
+// Output (failure): products/pdf-pipeline/state/concepts-failed-{YYYY-MM-DD}.json
+//
+// Env:
+//   OPENROUTER_API_KEY    required (unless --dry-run)
+//   OPENROUTER_HTTP_REFERER, OPENROUTER_APP_TITLE  optional headers
+//
+// Exit codes:
+//   0  success — valid JSON written
+//   1  generation/validation failed — failure file written
+//   2  usage / env error
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { routedChat } = require("../../../scripts/openrouter-routing.js");
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "../../..");
+const STATE_DIR = join(REPO_ROOT, "products", "pdf-pipeline", "state");
+const SYSTEM_PROMPT_PATH = join(__dirname, "prompts", "system.md");
+const SCHEMA_PATH = join(__dirname, "schema.json");
+const TOP_NICHES_PATH = join(STATE_DIR, "top-niches.json");
+
+const ALLOWED_FORMATS = new Set([
+  "planner",
+  "workbook",
+  "guide",
+  "checklist",
+  "ebook",
+  "template-pack",
+  "journal",
+  "course",
+]);
+
+function parseArgs(argv) {
+  const args = { count: 20, dryRun: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--niche") args.niche = argv[++i];
+    else if (a === "--count") args.count = Number(argv[++i]);
+    else if (a === "--out") args.out = argv[++i];
+    else if (a === "--dry-run") args.dryRun = true;
+    else if (a === "-h" || a === "--help") args.help = true;
+    else if (a.startsWith("--niche=")) args.niche = a.slice("--niche=".length);
+    else if (a.startsWith("--count=")) args.count = Number(a.slice("--count=".length));
+    else if (a.startsWith("--out=")) args.out = a.slice("--out=".length);
+  }
+  return args;
+}
+
+function usage() {
+  return `Usage: node generate.mjs --niche "<niche>" [--count 20] [--out <path>] [--dry-run]
+
+Generates a batch of PDF product concepts for the given niche and writes them to
+products/pdf-pipeline/state/concepts-YYYY-MM-DD.json.
+
+If --niche is omitted, reads products/pdf-pipeline/state/top-niches.json and
+picks the top-ranked entry.
+
+Requires OPENROUTER_API_KEY in the environment (unless --dry-run).
+`;
+}
+
+function todayStamp() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function readTopNiche() {
+  if (!existsSync(TOP_NICHES_PATH)) {
+    throw new Error(
+      `No --niche provided and ${TOP_NICHES_PATH} does not exist`
+    );
+  }
+  const raw = await readFile(TOP_NICHES_PATH, "utf8");
+  const data = JSON.parse(raw);
+  // Accept either {niches: [{name, score}, ...]} or a bare array.
+  const list = Array.isArray(data) ? data : data.niches;
+  if (!Array.isArray(list) || list.length === 0) {
+    throw new Error(`top-niches.json is empty or malformed`);
+  }
+  const sorted = [...list].sort(
+    (a, b) => (b.score ?? b.rank_score ?? 0) - (a.score ?? a.rank_score ?? 0)
+  );
+  const top = sorted[0];
+  const niche =
+    typeof top === "string" ? top : top.niche || top.name || top.title;
+  if (!niche) throw new Error(`Top niche entry has no niche/name/title field`);
+  return niche;
+}
+
+function buildUserPrompt(niche, count) {
+  return [
+    `Niche: ${niche}`,
+    `Generate exactly ${count} PDF product concepts for this niche.`,
+    `Return a single JSON object with the shape:`,
+    `{"concepts": [ ...${count} concept objects... ]}`,
+    `Vary the format field across the batch. No duplicates or near-duplicates.`,
+    `JSON only. No prose. No Markdown fences.`,
+  ].join("\n");
+}
+
+// Strip Markdown fences and grab the outer JSON object if the model wraps it.
+function extractJson(text) {
+  if (typeof text !== "string") return text;
+  let t = text.trim();
+  // Strip ```json ... ``` or ``` ... ``` fences.
+  const fenced = t.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  if (fenced) t = fenced[1].trim();
+  // Fallback: slice between first '{' and last '}'.
+  const first = t.indexOf("{");
+  const last = t.lastIndexOf("}");
+  if (first !== -1 && last !== -1 && last > first) {
+    t = t.slice(first, last + 1);
+  }
+  return JSON.parse(t);
+}
+
+function validateBatch(parsed, expectedCount) {
+  const errs = [];
+  if (!parsed || typeof parsed !== "object") {
+    return ["payload is not an object"];
+  }
+  const concepts = parsed.concepts;
+  if (!Array.isArray(concepts)) {
+    return ["payload.concepts is not an array"];
+  }
+  if (concepts.length !== expectedCount) {
+    errs.push(
+      `expected ${expectedCount} concepts, got ${concepts.length}`
+    );
+  }
+
+  const titles = new Set();
+  concepts.forEach((c, i) => {
+    const where = `concepts[${i}]`;
+    if (!c || typeof c !== "object") {
+      errs.push(`${where}: not an object`);
+      return;
+    }
+    const requireStr = (field, min, max) => {
+      const v = c[field];
+      if (typeof v !== "string" || v.length < min || v.length > max) {
+        errs.push(
+          `${where}.${field}: must be string ${min}-${max} chars (got ${
+            v === undefined ? "undefined" : typeof v + " len " + (v?.length ?? 0)
+          })`
+        );
+      }
+    };
+    requireStr("title", 3, 59);
+    requireStr("subtitle", 5, 200);
+    requireStr("target_buyer", 5, 200);
+    requireStr("hook", 30, 600);
+    requireStr("cover_prompt", 30, 800);
+
+    if (!ALLOWED_FORMATS.has(c.format)) {
+      errs.push(
+        `${where}.format: must be one of ${[...ALLOWED_FORMATS].join(",")} (got ${c.format})`
+      );
+    }
+
+    if (
+      !Array.isArray(c.toc) ||
+      c.toc.length < 6 ||
+      c.toc.length > 15 ||
+      !c.toc.every((s) => typeof s === "string" && s.length >= 3)
+    ) {
+      errs.push(`${where}.toc: must be 6-15 non-empty strings`);
+    }
+
+    if (
+      typeof c.price_usd !== "number" ||
+      !Number.isFinite(c.price_usd) ||
+      c.price_usd < 1 ||
+      c.price_usd > 199
+    ) {
+      errs.push(`${where}.price_usd: must be number 1-199`);
+    }
+
+    if (
+      !Array.isArray(c.tags) ||
+      c.tags.length < 5 ||
+      c.tags.length > 10 ||
+      !c.tags.every((s) => typeof s === "string" && s.length >= 2)
+    ) {
+      errs.push(`${where}.tags: must be 5-10 non-empty strings`);
+    }
+
+    if (typeof c.title === "string") {
+      const key = c.title.trim().toLowerCase();
+      if (titles.has(key)) errs.push(`${where}.title: duplicate of earlier title`);
+      titles.add(key);
+    }
+  });
+
+  // Format variety: at least 5 distinct formats across the batch.
+  const formats = new Set(
+    concepts.map((c) => c?.format).filter((f) => ALLOWED_FORMATS.has(f))
+  );
+  if (concepts.length >= 10 && formats.size < 5) {
+    errs.push(
+      `format variety: only ${formats.size} distinct formats across ${concepts.length} concepts (need >=5)`
+    );
+  }
+
+  return errs;
+}
+
+async function callModel(systemPrompt, userPrompt) {
+  return routedChat({
+    profile: "cheap_batch_edits",
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userPrompt },
+    ],
+    temperature: 0.85,
+    max_tokens: 12000,
+    silent: false,
+  });
+}
+
+async function writeJson(path, payload) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(payload, null, 2) + "\n", "utf8");
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    process.stdout.write(usage());
+    process.exit(0);
+  }
+
+  if (!Number.isInteger(args.count) || args.count < 1 || args.count > 100) {
+    console.error(`--count must be an integer 1-100 (got ${args.count})`);
+    process.exit(2);
+  }
+
+  let niche = args.niche;
+  if (!niche) {
+    try {
+      niche = await readTopNiche();
+      console.log(`No --niche given; using top niche from state: "${niche}"`);
+    } catch (err) {
+      console.error(err.message);
+      console.error(usage());
+      process.exit(2);
+    }
+  }
+
+  if (!args.dryRun && !process.env.OPENROUTER_API_KEY) {
+    console.error("OPENROUTER_API_KEY is required (or use --dry-run)");
+    process.exit(2);
+  }
+
+  const systemPrompt = await readFile(SYSTEM_PROMPT_PATH, "utf8");
+  const userPrompt = buildUserPrompt(niche, args.count);
+  const date = todayStamp();
+  const outPath =
+    args.out || join(STATE_DIR, `concepts-${date}.json`);
+  const failPath = join(STATE_DIR, `concepts-failed-${date}.json`);
+
+  if (args.dryRun) {
+    console.log("--- DRY RUN: system prompt ---");
+    console.log(systemPrompt);
+    console.log("--- DRY RUN: user prompt ---");
+    console.log(userPrompt);
+    console.log(`--- DRY RUN: would write to ${outPath} ---`);
+    process.exit(0);
+  }
+
+  let lastErr = null;
+  let lastRawText = null;
+  let lastModel = null;
+
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const reminderPrompt =
+      attempt === 1
+        ? userPrompt
+        : userPrompt +
+          "\n\nREMINDER: Return JSON ONLY. No prose, no Markdown fences. Top-level object with key 'concepts'.";
+
+    let result;
+    try {
+      console.log(`Attempt ${attempt}/2: calling OpenRouter (cheap_batch_edits)...`);
+      result = await callModel(systemPrompt, reminderPrompt);
+    } catch (err) {
+      lastErr = `OpenRouter call failed: ${err.message}`;
+      console.error(lastErr);
+      continue;
+    }
+
+    lastRawText = result.text;
+    lastModel = result.modelUsed;
+
+    let parsed;
+    try {
+      parsed = extractJson(result.text);
+    } catch (err) {
+      lastErr = `JSON parse failed: ${err.message}`;
+      console.error(lastErr);
+      continue;
+    }
+
+    const errs = validateBatch(parsed, args.count);
+    if (errs.length > 0) {
+      lastErr = `schema validation failed:\n  - ${errs.slice(0, 10).join("\n  - ")}${errs.length > 10 ? `\n  - ...and ${errs.length - 10} more` : ""}`;
+      console.error(lastErr);
+      continue;
+    }
+
+    const payload = {
+      niche,
+      generated_at: new Date().toISOString(),
+      count: parsed.concepts.length,
+      model_used: result.modelUsed || null,
+      concepts: parsed.concepts,
+    };
+    await writeJson(outPath, payload);
+    console.log(`Wrote ${parsed.concepts.length} concepts to ${outPath}`);
+    process.exit(0);
+  }
+
+  // Both attempts failed — write failure file and exit 1.
+  const failurePayload = {
+    niche,
+    generated_at: new Date().toISOString(),
+    requested_count: args.count,
+    last_error: lastErr,
+    model_used: lastModel,
+    raw_text: lastRawText,
+  };
+  await writeJson(failPath, failurePayload);
+  console.error(`Both attempts failed. Wrote diagnostics to ${failPath}`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(`Fatal: ${err.stack || err.message || err}`);
+  process.exit(1);
+});

--- a/products/pdf-pipeline/concepts/prompts/system.md
+++ b/products/pdf-pipeline/concepts/prompts/system.md
@@ -1,0 +1,59 @@
+You are the Concept Generator for the PDF Product Pipeline — an autonomous system that
+ships sellable PDF products to Gumroad daily.
+
+Your job: given a single niche, produce a diverse batch of distinct, commercially
+viable PDF product concepts that a self-publisher could ship within 24 hours.
+
+## Hard rules
+
+1. Output JSON ONLY. No prose before or after. No Markdown fences. No commentary.
+2. The top-level value must be an object with a single key `concepts` whose value
+   is an array of EXACTLY the requested number of concept objects (default 20).
+3. Every field listed below is REQUIRED on every concept. Do not omit fields.
+4. Do not repeat or near-duplicate any concept. Titles, subtitles, hooks, and
+   TOCs must each be materially different.
+5. Vary the `format` field across the batch — at minimum 5 distinct format values
+   must appear. Allowed values: planner, workbook, guide, checklist, ebook,
+   template-pack, journal, course.
+6. Stay strictly inside the supplied niche. Do not invent adjacent niches.
+7. No medical, legal, or financial promises that imply professional advice.
+   No claims of guaranteed income, cures, or outcomes.
+8. No copyrighted character names, no celebrity names, no brand impersonation.
+
+## Concept object schema
+
+```
+{
+  "title":         string  // < 60 chars, buyer-grabbing, no clickbait
+  "subtitle":      string  // one sentence value prop
+  "format":        string  // one of the 8 allowed formats above
+  "target_buyer":  string  // one-line persona ("Busy parent who...")
+  "toc":           string[] // 6-15 section titles, ordered, no numbering prefix
+  "hook":          string  // 2-3 sentence Gumroad listing first paragraph; ends on a benefit
+  "price_usd":     number  // realistic Gumroad price; whole or .99/.97 endings; typical 7-49
+  "tags":          string[] // 5-10 SEO tags, lowercase, no '#'
+  "cover_prompt":  string  // text-to-image prompt for the cover (see contract below)
+}
+```
+
+## cover_prompt contract
+
+A single English paragraph (40-80 words) suitable for a text-to-image model.
+Must include: subject / focal imagery, color palette, mood, layout intent
+("centered title block top third", etc.), and style descriptors (e.g. "flat
+vector", "soft watercolor", "modern editorial"). Do NOT include the literal
+title text — the cover-designer module composites the title separately.
+Avoid named artists, copyrighted styles, photorealistic faces of real people.
+
+## Quality bar
+
+- Titles read like products that already sell on Gumroad — concrete benefit or
+  outcome, not generic ("The 30-Day X Reset" beats "Guide to X").
+- Hooks open with the reader's problem or aspiration in the first sentence,
+  then state what the PDF delivers, and end with a benefit phrase.
+- TOC titles describe transformation, not topics ("Map your week in 10 minutes"
+  beats "Weekly Planning").
+- Prices reflect format: checklists 7-15, planners/workbooks 15-29, guides/ebooks
+  19-39, template-packs 25-49, courses 29-49.
+
+Return only the JSON object. No other text.

--- a/products/pdf-pipeline/concepts/schema.json
+++ b/products/pdf-pipeline/concepts/schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PDF Pipeline Concept Batch",
+  "description": "Output of products/pdf-pipeline/concepts/generate.mjs — a batch of PDF product concepts for one niche.",
+  "type": "object",
+  "required": ["niche", "generated_at", "count", "concepts"],
+  "additionalProperties": true,
+  "properties": {
+    "niche": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "model_used": {
+      "type": "string"
+    },
+    "concepts": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/concept" }
+    }
+  },
+  "definitions": {
+    "concept": {
+      "type": "object",
+      "required": [
+        "title",
+        "subtitle",
+        "format",
+        "target_buyer",
+        "toc",
+        "hook",
+        "price_usd",
+        "tags",
+        "cover_prompt"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 59
+        },
+        "subtitle": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 200
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "planner",
+            "workbook",
+            "guide",
+            "checklist",
+            "ebook",
+            "template-pack",
+            "journal",
+            "course"
+          ]
+        },
+        "target_buyer": {
+          "type": "string",
+          "minLength": 5,
+          "maxLength": 200
+        },
+        "toc": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 15,
+          "items": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 120
+          }
+        },
+        "hook": {
+          "type": "string",
+          "minLength": 30,
+          "maxLength": 600
+        },
+        "price_usd": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 199
+        },
+        "tags": {
+          "type": "array",
+          "minItems": 5,
+          "maxItems": 10,
+          "items": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 40
+          }
+        },
+        "cover_prompt": {
+          "type": "string",
+          "minLength": 30,
+          "maxLength": 800
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `products/pdf-pipeline/concepts/` — the Concept Generator stage of the PDF Product Pipeline.
- CLI `generate.mjs` takes `--niche` (or reads `state/top-niches.json`) and emits `state/concepts-{YYYY-MM-DD}.json` with 20 distinct, validated PDF product concepts (title, subtitle, format, target_buyer, toc, hook, price_usd, tags, cover_prompt).
- Uses the existing `scripts/openrouter-routing.js` `cheap_batch_edits` profile in a single batched call. On invalid JSON, retries once with a "JSON only" reminder; if still invalid, writes diagnostics to `state/concepts-failed-{date}.json` and exits 1.

## Files

- `products/pdf-pipeline/concepts/generate.mjs` — CLI (Node, ESM).
- `products/pdf-pipeline/concepts/prompts/system.md` — system prompt enforcing JSON-only, format variety, no duplicates.
- `products/pdf-pipeline/concepts/schema.json` — JSON Schema for the output batch (also enforced procedurally in `generate.mjs`).
- `products/pdf-pipeline/concepts/README.md` — contract, env vars, example output, downstream consumers.
- `products/pdf-pipeline/state/.gitkeep` — pipeline state directory.

## Stays in lane

This module does not touch research, PDF rendering, covers, upload, or analytics. It only converts a niche into a validated batch of concept specs that downstream modules consume.

## Test plan

- [x] `node products/pdf-pipeline/concepts/generate.mjs --dry-run --niche "Bullet journaling for ADHD adults"` prints prompts and exits 0.
- [x] Missing `--niche` and missing `state/top-niches.json` exits 2 with usage.
- [ ] With `OPENROUTER_API_KEY` set: end-to-end run produces a valid `concepts-{date}.json` that parses against `schema.json`.
- [ ] Synthetic "invalid JSON" upstream response routes to one retry and then writes `concepts-failed-{date}.json` with exit 1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds the **Concept Generator** stage to the PDF Product Pipeline, a new module that takes a niche (either via `--niche` flag or from `state/top-niches.json`) and generates 20 distinct, validated PDF product concepts using OpenRouter's cheap batch API. Each concept includes complete specifications (title, subtitle, format, target buyer, table of contents, hook, price, tags, and cover prompt) that downstream pipeline modules (research, cover design, PDF rendering, upload) will consume. The implementation includes robust validation for JSON schema compliance, format variety, title uniqueness, and two-attempt retry logic with diagnostic failure outputs.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `products/pdf-pipeline/concepts/README.md` |
| 2 | `products/pdf-pipeline/concepts/schema.json` |
| 3 | `products/pdf-pipeline/concepts/prompts/system.md` |
| 4 | `products/pdf-pipeline/concepts/generate.mjs` |
| 5 | `products/pdf-pipeline/state/.gitkeep` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Concept Generator stage for the PDF Product Pipeline to produce 20 validated PDF product concepts per niche in a single OpenRouter call, writing to `products/pdf-pipeline/state/concepts-{YYYY-MM-DD}.json` with a retry-and-diagnostics path on failures. This provides consistent, variety-checked inputs for downstream research, cover, rendering, and upload stages.

- **New Features**
  - CLI `products/pdf-pipeline/concepts/generate.mjs`: `--niche`, or read `state/top-niches.json`; `--count`, `--out`, `--dry-run`; exits 0/1/2; requires `OPENROUTER_API_KEY` unless `--dry-run`.
  - Validation via `schema.json` and code: field constraints, unique titles, and ≥5 formats across batches ≥10.
  - Prompting/routing: `prompts/system.md` (JSON-only, variety, no dupes) and `scripts/openrouter-routing.js` profile `cheap_batch_edits`; retries once on invalid JSON; writes `state/concepts-failed-{date}.json`.
  - Docs and state scaffolding: `README.md` and `products/pdf-pipeline/state/.gitkeep`.

<sup>Written for commit ee1e74303300c70b31213ca30b9240e10ac86dca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

