### PR TITLE
credential modules: registry + on/off flags + system prompt

### DIFF
--- a/config/credential-modules.yml
+++ b/config/credential-modules.yml
@@ -1,0 +1,75 @@
+# Credential gate + Doppler + backup processes — the two modules,
+# both individually flippable via `enabled: true|false`. Workflows
+# read this file via `scripts/credential-module-check.sh` and skip
+# their run when the relevant module is disabled.
+#
+# Source of truth for workflow gating. Mirrors the DDL in
+# `schemas/credential_modules.sql` if you want to back this with
+# a real database table.
+#
+# System prompt for any LLM editing this file:
+#   docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md
+# Contract:
+#   docs/CREDENTIAL_MODULE_STANDARD.md
+
+modules:
+
+  - id: credential-gate
+    description: >-
+      Enforces deletion protection and existence checks on critical
+      repo secrets (OPENROUTER_API_KEY, ADMIN_GITHUB_TOKEN, DOPPLER_TOKEN,
+      GITHUB_TOKEN, etc.). Blocks accidental secret deletion and writes
+      audit issues when a delete is attempted.
+    enabled: true
+    governs_workflows:
+      - .github/workflows/secret-persistence-guard.yml  # protect-critical-secrets job
+      - .github/workflows/credential-gatekeeper.yml
+    governs_scripts:
+      - scripts/gatekeeper-cli.sh
+    last_changed: 2026-06-20
+    change_reason: initial-modularization
+    rollback_steps:
+      - "Set enabled: false in this file."
+      - "Push to main. Next workflow run reads false → skips gate."
+
+  - id: doppler-recover
+    description: >-
+      Pulls missing repo secrets back from Doppler when the monitor
+      finds them empty. KEPT OFF until Doppler is reconciled with the
+      live GitHub secret values — when stale, this loop overwrites
+      freshly-set tokens with old ones.
+    enabled: false
+    governs_workflows:
+      - .github/workflows/secret-persistence-guard.yml  # auto-recover job
+      - .github/workflows/secrets-sentinel.yml          # heal step
+      - .github/workflows/gatekeeper-rotate.yml
+      - .github/workflows/secret-rotation-schedule.yml
+      - .github/workflows/doppler-secrets-sync.yml
+    governs_scripts:
+      - scripts/gatekeeper-sync.sh
+      - scripts/credential-autonomy-agent.js
+      - scripts/auto-credential-fetcher.js
+      - scripts/auto-sync-credentials.js
+    last_changed: 2026-06-20
+    change_reason: initial-modularization (stays off until Doppler is reconciled)
+    rollback_steps:
+      - "Reconcile Doppler with current GitHub secret values FIRST."
+      - "Set enabled: true in this file."
+      - "Run secret-persistence-guard via workflow_dispatch once with dry_run."
+
+  - id: credential-backup-harness
+    description: >-
+      Non-Doppler fallback: reads CREDENTIAL_BACKUP_JSON / SOPS / pass /
+      Bitwarden / 1Password / Infisical / Vault and restores any
+      missing secret. Runs when doppler-recover is off OR Doppler fails.
+    enabled: true
+    governs_workflows:
+      - .github/workflows/secret-persistence-guard.yml  # auto-recover backup-harness path
+      - .github/workflows/secrets-sentinel.yml
+    governs_scripts:
+      - scripts/credential-backup-harness.js
+    last_changed: 2026-06-20
+    change_reason: initial-modularization (kept on as the safe default fallback)
+    rollback_steps:
+      - "Set enabled: false in this file."
+      - "Push to main. Next workflow run reads false → skips harness."

--- a/config/credential-modules.yml
+++ b/config/credential-modules.yml
@@ -1,7 +1,7 @@
-# Credential gate + Doppler + backup processes — the two modules,
-# both individually flippable via `enabled: true|false`. Workflows
-# read this file via `scripts/credential-module-check.sh` and skip
-# their run when the relevant module is disabled.
+# Credential subsystem — three independently flippable modules,
+# each toggled via `enabled: true|false`. Workflows read this file
+# via `scripts/credential-module-check.sh` and skip their run when
+# the relevant module is disabled.
 #
 # Source of truth for workflow gating. Mirrors the DDL in
 # `schemas/credential_modules.sql` if you want to back this with

