### PR TITLE
fix(self-healing): emit broken areas with printf %s so self-heal can act

### DIFF
--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -108,7 +108,11 @@ jobs:
             BROKEN+=("Missing workflows: $AGENTS")
           fi
           
-          echo "broken=$(printf '; ' "${BROKEN[@]}")" >> $GITHUB_OUTPUT
+          # Use %s so each array element is actually emitted. Without it the
+          # format string has no conversion spec, so the broken descriptions are
+          # dropped and `broken` never reflects real failures (the self-heal
+          # phase then can't match "Stuck issues"/"GitHub Actions" to act on).
+          echo "broken=$(printf '%s; ' "${BROKEN[@]}")" >> $GITHUB_OUTPUT
 
       - name: Compile system health
         id: health


### PR DESCRIPTION
## Why

Completes the self-healing fixes from #14687. That PR restored `gh` auth, the repo target, and write permissions — but the `Scan for broken areas` step still uses `printf '; '` with **no conversion spec**, so the `BROKEN` array elements are dropped. `broken` never carries the real failure descriptions, and the self-heal phase's `grep` for `"Stuck issues"` / `"GitHub Actions"` can never match → the heal steps run but do nothing useful.

This is the same bug independently found in #14675 (which is otherwise superseded by #14687).

## Fix

`printf '; '` → `printf '%s; '` so each element is emitted; an empty array still yields an empty (healthy) result.

## Verification
- YAML validated.
- `npm test` green (no test references this line; behavior is shell-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwAgeWSxe66JphM7mBEgLH)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical bug in the self-healing workflow where broken areas were not being properly emitted to the output. The issue was that `printf '; '` was called without a format specifier, causing array elements containing failure descriptions to be dropped. By changing it to `printf '%s; '`, each element in the `BROKEN` array is now correctly emitted, allowing the self-heal phase to properly detect and act on issues like "Stuck issues" or "GitHub Actions" failures.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/self-healing.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the self-healing workflow by emitting each `BROKEN` array item with `printf '%s; '` so `broken` contains real failure descriptions. This lets the heal phase match patterns like "Stuck issues" and "GitHub Actions" and actually act.

<sup>Written for commit d527568820878e4138cf7ae1b3e88fbf15d1b90f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

