### PR TITLE
fix(self-healing): align broken output key + guard empty-array printf

### DIFF
--- a/.github/workflows/self-healing.yml
+++ b/.github/workflows/self-healing.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      broken_areas: ${{ steps.scan.outputs.broken }}
+      broken: ${{ steps.scan.outputs.broken }}
       system_health: ${{ steps.health.outputs.status }}
     steps:
       - name: Check GitHub Actions status
@@ -108,11 +108,16 @@ jobs:
             BROKEN+=("Missing workflows: $AGENTS")
           fi
           
-          # Use %s so each array element is actually emitted. Without it the
-          # format string has no conversion spec, so the broken descriptions are
-          # dropped and `broken` never reflects real failures (the self-heal
-          # phase then can't match "Stuck issues"/"GitHub Actions" to act on).
-          echo "broken=$(printf '%s; ' "${BROKEN[@]}")" >> $GITHUB_OUTPUT
+          # Emit each broken-area element with %s. Guard on array length: a bare
+          # `printf '%s; '` with no args still prints "; " (non-empty), which
+          # would mark the system needs-healing on every healthy run. An empty
+          # array must yield an empty value so Compile system health sees healthy.
+          if [[ ${#BROKEN[@]} -gt 0 ]]; then
+            BROKEN_STR="$(printf '%s; ' "${BROKEN[@]}")"
+          else
+            BROKEN_STR=""
+          fi
+          echo "broken=$BROKEN_STR" >> "$GITHUB_OUTPUT"
 
       - name: Compile system health
         id: health


### PR DESCRIPTION
## Why

Copilot's review on #14693 caught two real bugs that **still** kept the self-heal phase from acting, even after the auth/permission (#14687) and printf-`%s` (#14693) fixes:

1. **Output key mismatch.** `research-state` exported `broken_areas`, but the `self-heal` job reads `needs.research-state.outputs.broken` — a key that never existed. So the heal steps always saw an empty string and could never match `"Stuck issues"` / `"GitHub Actions"`. Renamed the job output to `broken` to match every consumer (no other reference to `broken_areas` exists).
2. **Empty-array printf.** `printf '%s; '` with no args still prints `"; "` (non-empty), which marks the system `needs-healing` on every healthy run. Guarded on `${#BROKEN[@]}` so an empty array yields an empty (healthy) value. Also quoted `$GITHUB_OUTPUT`.

## Verification
```
empty    -> []
nonempty -> [GitHub Actions: 4 failures; Stuck issues: 6 open; ]
```
YAML validated.

With this, the loop is genuinely wired: healthy stays healthy, real failures flow through to the heal steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwAgeWSxe66JphM7mBEgLH)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes two bugs preventing the self-healing workflow from functioning correctly. First, it renames the `broken_areas` output to `broken` to match what downstream jobs are actually reading (`needs.research-state.outputs.broken`). Second, it guards the `printf` statement against empty arrays, since `printf '%s; '` with no arguments still produces `"; "` (a non-empty string), which would incorrectly mark healthy systems as needing healing. The fix ensures empty arrays produce empty strings, allowing the workflow to correctly distinguish between healthy and broken states.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/self-healing.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the self-healing workflow so health detection is accurate and healing steps run only on real failures.

- **Bug Fixes**
  - Renamed job output from `broken_areas` to `broken` to match `needs.research-state.outputs.broken`.
  - Guarded empty-array `printf` so no args produce an empty `broken` value; also quoted `$GITHUB_OUTPUT`.

<sup>Written for commit 038465a424f775ac72a2a8aaa8f1246a7a8c41b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