--- a/docs/CREDENTIAL_MODULE_STANDARD.md
+++ b/docs/CREDENTIAL_MODULE_STANDARD.md
@@ -52,8 +52,9 @@ disables protection.
    module in the same commit.
 3. If you have the DB backend in use, append an
    `INSERT INTO credential_modules_audit (...)` row reflecting the flip.
-4. Open a PR; the `agent-fingerprint-gate` + `auditor-controller`
-   workflows will run.
+4. Open a PR. The `agent-fingerprint-gate` workflow (landed in PR #14684)
+   runs on changed files. The `auditor-controller` workflow (proposed in
+   PR #14679) will also gate this surface once that PR merges.
 
 ## Re-enabling `doppler-recover` (special case)
 
@@ -82,13 +83,13 @@ GitHub secrets via the auto-recover loop. Re-enable only after:
 
 ## Auditor coverage
 
-The auditor in `scripts/auditor-controller.js` (PR #14679) already
-checks:
+`scripts/auditor-controller.js` (proposed in PR #14679; not yet on `main`)
+will check:
 
 - `doppler-disabled` — kill switches present in
   `secret-persistence-guard.yml` and `secrets-sentinel.yml`.
 - `doppler-spread` — no new Doppler call sites outside the allowlist.
 
-A future assertion can read this YAML and verify that every workflow
-listed under a module's `governs_workflows` actually calls
-`credential-module-check.sh` with the right id.
+Once that lands, a follow-up assertion can read this YAML and verify
+that every workflow listed under a module's `governs_workflows` actually
+calls `credential-module-check.sh` with the right id.

--- a/docs/CREDENTIAL_MODULE_STANDARD.md
+++ b/docs/CREDENTIAL_MODULE_STANDARD.md
@@ -1,0 +1,94 @@
+# Credential Module Standard
+
+The credential subsystem is split into **three independently flippable
+modules**:
+
+| ID | What it does | Default |
+|----|--------------|---------|
+| `credential-gate` | Blocks deletion of critical secrets; logs audit issues. | `enabled: true` |
+| `doppler-recover` | Pulls missing secrets from Doppler. **Off until Doppler is reconciled.** | `enabled: false` |
+| `credential-backup-harness` | Non-Doppler fallback: `CREDENTIAL_BACKUP_JSON` / SOPS / pass / Bitwarden / 1Password / Infisical / Vault. | `enabled: true` |
+
+## Where the flag lives
+
+- **File source of truth**: [`config/credential-modules.yml`](../config/credential-modules.yml)
+- **Database source of truth** (optional): [`schemas/credential_modules.sql`](../schemas/credential_modules.sql)
+- **System prompt** for LLMs editing this surface: [`docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md`](prompts/LLM/credentialgate/SYSTEM_PROMPT.md)
+
+If you keep both: pick one as source of truth, and sync the other from
+it. The workflows read the YAML (no DB needed in CI).
+
+## How a workflow gates itself on a module
+
+Every workflow path that does credential work must call the gate as its
+first active step:
+
+```yaml
+- name: Skip if <module-id> is disabled
+  id: gate
+  run: |
+    if ! bash scripts/credential-module-check.sh <module-id>; then
+      echo "::notice::<module-id> module is disabled; skipping."
+      exit 0
+    fi
+```
+
+`scripts/credential-module-check.sh` returns:
+
+| Exit | Meaning |
+|------|---------|
+| `0` | Module enabled — proceed. |
+| `78` | Module disabled — skip cleanly. |
+| `2` | Usage error (bad arg). |
+
+If `config/credential-modules.yml` is missing the helper **fails open**
+(treats the module as enabled) so a corrupted config never silently
+disables protection.
+
+## Flipping a module
+
+1. Edit the `enabled:` flag in `config/credential-modules.yml`.
+2. Update `last_changed`, `change_reason`, and `rollback_steps` for that
+   module in the same commit.
+3. If you have the DB backend in use, append an
+   `INSERT INTO credential_modules_audit (...)` row reflecting the flip.
+4. Open a PR; the `agent-fingerprint-gate` + `auditor-controller`
+   workflows will run.
+
+## Re-enabling `doppler-recover` (special case)
+
+The reason it's off: stale Doppler values used to overwrite freshly-set
+GitHub secrets via the auto-recover loop. Re-enable only after:
+
+1. Verify each secret listed under the module in Doppler matches the
+   current GitHub Secret value.
+2. Document the reconciliation in the PR body
+   (e.g. "verified OPENROUTER_API_KEY, ADMIN_GITHUB_TOKEN, DOPPLER_TOKEN
+   match in Doppler vs GitHub as of `<timestamp>`").
+3. Flip `enabled: true`, push, and run `secret-persistence-guard.yml`
+   manually with `dry_run: true` once to confirm no overwrite would
+   happen.
+
+## Adding a new credential module
+
+1. Add a new entry to `config/credential-modules.yml` with a clear
+   `description`, starting `enabled: false`, and the workflows /
+   scripts it governs.
+2. Add a matching `INSERT INTO credential_modules` row to
+   `schemas/credential_modules.sql`.
+3. Add a row to the table in this doc.
+4. Have every workflow path it governs call
+   `scripts/credential-module-check.sh <new-id>` first.
+
+## Auditor coverage
+
+The auditor in `scripts/auditor-controller.js` (PR #14679) already
+checks:
+
+- `doppler-disabled` — kill switches present in
+  `secret-persistence-guard.yml` and `secrets-sentinel.yml`.
+- `doppler-spread` — no new Doppler call sites outside the allowlist.
+
+A future assertion can read this YAML and verify that every workflow
+listed under a module's `governs_workflows` actually calls
+`credential-module-check.sh` with the right id.

--- a/docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md
+++ b/docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md
@@ -80,7 +80,7 @@ You are working on the credential-management subsystem of
 | Workflow gate helper | `scripts/credential-module-check.sh` |
 | Doppler-using workflows | listed under `doppler-recover.governs_workflows` in the YAML |
 | Backup harness | `scripts/credential-backup-harness.js` |
-| Auditor that watches this surface | `scripts/auditor-controller.js` (PR #14679) |
+| Auditor that watches this surface | `scripts/auditor-controller.js` (proposed in PR #14679 — not yet on `main`) |
 
 ## What to output
 

--- a/docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md
+++ b/docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md
@@ -1,0 +1,94 @@
+# System prompt — Credential Gate / Doppler / Backup Harness work
+
+Use this as the system prompt when sending **any** task touching the
+credential gate, Doppler recover, or backup harness modules to an LLM
+(Claude, OpenRouter persona, Devin, Cursor, etc.). Copy verbatim.
+
+---
+
+You are working on the credential-management subsystem of
+`midnghtsapphire/revvel-standards`. The single source of truth is:
+
+- **`config/credential-modules.yml`** — the registry of three modules
+  (`credential-gate`, `doppler-recover`, `credential-backup-harness`),
+  each with an `enabled: true|false` flag.
+- **`schemas/credential_modules.sql`** — DDL that mirrors the YAML if
+  the user backs the flags with a database.
+- **`docs/CREDENTIAL_MODULE_STANDARD.md`** — the contract.
+- **`scripts/credential-module-check.sh`** — the helper workflows call
+  to decide whether to skip themselves.
+
+## Hard rules — do not violate
+
+1. **Never overwrite a freshly-set GitHub secret with a stale Doppler
+   value.** This is the bug that wasted the user's weeks of recovery.
+   The `doppler-recover` flag must remain `false` until the user
+   confirms Doppler is reconciled.
+
+2. **Add, do not replace.** The user has rebuilt the credential
+   gatekeeper many times across sessions because prior agents rewrote
+   it from scratch instead of finishing existing work. Read
+   `config/credential-modules.yml` first. Extend it. Do not start over.
+
+3. **Modules are independently flippable.** Never wire `credential-gate`
+   so that disabling it also disables the backup harness, or vice
+   versa. Each module's `enabled` flag must independently kill its own
+   workflow paths.
+
+4. **Every workflow path governed by a module must call
+   `scripts/credential-module-check.sh <module-id>` as its first
+   active step and exit 0 if the check reports disabled.** No new
+   credential workflow merges without this guard.
+
+5. **Doppler is opt-in, not default.** Any new code that talks to
+   Doppler must check `doppler-recover.enabled` first AND be listed in
+   that module's `governs_workflows` or `governs_scripts` array.
+
+6. **Add to the audit log.** Any code change that flips an `enabled`
+   flag must include a one-line `change_reason` and a `rollback_steps`
+   list in the YAML (and an audit row in the SQL table if the DB
+   backend is in use).
+
+## Soft rules — strong preference
+
+- One concern per PR. A Doppler-recover fix should not also touch the
+  gate or the harness.
+- No new credential-management workflows without a corresponding entry
+  in `config/credential-modules.yml`. If you add a workflow that
+  reads/writes secrets, add it to an existing module's
+  `governs_workflows` list or create a new module entry (with a clear
+  `description` and starting `enabled: false`).
+- Re-enabling `doppler-recover` requires a documented reconciliation
+  step in the PR body ("verified Doppler holds current values for
+  X, Y, Z secrets as of `<timestamp>`").
+
+## Tone and shape
+
+- Be terse. The user pays per token.
+- Do not ask clarifying questions if a default is documented above.
+- Do not propose new abstractions. Use the YAML + SQL shape that
+  exists.
+- Do not paste this system prompt back in your response.
+
+## Where things live
+
+| Concern | Path |
+|---------|------|
+| Module registry (file) | `config/credential-modules.yml` |
+| Module registry (DB) | `schemas/credential_modules.sql` |
+| Standard / contract | `docs/CREDENTIAL_MODULE_STANDARD.md` |
+| Workflow gate helper | `scripts/credential-module-check.sh` |
+| Doppler-using workflows | listed under `doppler-recover.governs_workflows` in the YAML |
+| Backup harness | `scripts/credential-backup-harness.js` |
+| Auditor that watches this surface | `scripts/auditor-controller.js` (PR #14679) |
+
+## What to output
+
+A diff that:
+1. Edits / extends the YAML registry if module state changes.
+2. Edits / extends the SQL DDL or adds a migration if the DB backend is
+   in use.
+3. Adds the module-check guard to any new workflow path it governs.
+4. Updates the relevant module's `last_changed`, `change_reason`,
+   `rollback_steps`.
+5. Nothing else.

--- a/schemas/credential_modules.sql
+++ b/schemas/credential_modules.sql
@@ -17,8 +17,12 @@ CREATE TABLE IF NOT EXISTS credential_modules (
   enabled         BOOLEAN     NOT NULL DEFAULT FALSE,
 
   -- ── What this module governs (string arrays serialized as JSON) ─────
-  governs_workflows  JSONB    NOT NULL DEFAULT '[]'::jsonb,
-  governs_scripts    JSONB    NOT NULL DEFAULT '[]'::jsonb,
+  -- CHECK constraints enforce array shape so non-array payloads (object,
+  -- string, null) can't sneak in. Per cubic review.
+  governs_workflows  JSONB    NOT NULL DEFAULT '[]'::jsonb
+                              CHECK (jsonb_typeof(governs_workflows) = 'array'),
+  governs_scripts    JSONB    NOT NULL DEFAULT '[]'::jsonb
+                              CHECK (jsonb_typeof(governs_scripts) = 'array'),
 
   -- ── Audit ───────────────────────────────────────────────────────────
   last_changed    TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -33,6 +37,23 @@ CREATE TABLE IF NOT EXISTS credential_modules (
 
 CREATE INDEX IF NOT EXISTS idx_credential_modules_enabled
   ON credential_modules (enabled);
+
+-- Per cubic review: keep updated_at fresh on every row update so audit
+-- metadata doesn't go stale. Postgres pattern — replace the function
+-- safely and attach a BEFORE UPDATE trigger.
+CREATE OR REPLACE FUNCTION credential_modules_touch_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS credential_modules_set_updated_at ON credential_modules;
+CREATE TRIGGER credential_modules_set_updated_at
+  BEFORE UPDATE ON credential_modules
+  FOR EACH ROW
+  EXECUTE FUNCTION credential_modules_touch_updated_at();
 
 -- Append-only audit trail of every flip; the main table holds current state.
 CREATE TABLE IF NOT EXISTS credential_modules_audit (

--- a/schemas/credential_modules.sql
+++ b/schemas/credential_modules.sql
@@ -1,0 +1,65 @@
+-- credential_modules — durable on/off flag table for the credential gate,
+-- the Doppler recover process, and the backup harness process.
+--
+-- Mirrors `config/credential-modules.yml`. Workflows read the YAML (no DB
+-- needed in CI); apps with a DB can mirror it here for runtime flips
+-- without a git push. Sync the two periodically OR pick one as source of
+-- truth and treat the other as a cache.
+--
+-- Postgres-flavoured DDL. Adjust types for SQLite / MySQL as needed.
+
+CREATE TABLE IF NOT EXISTS credential_modules (
+  -- ── Identity ─────────────────────────────────────────────────────────
+  id              TEXT        PRIMARY KEY,          -- e.g. 'credential-gate'
+  description     TEXT        NOT NULL,
+
+  -- ── The flag (the whole point of this table) ────────────────────────
+  enabled         BOOLEAN     NOT NULL DEFAULT FALSE,
+
+  -- ── What this module governs (string arrays serialized as JSON) ─────
+  governs_workflows  JSONB    NOT NULL DEFAULT '[]'::jsonb,
+  governs_scripts    JSONB    NOT NULL DEFAULT '[]'::jsonb,
+
+  -- ── Audit ───────────────────────────────────────────────────────────
+  last_changed    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  changed_by      TEXT,                              -- GitHub login of who flipped it
+  change_reason   TEXT,                              -- free text
+  rollback_steps  JSONB       NOT NULL DEFAULT '[]'::jsonb,
+
+  -- ── Provenance ──────────────────────────────────────────────────────
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_credential_modules_enabled
+  ON credential_modules (enabled);
+
+-- Append-only audit trail of every flip; the main table holds current state.
+CREATE TABLE IF NOT EXISTS credential_modules_audit (
+  audit_id        BIGSERIAL   PRIMARY KEY,
+  module_id       TEXT        NOT NULL,
+  enabled_before  BOOLEAN,
+  enabled_after   BOOLEAN     NOT NULL,
+  changed_by      TEXT,
+  change_reason   TEXT,
+  changed_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_credential_modules_audit_module
+  ON credential_modules_audit (module_id, changed_at DESC);
+
+-- Seed the two modules + the backup harness module to match the YAML SSOT.
+INSERT INTO credential_modules (id, description, enabled, change_reason) VALUES
+  ('credential-gate',
+   'Enforces deletion protection and existence checks on critical repo secrets.',
+   TRUE,
+   'initial-modularization'),
+  ('doppler-recover',
+   'Pulls missing repo secrets back from Doppler. OFF until Doppler is reconciled with live GitHub values.',
+   FALSE,
+   'initial-modularization (stays off until reconciled)'),
+  ('credential-backup-harness',
+   'Non-Doppler fallback: CREDENTIAL_BACKUP_JSON / SOPS / pass / Bitwarden / 1Password / Infisical / Vault.',
+   TRUE,
+   'initial-modularization')
+ON CONFLICT (id) DO NOTHING;

--- a/schemas/credential_modules.sql
+++ b/schemas/credential_modules.sql
@@ -48,7 +48,7 @@ CREATE TABLE IF NOT EXISTS credential_modules_audit (
 CREATE INDEX IF NOT EXISTS idx_credential_modules_audit_module
   ON credential_modules_audit (module_id, changed_at DESC);
 
--- Seed the two modules + the backup harness module to match the YAML SSOT.
+-- Seed the three modules to match the YAML SSOT.
 INSERT INTO credential_modules (id, description, enabled, change_reason) VALUES
   ('credential-gate',
    'Enforces deletion protection and existence checks on critical repo secrets.',

--- a/scripts/credential-module-check.sh
+++ b/scripts/credential-module-check.sh
@@ -3,7 +3,12 @@
 #
 # Reads config/credential-modules.yml and exits 0 if the module is
 # enabled (workflow may proceed), 78 if disabled (workflow should
-# skip gracefully), 2 on usage/parse error.
+# skip gracefully), 2 on usage error.
+#
+# Note: parse errors (corrupted YAML, missing config, unknown value)
+# intentionally **fail open** with exit 0 + stderr warning, so a
+# broken config never silently disables protection. Only USAGE errors
+# return 2.
 #
 # Usage in a workflow step:
 #   - name: Skip if doppler-recover module is disabled
@@ -34,19 +39,28 @@ if [[ ! -f "$CONFIG" ]]; then
 fi
 
 # Find the module's `enabled:` value with awk:
-#   - look for `  - id: <module-id>`
+#   - look for `  - id: <module-id>` (strip inline YAML comments + trailing
+#     whitespace before comparing so `- id: foo  # note` still matches)
 #   - then within that record (until the next `  - id:` or EOF),
-#     pick up the first `    enabled: true|false`.
+#     pick up the first `    enabled: true|false` (same strip applied).
+# Per Copilot review: the prior version compared the whole remainder of
+# the line, so an inline comment on either line caused fail-open even
+# when the operator typed `enabled: false  # keep off`.
 ENABLED=$(awk -v want="$MODULE_ID" '
+  function strip(s) {
+    sub(/[[:space:]]*#.*$/, "", s)   # drop inline comment
+    sub(/[[:space:]]+$/, "", s)      # drop trailing whitespace
+    return s
+  }
   BEGIN { inblock = 0 }
   /^  - id:[[:space:]]+/ {
     sub(/^  - id:[[:space:]]+/, "", $0)
-    inblock = ($0 == want) ? 1 : 0
+    inblock = (strip($0) == want) ? 1 : 0
     next
   }
   inblock && /^    enabled:[[:space:]]+/ {
     sub(/^    enabled:[[:space:]]+/, "", $0)
-    print $0
+    print strip($0)
     exit
   }
 ' "$CONFIG")

--- a/scripts/credential-module-check.sh
+++ b/scripts/credential-module-check.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# credential-module-check.sh — workflow gate.
+#
+# Reads config/credential-modules.yml and exits 0 if the module is
+# enabled (workflow may proceed), 78 if disabled (workflow should
+# skip gracefully), 2 on usage/parse error.
+#
+# Usage in a workflow step:
+#   - name: Skip if doppler-recover module is disabled
+#     id: gate
+#     run: |
+#       if ! bash scripts/credential-module-check.sh doppler-recover; then
+#         echo "::notice::doppler-recover module is disabled; skipping."
+#         echo "skip=true" >> "$GITHUB_OUTPUT"
+#         exit 0
+#       fi
+#       echo "skip=false" >> "$GITHUB_OUTPUT"
+#
+# No yq / no jq required — pure POSIX awk over the YAML.
+
+set -euo pipefail
+
+MODULE_ID="${1:-}"
+if [[ -z "$MODULE_ID" ]]; then
+  echo "usage: $0 <module-id>" >&2
+  echo "  module-id: credential-gate | doppler-recover | credential-backup-harness" >&2
+  exit 2
+fi
+
+CONFIG="${CREDENTIAL_MODULES_CONFIG:-config/credential-modules.yml}"
+if [[ ! -f "$CONFIG" ]]; then
+  echo "credential-module-check: $CONFIG not found; treating $MODULE_ID as ENABLED (fail-open)" >&2
+  exit 0
+fi
+
+# Find the module's `enabled:` value with awk:
+#   - look for `  - id: <module-id>`
+#   - then within that record (until the next `  - id:` or EOF),
+#     pick up the first `    enabled: true|false`.
+ENABLED=$(awk -v want="$MODULE_ID" '
+  BEGIN { inblock = 0 }
+  /^  - id:[[:space:]]+/ {
+    sub(/^  - id:[[:space:]]+/, "", $0)
+    inblock = ($0 == want) ? 1 : 0
+    next
+  }
+  inblock && /^    enabled:[[:space:]]+/ {
+    sub(/^    enabled:[[:space:]]+/, "", $0)
+    print $0
+    exit
+  }
+' "$CONFIG")
+
+case "${ENABLED:-}" in
+  true)
+    exit 0
+    ;;
+  false)
+    exit 78
+    ;;
+  "")
+    echo "credential-module-check: module '$MODULE_ID' not found in $CONFIG; fail-open (ENABLED)" >&2
+    exit 0
+    ;;
+  *)
+    echo "credential-module-check: unexpected 'enabled' value '$ENABLED' for '$MODULE_ID'; fail-open" >&2
+    exit 0
+    ;;
+esac

--- a/tests/credential-module-check.test.sh
+++ b/tests/credential-module-check.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# tests/credential-module-check.test.sh — exercise the safety contract
+# of scripts/credential-module-check.sh.
+#
+# Run from repo root:
+#   bash tests/credential-module-check.test.sh
+#
+# Exits 0 if all cases pass, 1 on any failure. Per cubic + Copilot
+# review on PR #14688: this script gates credential workflows, so a
+# small regression suite around enabled/disabled/missing/unknown/
+# inline-comment paths is worth its weight.
+
+set -u
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/scripts/credential-module-check.sh"
+PASS=0
+FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ── Fixture: a minimal but representative config ─────────────────────────────
+cat > "$TMP/config.yml" <<'YAML'
+modules:
+
+  - id: enabled-mod
+    description: present and enabled
+    enabled: true
+
+  - id: disabled-mod
+    description: present and disabled
+    enabled: false
+
+  - id: commented-disabled
+    description: disabled with inline comment (regression for the bug we just fixed)
+    enabled: false  # keep off until reconciled
+
+  - id: commented-enabled  # inline comment on the id line itself
+    description: enabled with inline comment on the id
+    enabled: true
+YAML
+
+# ── Test harness ────────────────────────────────────────────────────────────
+assert_exit() {
+  # assert_exit <expected_code> <description> -- <command...>
+  local expected="$1"; shift
+  local desc="$1"; shift
+  [[ "$1" == "--" ]] && shift
+  local got
+  "$@" >/dev/null 2>&1
+  got=$?
+  if [[ "$got" == "$expected" ]]; then
+    echo "  ✓ $desc (exit $got)"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $desc (expected $expected, got $got)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== credential-module-check.sh contract tests ==="
+
+# 1. Usage error returns 2
+assert_exit 2 "no args → exit 2 (usage)" -- bash "$SCRIPT"
+
+# 2. Enabled module returns 0
+CREDENTIAL_MODULES_CONFIG="$TMP/config.yml" \
+  assert_exit 0 "enabled module → exit 0" -- bash "$SCRIPT" enabled-mod
+
+# 3. Disabled module returns 78
+CREDENTIAL_MODULES_CONFIG="$TMP/config.yml" \
+  assert_exit 78 "disabled module → exit 78" -- bash "$SCRIPT" disabled-mod
+
+# 4. Disabled with INLINE COMMENT — the bug Copilot caught
+CREDENTIAL_MODULES_CONFIG="$TMP/config.yml" \
+  assert_exit 78 "disabled with inline comment → exit 78 (no fail-open)" -- bash "$SCRIPT" commented-disabled
+
+# 5. Enabled module with INLINE COMMENT on the id line
+CREDENTIAL_MODULES_CONFIG="$TMP/config.yml" \
+  assert_exit 0 "enabled with inline comment on id → exit 0" -- bash "$SCRIPT" commented-enabled
+
+# 6. Unknown module → fail-open (exit 0) per documented safety contract
+CREDENTIAL_MODULES_CONFIG="$TMP/config.yml" \
+  assert_exit 0 "unknown module → fail-open exit 0" -- bash "$SCRIPT" not-in-config
+
+# 7. Missing config file → fail-open
+CREDENTIAL_MODULES_CONFIG="$TMP/does-not-exist.yml" \
+  assert_exit 0 "missing config → fail-open exit 0" -- bash "$SCRIPT" enabled-mod
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "passed: $PASS  failed: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Why

Per your `/odragnet` comment on PR #14679:

> we need to modularize both the gate credential doppler process and the back up process. Create database tables with a flag to turn off or on both processes. Create a system prompt for all this and put in revvel-standards/docs/prompts/LLM/credentialgate/

`/odragnet` isn't wired yet, so doing the work directly.

## What

Three independently flippable modules, each with an `enabled: true|false` flag:

| Module | Default | What it gates |
|--------|---------|---------------|
| `credential-gate` | **on** | Deletion protection + existence checks |
| `doppler-recover` | **off** | Pulls from Doppler (stays off until reconciled — the stale-overwrite bug) |
| `credential-backup-harness` | **on** | `CREDENTIAL_BACKUP_JSON` / SOPS / pass / Bitwarden / 1Password / Infisical / Vault |

### Files

| Path | Purpose |
|------|---------|
| `config/credential-modules.yml` | The runtime registry — the "table" workflows can read in CI (no DB needed) |
| `schemas/credential_modules.sql` | Postgres DDL mirror + append-only `credential_modules_audit` table for the optional DB backend |
| `scripts/credential-module-check.sh` | Pure POSIX awk gate helper — exit `0` enabled, `78` disabled, `2` usage error; **fails open** on missing config so a corrupted file never silently disables protection |
| `docs/CREDENTIAL_MODULE_STANDARD.md` | The contract: where the flag lives, how to flip, how to add a new module, special-case for re-enabling Doppler safely |
| `docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md` | Verbatim system prompt for any LLM working on this surface — hard rules (don't overwrite fresh secrets, add don't replace, modules independently flippable) |

### How a workflow gates itself

```yaml
- name: Skip if <module-id> is disabled
  run: |
    if ! bash scripts/credential-module-check.sh <module-id>; then
      echo "::notice::<module-id> module is disabled; skipping."
      exit 0
    fi
```

## Verified

```
$ bash scripts/credential-module-check.sh credential-gate           ; echo $?
0
$ bash scripts/credential-module-check.sh doppler-recover           ; echo $?
78
$ bash scripts/credential-module-check.sh credential-backup-harness ; echo $?
0
$ bash scripts/credential-module-check.sh bogus-module 2>&1         ; echo $?
fail-open (ENABLED)
0
```

## Scope

No workflow changes in this PR — the helper + registry + standard + system prompt land cleanly. Wiring the existing `secret-persistence-guard.yml`, `secrets-sentinel.yml`, `gatekeeper-rotate.yml` etc. to call the check is a follow-up so this PR stays reviewable.

## Notes

The system prompt at `docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md` is meant to be copy-pasted verbatim into any agent's system prompt when sending it credential-gate / Doppler / harness work. Stops the "agent built it from scratch again" pattern by giving every model the same contract.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnDB4t4i3hnTDgPSfnHxEs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a modular credential management system with three independently flippable modules (`credential-gate`, `doppler-recover`, `credential-backup-harness`) controlled by on/off flags in a YAML registry. It provides the infrastructure—a config file, a POSIX shell script for workflow gating, optional Postgres DDL for database-backed flags, comprehensive documentation, and an LLM system prompt—to safely enable or disable credential protection, Doppler sync, and backup harness processes without code changes. The `doppler-recover` module starts disabled to prevent stale Doppler values from overwriting fresh GitHub secrets until reconciliation is complete.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `config/credential-modules.yml` |
| 2 | `docs/CREDENTIAL_MODULE_STANDARD.md` |
| 3 | `scripts/credential-module-check.sh` |
| 4 | `docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md` |
| 5 | `schemas/credential_modules.sql` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modularizes the credential system with on/off flags for `credential-gate`, `doppler-recover`, and `credential-backup-harness`, plus a gate script, registry, system prompt, and a contract test suite for the gate. Hardens the SQL schema with JSONB CHECK constraints and an `updated_at` trigger; no workflow wiring in this PR.

- **New Features**
  - Registry at `config/credential-modules.yml` with `enabled` flags (defaults: gate ON, Doppler OFF, backup harness ON) and governance metadata.
  - Gate helper `scripts/credential-module-check.sh` for CI gating (exit 0 enabled, 78 disabled, 2 usage; fail-open on missing/invalid config).
  - Postgres DDL mirror and audit trail at `schemas/credential_modules.sql`; docs at `docs/CREDENTIAL_MODULE_STANDARD.md` and system prompt at `docs/prompts/LLM/credentialgate/SYSTEM_PROMPT.md`.
  - Contract tests at `tests/credential-module-check.test.sh` covering usage, enabled/disabled, inline-comment regression, unknown module, and missing config.

- **Bug Fixes**
  - `credential-module-check.sh` strips inline YAML comments and trailing whitespace when reading `id` and `enabled`, preventing `enabled: false  # keep off` from fail-opening.
  - Schema hardening: JSONB CHECK constraints enforce array shape for `governs_workflows`/`governs_scripts`, and a BEFORE UPDATE trigger keeps `updated_at` fresh.
  - Header/docs corrections: “three independently flippable modules,” and clear status notes for `agent-fingerprint-gate` (landed elsewhere) and `auditor-controller` (proposed).

<sup>Written for commit 2db8d8cbfbb3d50e6daa6408423e73b60bae7c92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

