### PR TITLE
Project-type router + Mālama public-mirror kit

### DIFF
--- a/.github/workflows/mirror-malama.yml
+++ b/.github/workflows/mirror-malama.yml
@@ -1,0 +1,65 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# MIRROR MĀLAMA ENGINE → PUBLIC REPO
+# Who: Audrey Evans (midnghtsapphire)
+# When: 2026-06-20
+# Why: Publish the AGPLv3 open-core engine (skills/malama/) so it can serve as
+#      the adoption funnel for oAudrey, without exposing the rest of the repo.
+# What: Syncs ONLY skills/malama/ to a separate public repo. No-ops until the
+#       MALAMA_MIRROR_TOKEN secret and MALAMA_MIRROR_REPO variable are set, so
+#       nothing publishes by accident.
+# ═══════════════════════════════════════════════════════════════════════════
+name: Mirror Mālama Engine
+
+on:
+  workflow_dispatch: {}        # manual trigger
+  push:
+    branches: [main]
+    paths: ["skills/malama/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check mirror is configured
+        id: gate
+        run: |
+          if [ -z "${{ secrets.MALAMA_MIRROR_TOKEN }}" ] || [ -z "${{ vars.MALAMA_MIRROR_REPO }}" ]; then
+            echo "Mirror not configured (set MALAMA_MIRROR_TOKEN secret + MALAMA_MIRROR_REPO var). Skipping."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/checkout@v4
+
+      - name: Secret scan (refuse to publish credentials)
+        if: steps.gate.outputs.go == 'true'
+        run: |
+          if grep -rniE 'sk-[a-z0-9]{20}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|xox[baprs]-|BEGIN [A-Z ]*PRIVATE KEY' skills/malama/; then
+            echo "::error::Credential-shaped string found in skills/malama/ — aborting publish."
+            exit 1
+          fi
+          echo "No credential-shaped strings found."
+
+      - name: Push skills/malama → public repo
+        if: steps.gate.outputs.go == 'true'
+        env:
+          TOKEN: ${{ secrets.MALAMA_MIRROR_TOKEN }}
+          TARGET: ${{ vars.MALAMA_MIRROR_REPO }}   # e.g. midnghtsapphire/malama
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          cp -R skills/malama/. "$tmp"/
+          cd "$tmp"
+          git init -b main
+          git config user.name  "oAudrey Mirror Bot"
+          git config user.email "angelreporters@gmail.com"
+          git add .
+          git commit -m "Sync Mālama engine from revvel-standards@${GITHUB_SHA:0:7}"
+          git push --force "https://x-access-token:${TOKEN}@github.com/${TARGET}.git" main
+          echo "Mirrored to https://github.com/${TARGET}"

--- a/.github/workflows/mirror-malama.yml
+++ b/.github/workflows/mirror-malama.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Secret scan (refuse to publish credentials)
         if: steps.gate.outputs.go == 'true'
         run: |
-          if grep -rniE 'sk-[a-z0-9]{20}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|xox[baprs]-|BEGIN [A-Z ]*PRIVATE KEY' skills/malama/; then
-            echo "::error::Credential-shaped string found in skills/malama/ — aborting publish."
+          # -l lists only matching FILE PATHS, never the matched content, so a
+          # real credential is never leaked into the Actions logs.
+          if grep -rliE 'sk-[a-z0-9]{20}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|xox[baprs]-|BEGIN [A-Z ]*PRIVATE KEY' skills/malama/ > /tmp/secret_hits; then
+            echo "::error::Credential-shaped string found in skills/malama/ — aborting publish. Offending files:"
+            cat /tmp/secret_hits
             exit 1
           fi
           echo "No credential-shaped strings found."

--- a/docs/AUTOMATION_AUDIT.md
+++ b/docs/AUTOMATION_AUDIT.md
@@ -364,3 +364,21 @@ Two core self-healing workflows were silently failing on every run because of
 The recurring gotchas behind these (gh repo target without checkout, gh auth,
 job permissions, shell injection) are now documented in `CLAUDE.md` so future
 agents don't re-discover them.
+
+---
+
+## Update — June 20, 2026: Mālama engine mirror workflow
+
+Added **`.github/workflows/mirror-malama.yml`** as part of the oAudrey open-core
+rollout. It syncs ONLY the AGPLv3 engine directory `skills/malama/` to a separate
+public repo, so the open core can act as an adoption funnel without exposing the
+rest of the proprietary repo.
+
+Safety properties:
+- **No-ops by default** — does nothing unless both the `MALAMA_MIRROR_TOKEN`
+  secret and the `MALAMA_MIRROR_REPO` variable are configured, so nothing
+  publishes by accident.
+- **Refuses to publish credentials** — runs a secret scan over `skills/malama/`
+  and fails the job if a credential-shaped string is found.
+- Triggers: `workflow_dispatch` (manual) and `push` to `main` touching
+  `skills/malama/**`. Companion local tool: `scripts/publish-malama.sh`.

--- a/scripts/publish-malama.sh
+++ b/scripts/publish-malama.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# publish-malama.sh — extract the open-core Mālama engine into a clean,
+# standalone, publishable directory (ready to push to a PUBLIC repo).
+#
+# This does NOT publish anything by itself. It copies skills/malama/ into a
+# dist dir, verifies it's secret-free, and prints the exact git commands to
+# create the public repo when YOU decide to.
+#
+# Usage:
+#   scripts/publish-malama.sh [dest_dir]      # default: ./dist/malama
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$REPO_ROOT/skills/malama"
+DEST="${1:-$REPO_ROOT/dist/malama}"
+
+echo "→ Source : $SRC"
+echo "→ Dest   : $DEST"
+
+if [[ ! -d "$SRC" ]]; then
+  echo "✗ $SRC not found" >&2; exit 1
+fi
+
+# 1. Secret scan — refuse to package if anything looks like a credential.
+echo "→ Scanning for secrets…"
+if grep -rniE 'sk-[a-z0-9]{20}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----' "$SRC"; then
+  echo "✗ Potential secret found in skills/malama/ — aborting. Remove it before publishing." >&2
+  exit 2
+fi
+echo "  ✓ no credential-shaped strings found"
+
+# 2. Stage a clean copy.
+rm -rf "$DEST"
+mkdir -p "$DEST"
+cp -R "$SRC"/. "$DEST"/
+
+# 3. Make README the front page (LICENSE already inside).
+[[ -f "$DEST/README.md" ]] || echo "⚠ no README.md in package"
+
+echo
+echo "✓ Packaged Mālama engine at: $DEST"
+echo "  Contents:"
+( cd "$DEST" && ls -1 )
+
+cat <<EOF
+
+Next step — publish when ready (this script intentionally does NOT do it):
+
+  cd "$DEST"
+  git init -b main
+  git add .
+  git commit -m "Mālama — open self-evolving agent engine (AGPL-3.0)"
+  # create an EMPTY public repo first, then:
+  git remote add origin git@github.com:<you>/malama.git
+  git push -u origin main
+
+Reminder: AGPL publication is effectively irreversible. Confirm the secret
+scan above passed and that this is the version you want public.
+EOF

--- a/scripts/publish-malama.sh
+++ b/scripts/publish-malama.sh
@@ -23,8 +23,12 @@ fi
 
 # 1. Secret scan — refuse to package if anything looks like a credential.
 echo "→ Scanning for secrets…"
-if grep -rniE 'sk-[a-z0-9]{20}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----' "$SRC"; then
-  echo "✗ Potential secret found in skills/malama/ — aborting. Remove it before publishing." >&2
+# -l lists only matching FILE PATHS, never the matched content, so a real
+# credential is never echoed to stdout/CI logs.
+hits="$(grep -rliE 'sk-[a-z0-9]{20}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY-----' "$SRC" || true)"
+if [ -n "$hits" ]; then
+  echo "✗ Potential secret found in these files — aborting (remove before publishing):" >&2
+  echo "$hits" >&2
   exit 2
 fi
 echo "  ✓ no credential-shaped strings found"

--- a/skills/SKILLS_INDEX.yml
+++ b/skills/SKILLS_INDEX.yml
@@ -111,6 +111,20 @@ skills:
       - "agent operating loop"
       - "session constitution"
 
+  - name: project_router
+    title: "Project Router — Auto-Load the Right Master Docs by Project Type"
+    version: "1.0.0"
+    path: "skills/project-router/"
+    skill_file: "skills/project-router/project-router.skill.yml"
+    category: "Agent Operations"
+    access: all
+    triggers:
+      - "project router"
+      - "detect project type"
+      - "which standard"
+      - "shape router"
+      - "session start router"
+
   - name: gbrain
     title: "GBrain — Persistent Agent Memory"
     version: "1.0.0"

--- a/skills/malama/README.md
+++ b/skills/malama/README.md
@@ -1,0 +1,53 @@
+# Mālama 🌺 — the open self-evolving agent engine
+
+> *Mālama* (Hawaiian): **to care for, to steward, to maintain.**
+
+Mālama is a small, model-agnostic operating constitution for an autonomous
+engineering agent. It plans, executes in verifiable steps, recovers from its own
+failures, rewrites its own tactics to improve, and remembers what it learned
+between sessions — without inventing results.
+
+It is the **open core** of [**oAudrey**](https://oaudrey.com), the automation hub
+from **Freedom Angel Corp**. Self-host Mālama free, or let oAudrey host and run
+it for you.
+
+**oAudrey runs on the Mālama engine.**
+
+---
+
+## What's here
+
+| File | What it is |
+|---|---|
+| [`SYSTEM_PROMPT.md`](./SYSTEM_PROMPT.md) | The drop-in master prompt (paste into any agent runtime / `CLAUDE.md`) |
+| [`SKILL.md`](./SKILL.md) | The skill spec — control loop, self-modification, honesty rules |
+| [`malama.skill.yml`](./malama.skill.yml) | Machine-readable skill config |
+| [`LICENSE`](./LICENSE) | AGPL-3.0-or-later |
+
+## Quickstart
+
+Drop the fenced block from [`SYSTEM_PROMPT.md`](./SYSTEM_PROMPT.md) into your
+agent's system prompt (or a `CLAUDE.md`). That's it — the agent now runs the
+Mālama loop: **Plan → Act → Verify → Learn**, with full self-modification and a
+`learnings.md` memory ledger.
+
+## What makes it different
+
+- **Self-evolving, not just self-healing** — the agent may rewrite its own
+  tactics block to get better, while its identity and the honesty rule stay put.
+- **Honest by construction** — it is explicitly forbidden from fabricating
+  metrics, citations, or success rates. (That rule exists *because* it was
+  distilled from a design that over-claimed; Mālama keeps the engineering and
+  drops the fiction.)
+- **Mission-linked** — a percentage of every paid oAudrey plan funds
+  trafficking-survivor reskilling, recovery, and restoration via Freedom Angel
+  Fighters.
+
+## License
+
+**AGPL-3.0-or-later.** Free to use, modify, and self-host. If you run a modified
+version as a network service, you must publish your source. See
+[`LICENSE`](./LICENSE). The oAudrey hosted product and its vertical agents are
+proprietary to Freedom Angel Corp.
+
+— © 2026 Audrey Evans / Freedom Angel Corp · `angelreporters@gmail.com`

--- a/skills/project-router/SKILL.md
+++ b/skills/project-router/SKILL.md
@@ -1,0 +1,97 @@
+# Skill: Project Router — Auto-Load the Right Master Docs by Project Type
+
+**Skill Name:** `project-router`
+**Version:** 1.0.0
+**Date:** 2026-06-20
+**Status:** Beta
+**Category:** Agent Operations
+**Type:** Session-start detector — runs once, decides what to load
+
+---
+
+## Purpose
+
+At session start, **detect what kind of project the agent is in** and load the
+matching playbook — so the agent reads the *right* standard instead of every
+standard. It is the auto-detect front end for the **Solution-Shape Router**
+already described in `standards/shapes/` and `AUTOMATED_PRODUCT_PIPELINE.md`.
+
+Every project loads the **Mālama** system prompt as a base; on top of that the
+router adds the one `standards/shapes/*` doc that matches the detected shape,
+plus the repo rules (`AGENTS.md`).
+
+> This is the answer to "depending on project type, trigger a different master
+> readme" — different shape, different standard, same Mālama engine underneath.
+
+---
+
+## How It Works
+
+```
+detect.py  ──scans cwd──▶  scores each shape from filesystem signals
+                           ▶ picks the winner (highest score, priority tiebreak)
+                           ▶ prints the docs to load:
+                               skills/malama/SYSTEM_PROMPT.md  (base)
+                               standards/shapes/<SHAPE>.md     (matched)
+                               AGENTS.md                       (repo rules)
+```
+
+| Shape | Detected from | Loads |
+|---|---|---|
+| MCP server | `.mcp.json`, `mcp-servers/`, MCP SDK dep | `standards/shapes/MCP.md` |
+| Agent skill | `*.skill.yml`, `SKILL.md` | `standards/shapes/SKILL.md` |
+| CLI tool | `package.json` `bin`, console_scripts, Cargo `[[bin]]` | `standards/shapes/CLI.md` |
+| API service | express/fastify/fastapi/flask/django, openapi spec | `standards/shapes/API.md` |
+| Full app | next/react/vue/svelte/angular, `index.html` | `standards/shapes/APP.md` |
+| Data | `*.ipynb`, `*.csv/.parquet/.xlsx`, pandas | `standards/shapes/EXCEL.md` |
+| PDF / booklet | `*.tex`, `booklet/` | `standards/shapes/PDF.md` |
+| Infrastructure | Dockerfile/compose, `*.tf` | `standards/DOCKER.md` |
+| *(none)* | no strong signal | `standards/shapes/README.md` |
+
+Routing table is editable in [`routes.yml`](./routes.yml) (mirrored inside
+`detect.py` so the engine stays zero-dependency).
+
+---
+
+## Usage
+
+```bash
+# Human-readable
+python3 skills/project-router/detect.py .
+
+# Machine-readable (for a SessionStart hook)
+python3 skills/project-router/detect.py . --json
+```
+
+### Wire it as a session-start hook (optional)
+
+Add to `.claude/settings.json` so every session auto-detects and reports the
+docs to load:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [ { "type": "command",
+        "command": "python3 skills/project-router/detect.py . --json" } ] }
+    ]
+  }
+}
+```
+
+The agent then reads the three `load` paths before starting work.
+
+---
+
+## Trigger Keywords
+
+```
+project router, detect project type, which standard, shape router,
+what should I load, session start router
+```
+
+## Relationship
+
+- Loads the **[`malama`](../malama/SKILL.md)** system prompt as the base for every shape.
+- Routes into the existing **[`standards/shapes/`](../../standards/shapes/README.md)** docs.
+- Part of the Solution-Shape Router step in `standards/AUTOMATED_PRODUCT_PIPELINE.md`.

--- a/skills/project-router/detect.py
+++ b/skills/project-router/detect.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+project-router / detect.py — Mālama project-type router.
+
+Inspects a working directory, decides which "shape" it is (per
+standards/shapes/), and prints which master docs an agent should load into
+context at session start: always the Mālama system prompt, plus the matching
+shape standard, plus the repo rules.
+
+Zero dependencies (stdlib only) so the open-core engine stays portable.
+The routing table below mirrors routes.yml (kept in sync for human editing).
+
+Usage:
+    python3 detect.py [path]           # human-readable
+    python3 detect.py [path] --json    # machine-readable for hooks
+"""
+
+from __future__ import annotations
+import json
+import os
+import sys
+import glob
+
+# --- Routing table (mirrors routes.yml) -----------------------------------
+# Each shape: signals that score points, and the docs to load when it wins.
+# Higher score wins; ties broken by PRIORITY order (earlier = stronger).
+
+MALAMA_PROMPT = "skills/malama/SYSTEM_PROMPT.md"
+REPO_RULES = "AGENTS.md"
+
+PRIORITY = ["mcp", "skill", "cli", "api", "app", "data", "pdf", "infra"]
+
+SHAPES = {
+    "mcp":   {"standard": "standards/shapes/MCP.md",   "label": "MCP server"},
+    "skill": {"standard": "standards/shapes/SKILL.md", "label": "Agent skill"},
+    "cli":   {"standard": "standards/shapes/CLI.md",   "label": "CLI tool"},
+    "api":   {"standard": "standards/shapes/API.md",   "label": "API service"},
+    "app":   {"standard": "standards/shapes/APP.md",   "label": "Full app"},
+    "data":  {"standard": "standards/shapes/EXCEL.md", "label": "Data / spreadsheet"},
+    "pdf":   {"standard": "standards/shapes/PDF.md",   "label": "PDF / booklet"},
+    "infra": {"standard": "standards/DOCKER.md",       "label": "Infrastructure"},
+}
+
+FALLBACK = {"standard": "standards/shapes/README.md", "label": "Generic (no clear shape)"}
+
+
+def _exists(root: str, *names: str) -> bool:
+    return any(os.path.exists(os.path.join(root, n)) for n in names)
+
+
+def _glob(root: str, pattern: str) -> list[str]:
+    return glob.glob(os.path.join(root, pattern)) + glob.glob(os.path.join(root, "**", pattern), recursive=False)
+
+
+def _read(root: str, name: str) -> str:
+    try:
+        with open(os.path.join(root, name), encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def _pkg_json(root: str) -> dict:
+    raw = _read(root, "package.json")
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+def detect(root: str) -> dict:
+    """Return {shape, score, matched[], load[]} for the directory at root."""
+    root = os.path.abspath(root)
+    scores: dict[str, int] = {k: 0 for k in SHAPES}
+    matched: dict[str, list[str]] = {k: [] for k in SHAPES}
+
+    pkg = _pkg_json(root)
+    deps = {}
+    if pkg:
+        deps = {**pkg.get("dependencies", {}), **pkg.get("devDependencies", {})}
+    pyproject = _read(root, "pyproject.toml") + _read(root, "setup.py") + _read(root, "requirements.txt")
+
+    def hit(shape: str, points: int, why: str) -> None:
+        scores[shape] += points
+        matched[shape].append(why)
+
+    # MCP
+    if _exists(root, ".mcp.json") or os.path.isdir(os.path.join(root, "mcp-servers")):
+        hit("mcp", 3, ".mcp.json / mcp-servers present")
+    if "@modelcontextprotocol/sdk" in deps or "mcp" in pyproject.lower().split():
+        hit("mcp", 3, "MCP SDK dependency")
+
+    # SKILL
+    if _glob(root, "*.skill.yml") or _exists(root, "SKILL.md"):
+        hit("skill", 3, "*.skill.yml / SKILL.md present")
+
+    # CLI
+    if isinstance(pkg.get("bin"), (str, dict)):
+        hit("cli", 3, "package.json 'bin' entry")
+    if "[project.scripts]" in pyproject or "console_scripts" in pyproject:
+        hit("cli", 3, "python console_scripts")
+    if _exists(root, "Cargo.toml") and "[[bin]]" in _read(root, "Cargo.toml"):
+        hit("cli", 2, "Cargo [[bin]]")
+
+    # API
+    api_deps = {"express", "fastify", "koa", "@nestjs/core", "fastapi", "flask", "django", "starlette"}
+    if api_deps & set(deps):
+        hit("api", 3, f"web-server dep ({', '.join(sorted(api_deps & set(deps)))})")
+    if any(d in pyproject.lower() for d in ("fastapi", "flask", "django", "starlette")):
+        hit("api", 3, "python web framework")
+    if _glob(root, "openapi*.y*ml") or _glob(root, "swagger*.*"):
+        hit("api", 2, "openapi/swagger spec")
+
+    # APP
+    app_deps = {"next", "react", "react-dom", "vue", "svelte", "@angular/core", "nuxt", "@remix-run/react"}
+    if app_deps & set(deps):
+        hit("app", 3, f"frontend framework ({', '.join(sorted(app_deps & set(deps)))})")
+    if _exists(root, "index.html") and not (app_deps & set(deps)):
+        hit("app", 1, "index.html")
+
+    # DATA
+    if _glob(root, "*.ipynb"):
+        hit("data", 2, "jupyter notebook")
+    if _glob(root, "*.csv") or _glob(root, "*.parquet") or _glob(root, "*.xlsx"):
+        hit("data", 2, "tabular data files")
+    if {"pandas", "numpy", "polars"} & set(k.lower() for k in deps):
+        hit("data", 1, "data dependency")
+
+    # PDF
+    if _glob(root, "*.tex") or os.path.isdir(os.path.join(root, "booklet")):
+        hit("pdf", 3, "LaTeX / booklet source")
+
+    # INFRA
+    if _exists(root, "Dockerfile", "docker-compose.yml", "compose.yaml"):
+        hit("infra", 2, "Dockerfile / compose")
+    if _glob(root, "*.tf"):
+        hit("infra", 2, "terraform files")
+
+    # Pick winner
+    best = max(PRIORITY, key=lambda s: (scores[s], -PRIORITY.index(s)))
+    if scores[best] == 0:
+        shape, info, why = "generic", FALLBACK, ["no strong signals"]
+    else:
+        shape, info, why = best, SHAPES[best], matched[best]
+
+    load = [MALAMA_PROMPT, info["standard"], REPO_RULES]
+    return {
+        "shape": shape,
+        "label": info["label"],
+        "score": scores.get(best, 0),
+        "matched": why,
+        "load": load,
+        "all_scores": {k: v for k, v in scores.items() if v},
+    }
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if a != "--json"]
+    as_json = "--json" in sys.argv
+    root = args[0] if args else "."
+    result = detect(root)
+
+    if as_json:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    print(f"Detected shape: {result['label']} ({result['shape']}, score {result['score']})")
+    print("Matched signals:")
+    for w in result["matched"]:
+        print(f"  - {w}")
+    print("\nLoad these into context at session start:")
+    for path in result["load"]:
+        tag = ("base agent prompt" if path == MALAMA_PROMPT
+               else "repo rules" if path == REPO_RULES else "shape standard")
+        print(f"  - {path:<34} ({tag})")
+    if result["all_scores"]:
+        print(f"\n(other candidates: {result['all_scores']})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/project-router/detect.py
+++ b/skills/project-router/detect.py
@@ -49,7 +49,9 @@ def _exists(root: str, *names: str) -> bool:
 
 
 def _glob(root: str, pattern: str) -> list[str]:
-    return glob.glob(os.path.join(root, pattern)) + glob.glob(os.path.join(root, "**", pattern), recursive=False)
+    # recursive=True so the "**" segment actually expands into nested dirs
+    # (root/**/<pattern> also matches root-level files, so this covers both).
+    return glob.glob(os.path.join(root, "**", pattern), recursive=True)
 
 
 def _read(root: str, name: str) -> str:

--- a/skills/project-router/project-router.skill.yml
+++ b/skills/project-router/project-router.skill.yml
@@ -1,0 +1,55 @@
+name: project_router
+title: "Project Router — Auto-Load the Right Master Docs by Project Type"
+version: 1.0.0
+description: "At session start, detect the project's shape (MCP / skill / CLI / API / app / data / PDF / infra) from filesystem signals and load the matching standards/shapes doc plus the Mālama system prompt. Auto-detect front end for the Solution-Shape Router."
+
+metadata:
+  author: "Revvel AI Engine"
+  category: "Agent Operations"
+  tags: [router, project-type, shape, session-start, detection, malama]
+  created_at: "2026-06-20"
+  updated_at: "2026-06-20"
+
+dependencies:
+  skills: [malama]
+  tools: []
+  pip_packages: []   # zero-dependency, stdlib only
+
+related:
+  detector: "skills/project-router/detect.py"
+  routes: "skills/project-router/routes.yml"
+  shapes: "standards/shapes/README.md"
+
+triggers:
+  - "project router"
+  - "detect project type"
+  - "which standard"
+  - "shape router"
+  - "session start router"
+  - "what should I load"
+
+implementation:
+  type: "python_script"
+  language: "python"
+  entrypoint: "skills/project-router/detect.py"
+  invoke: "python3 skills/project-router/detect.py . --json"
+  content: |
+    # Project Router Skill
+
+    ## Purpose
+    Detect a project's shape at session start and load the right playbook:
+    always the Mālama system prompt (base) + the matching standards/shapes
+    standard + AGENTS.md (repo rules). Avoids loading every standard.
+
+    ## Run
+    python3 skills/project-router/detect.py .          # human
+    python3 skills/project-router/detect.py . --json   # for hooks
+
+    ## Shapes -> standard
+    mcp -> MCP.md | skill -> SKILL.md | cli -> CLI.md | api -> API.md |
+    app -> APP.md | data -> EXCEL.md | pdf -> PDF.md | infra -> DOCKER.md |
+    none -> shapes/README.md
+
+    ## Editing routes
+    routes.yml is the human source of truth; detect.py embeds the same table
+    so the engine has no external dependencies. Keep them in sync.

--- a/skills/project-router/routes.yml
+++ b/skills/project-router/routes.yml
@@ -1,0 +1,51 @@
+# Mālama Project-Type Router — routing table (human-readable source of truth)
+#
+# detect.py embeds this same table as a Python dict so the engine stays
+# zero-dependency. If you edit routes here, mirror the change in detect.py.
+#
+# Winner = highest score; ties broken by `priority` order (earlier = stronger).
+# Every match also loads the Mālama system prompt + repo rules as a base.
+
+base_load:
+  - skills/malama/SYSTEM_PROMPT.md   # base agent prompt (always)
+  - AGENTS.md                        # repo rules (always)
+
+priority: [mcp, skill, cli, api, app, data, pdf, infra]
+
+shapes:
+  mcp:
+    label: MCP server
+    standard: standards/shapes/MCP.md
+    signals: [".mcp.json or mcp-servers/", "@modelcontextprotocol/sdk dep"]
+  skill:
+    label: Agent skill
+    standard: standards/shapes/SKILL.md
+    signals: ["*.skill.yml", "SKILL.md"]
+  cli:
+    label: CLI tool
+    standard: standards/shapes/CLI.md
+    signals: ["package.json 'bin'", "python console_scripts", "Cargo [[bin]]"]
+  api:
+    label: API service
+    standard: standards/shapes/API.md
+    signals: ["express/fastify/fastapi/flask/django dep", "openapi/swagger spec"]
+  app:
+    label: Full app
+    standard: standards/shapes/APP.md
+    signals: ["next/react/vue/svelte/angular dep", "index.html"]
+  data:
+    label: Data / spreadsheet
+    standard: standards/shapes/EXCEL.md
+    signals: ["*.ipynb", "*.csv / *.parquet / *.xlsx", "pandas/numpy/polars dep"]
+  pdf:
+    label: PDF / booklet
+    standard: standards/shapes/PDF.md
+    signals: ["*.tex", "booklet/ dir"]
+  infra:
+    label: Infrastructure
+    standard: standards/DOCKER.md
+    signals: ["Dockerfile / compose", "*.tf terraform"]
+
+fallback:
+  label: Generic (no clear shape)
+  standard: standards/shapes/README.md


### PR DESCRIPTION
## What this adds

Two follow-ups to the merged oAudrey × Mālama open-core work (#14689).

### 1. Project Router — auto-load the right master docs by project type
`skills/project-router/` — the auto-detect front end for the existing Solution-Shape Router.

- **`detect.py`** — zero-dependency (stdlib only) session-start detector. Scans the working dir, scores its shape, and prints the docs an agent should load: the Mālama system prompt (base) + the matching `standards/shapes/*` doc + `AGENTS.md`.
- Shapes: `mcp · skill · cli · api · app · data · pdf · infra`, with a generic fallback.
- **`routes.yml`** — human-editable routing table (mirrored inside `detect.py` so the engine stays dependency-free).
- `SKILL.md`, `project-router.skill.yml`, registered in `skills/SKILLS_INDEX.yml`.

Verified locally: this repo → MCP; FastAPI fixture → API; Next.js fixture → app.

This is the answer to *"depending on project type, trigger a different master readme"* — different shape, different standard, same Mālama engine underneath.

### 2. Mālama public-mirror kit (publish-ready, nothing auto-publishes)
Prepares the AGPLv3 open core for publishing as the adoption funnel, without exposing the rest of the (proprietary) repo.

- **`skills/malama/README.md`** — public front page.
- **`scripts/publish-malama.sh`** — secret-scans and packages `skills/malama/` into a standalone dir, then prints the publish commands. Does **not** push.
- **`.github/workflows/mirror-malama.yml`** — optional sync of `skills/malama/` to a public repo. **No-ops until** `MALAMA_MIRROR_TOKEN` (secret) + `MALAMA_MIRROR_REPO` (var) are set, and refuses to publish if a credential-shaped string is found.

### Safety / scope
- Only `skills/malama/` is AGPLv3; nothing else is relicensed.
- No live publishing happens in this PR — going public stays a deliberate, gated action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRXCPdFgZi6guk4ev9rbXq)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds two major components for the Mālama open-core agent engine: First, a **Project Router** that automatically detects project types (MCP server, CLI, API, app, data, PDF, infrastructure) from filesystem signals and loads the appropriate standards documentation alongside the base Mālama system prompt. Second, a **public-mirror publishing kit** that prepares the AGPLv3-licensed `skills/malama/` directory for publication to a separate public repository, including secret-scanning safeguards and a GitHub Actions workflow (configured to no-op until explicitly enabled). The router is a zero-dependency Python script that scores project shapes and routes to the matching `standards/shapes/*` documentation, while the publishing kit includes a bash script and workflow that refuse to publish if credentials are detected.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `skills/malama/README.md` |
| 2 | `skills/project-router/routes.yml` |
| 3 | `skills/project-router/detect.py` |
| 4 | `skills/project-router/SKILL.md` |
| 5 | `skills/project-router/project-router.skill.yml` |
| 6 | `skills/SKILLS_INDEX.yml` |
| 7 | `scripts/publish-malama.sh` |
| 8 | `.github/workflows/mirror-malama.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a zero-dependency project-type router that auto-detects repo shape and lists the three master docs to load, plus a gated public-mirror kit for the AGPLv3 Mālama engine. Hardens detection (recursive glob for nested files) and secret scanning (non-leaking), and documents the mirror workflow in `docs/AUTOMATION_AUDIT.md`.

- **New Features**
  - Project Router: `skills/project-router/detect.py` scans the cwd, scores shapes (`mcp`, `skill`, `cli`, `api`, `app`, `data`, `pdf`, `infra`), and returns the 3 docs to load: `skills/malama/SYSTEM_PROMPT.md`, the matched `standards/shapes/<SHAPE>.md`, and `AGENTS.md`. Supports `--json`; routes editable in `routes.yml`; registered in `skills/SKILLS_INDEX.yml`. Now uses recursive globbing to detect nested files (e.g. `**/openapi*.yml`, `**/*.ipynb`).
  - Public mirror kit: `skills/malama/README.md`; `scripts/publish-malama.sh` secret-scans and stages a clean package (no push); `.github/workflows/mirror-malama.yml` syncs `skills/malama/` only when `MALAMA_MIRROR_TOKEN` + `MALAMA_MIRROR_REPO` are set and refuses to publish on credential-shaped strings. Secret scans print file paths only (no matched content). Added workflow entry and safety notes to `docs/AUTOMATION_AUDIT.md`.

- **Migration**
  - Optional: run `python3 skills/project-router/detect.py . --json` at SessionStart to preload the returned docs.
  - To enable mirroring, set `MALAMA_MIRROR_TOKEN` (secret) and `MALAMA_MIRROR_REPO` (var) in GitHub; otherwise the workflow no-ops.

<sup>Written for commit 03d5cec9d644b48339d905d7976be2812f122aeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

