### PR TITLE
feat(biome): add credit-free additive self-healing crew (BIOME)

### DIFF
--- a/.github/workflows/biome-homeostat.yml
+++ b/.github/workflows/biome-homeostat.yml
@@ -1,0 +1,49 @@
+name: BIOME Homeostat
+
+# Credit-free homeostasis regulator. Detects whether the AI-lane keys
+# (OpenRouter / Anthropic / Perplexity — the ones Doppler keeps wiping) are
+# present. Missing keys never degrade the crew (BIOME is credit-free); homeostat
+# just posts ONE consolidated, deduped status note and auto-resolves it when the
+# keys return. No needs-human spam.
+
+on:
+  schedule:
+    - cron: '40 */6 * * *'  # every 6 hours
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: biome-homeostat
+  cancel-in-progress: false
+
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  regulate:
+    name: Check AI-lane keys (credit-free)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run homeostat
+        # These secrets are read ONLY to detect presence. They are passed through
+        # env: (never interpolated into the shell) and may legitimately be empty —
+        # that is the credit-free case the homeostat is designed to report.
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+        run: node scripts/biome/homeostat.js

--- a/.github/workflows/biome-medic.yml
+++ b/.github/workflows/biome-medic.yml
@@ -1,0 +1,55 @@
+name: BIOME Medic
+
+# Credit-free, rule-based remediation (the crew's macrophage). No AI keys.
+# Storm-safe by default: re-surfaces stuck items (adds `self-heal` + comment) and,
+# when AI lanes are offline, clears dead `openrouter:needs-key` blocks so the
+# rule-based lanes can pick the work back up. Never deletes content
+# (COMMENT-DONT-DELETE / RVS-AGENT-001).
+#
+# Re-running failed workflow runs is OFF by default (storm-prone). Enable for a
+# single manual run via the workflow_dispatch input; it excludes BIOME's own
+# workflows to avoid loops. (Enabling reruns also needs `actions: write`.)
+
+on:
+  schedule:
+    - cron: '50 */6 * * *'  # every 6 hours, offset behind sentinel/homeostat
+  workflow_dispatch:
+    inputs:
+      allow_reruns:
+        description: 'Allow rule-based re-runs of failed (non-BIOME) workflow runs'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+concurrency:
+  group: biome-medic
+  cancel-in-progress: false
+
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  remediate:
+    name: Rule-based remediation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run medic
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          BIOME_ALLOW_RERUNS: ${{ github.event.inputs.allow_reruns || 'false' }}
+        run: node scripts/biome/medic.js

--- a/.github/workflows/biome-sentinel.yml
+++ b/.github/workflows/biome-sentinel.yml
@@ -1,0 +1,42 @@
+name: BIOME Sentinel
+
+# Credit-free, rule-based failure detector (the crew's nociceptor). No AI keys.
+# Scans recent runs + open issues via GITHUB_TOKEN only and files/updates a single
+# deduped [BIOME-SENTINEL] incident when the fleet is in pain.
+
+on:
+  schedule:
+    - cron: '20 */2 * * *'  # every 2 hours, offset from the 4h self-healing loop
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+concurrency:
+  group: biome-sentinel
+  cancel-in-progress: false
+
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  sense:
+    name: Detect fleet pain (rule-based)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run sentinel
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: node scripts/biome/sentinel.js

--- a/.github/workflows/biome-sheaf.yml
+++ b/.github/workflows/biome-sheaf.yml
@@ -1,0 +1,56 @@
+name: BIOME Sheaf
+
+# The crew's connective tissue: the monitor feed. Glues each worker's local status
+# section into one globally-consistent fleet-health object and commits it as
+# docs/biome/biome-status.json (+ .html). Credit-free; reads via GITHUB_TOKEN only.
+# Single committer for the feed (avoids commit races with the other workers).
+# An external monitor (e.g. Lovable) can poll the committed JSON.
+
+on:
+  schedule:
+    - cron: '0 */1 * * *'  # hourly
+  workflow_dispatch: {}
+
+permissions:
+  contents: write   # commits the status feed
+  issues: read
+  actions: read
+
+concurrency:
+  group: biome-sheaf
+  cancel-in-progress: false
+
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  glue:
+    name: Generate + commit status feed
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Generate feed
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: node scripts/biome/sheaf.js
+
+      - name: Commit feed if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/biome/biome-status.json docs/biome/biome-status.html
+          if git diff --cached --quiet; then
+            echo "No status change."
+          else
+            git commit -m "chore(biome): refresh crew status feed [skip ci]"
+            git push
+          fi

--- a/docs/PROVENANCE_STANDARD.md
+++ b/docs/PROVENANCE_STANDARD.md
@@ -124,6 +124,7 @@ agent to exactly the right action without guessing.
 | `ImgBot (ImgBot.net) via the GitHub App` | Image optimization |
 | `Mabl (Mabl Inc., PAUSED) via @mablhq/mabl-cli` | Paused testing tool |
 | `Octopus Review (Octopus Review Inc.) via github.com/apps/octopus-review + @octp/cli` | PR analyzer + issue filer. Secret: `OCTOPUS_TOKEN` (format `oct_...`). CLI wrapped by `.github/workflows/octopus-cli.yml`. Octopus-filed issues are translated into the WR pipeline by `.github/workflows/octopus-route.yml`. |
+| `BIOME (us) via .github/workflows/biome-*.yml` | Credit-free, additive self-healing crew (no AI keys; `GITHUB_TOKEN` only). Workers: `biome-sentinel`, `biome-medic`, `biome-homeostat`, `biome-sheaf`. Status feed: `docs/biome/biome-status.json`. Design + registry: `docs/biome/README.md`, `docs/biome/crew.yml`. |
 
 Extend as we add. Source of truth for costs stays
 `docs/TOOL_COST_INDEX.md`; source of truth for active tools stays

--- a/docs/biome/README.md
+++ b/docs/biome/README.md
@@ -1,0 +1,126 @@
+# BIOME — Biomimetic Independent Operations & Monitoring Engine
+
+A **credit-free, additive** self-healing crew for `revvel-standards`. BIOME runs
+*alongside* the existing ~70-workflow fleet. It edits, renames, and deletes
+nothing (per `standards/COMMENT-DONT-DELETE.md` (RVS-AGENT-001) and
+`standards/PRESERVE_GOALS_AND_HISTORY.md` (RVS-PRESERVE-001)).
+
+## Why it exists
+
+The existing self-healing loop leans on AI lanes (OpenRouter / Anthropic /
+Perplexity). When Doppler rotates or wipes those secrets, the AI lanes go dark and
+triage collapses to a dead "static-fallback · rule-based" stub that pings
+`needs-human`. BIOME is the layer that **keeps healing when the keys are gone**:
+every worker runs on deterministic rules + the free, built-in `GITHUB_TOKEN`.
+
+> **Credit-free invariant:** no BIOME worker ever requires a paid API key. Missing
+> AI keys are *informational*, never a degradation of the crew.
+
+## The metaphor (sheaves + biomimicry)
+
+- **Sheaf** — each worker emits a *local* status section; `sheaf` glues them into
+  one globally-consistent fleet-health object (local sections → global section,
+  exactly as a sheaf glues). That global object is the monitor feed.
+- **Biomimic** — each worker is a biological self-healing *reflex* that fires
+  without external dependencies, the way an immune response doesn't wait for
+  permission.
+
+## The crew
+
+| Worker | Biomimetic role | Schedule | What it does (rule-based, no AI) |
+|--------|-----------------|----------|----------------------------------|
+| `biome-sentinel` | nociceptor (pain sensor) | every 2h | Scans recent runs + open issues; files/updates one deduped `[BIOME-SENTINEL]` incident when failures or stuck items cross threshold. |
+| `biome-medic` | macrophage (immune cell) | every 6h | Re-surfaces stuck items (`self-heal` label + comment); when AI lanes are offline, clears dead `openrouter:needs-key` blocks. Storm-safe; never deletes content. |
+| `biome-homeostat` | homeostasis regulator | every 6h | Detects missing AI keys (the Doppler-wipe case); posts ONE consolidated, deduped status note and auto-resolves it when keys return. No `needs-human` spam. |
+| `biome-sheaf` | connective tissue | hourly | Glues every worker's local section into `biome-status.json` + `biome-status.html` and commits them (single committer — no commit races). |
+
+## The loop (detect → remediate → monitor → reset)
+
+1. **Detect** — `biome-sentinel` finds failures/stuck items via the GitHub API and
+   files a deduped incident labeled `biome`, `scorecard`, `self-heal`.
+2. **Remediate** — `biome-medic` applies rule-based, storm-safe fixes (re-label +
+   comment; clear dead key-blocks). Re-running failed runs is **off by default**.
+3. **Regulate** — `biome-homeostat` keeps the crew "healthy" even with AI lanes
+   offline and surfaces a single, calm status note.
+4. **Monitor** — `biome-sheaf` publishes the glued status feed every hour.
+5. **Reset** — incidents/status notes auto-resolve (close) when the fleet recovers;
+   nothing is force-deleted.
+
+## The monitor feed (for Lovable)
+
+`biome-sheaf` commits a stable, machine-readable feed:
+
+- `docs/biome/biome-status.json` — schema `biome-status/v1`
+- `docs/biome/biome-status.html` — self-contained human view
+
+Lovable (or any external monitor) can poll the raw JSON, e.g.:
+
+```text
+https://raw.githubusercontent.com/midnghtsapphire/revvel-standards/main/docs/biome/biome-status.json
+```
+
+Feed shape:
+
+```json
+{
+  "schema": "biome-status/v1",
+  "generated_at": "<ISO-8601>",
+  "credit_free": true,
+  "overall": "healthy | degraded | down",
+  "workers": {
+    "sentinel":  { "status": "...", "summary": "...", "counts": {}, "detail": {} },
+    "homeostat": { "status": "...", "summary": "...", "counts": {}, "detail": {} },
+    "medic":     { "status": "...", "summary": "...", "counts": {}, "detail": {} },
+    "sheaf":     { "status": "...", "summary": "...", "counts": {}, "detail": {} }
+  }
+}
+```
+
+`overall` is the worst severity across workers (the sheaf gluing rule). A missing
+AI key keeps `overall` healthy by design.
+
+## Standards adherence
+
+- **No-delete / preserve** — workers only add labels/comments and close resolved
+  ops issues; they never delete code or content. Removing a stale *label* is
+  metadata, not a content deletion.
+- **Token-with-fallback** — every worker uses
+  `secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN`.
+- **`GH_REPO`** — set so `gh`/API calls resolve the repo without a remote.
+- **Narrow permissions** — least privilege per worker; only `biome-sheaf` gets
+  `contents: write` (it is the single committer of the feed).
+- **No untrusted interpolation** — no `${{ github.event.* }}` is interpolated into
+  any `run:` shell.
+
+## Files
+
+```text
+.github/workflows/biome-sentinel.yml
+.github/workflows/biome-medic.yml
+.github/workflows/biome-homeostat.yml
+.github/workflows/biome-sheaf.yml
+scripts/biome/gh.js          # shared credit-free GitHub REST helper
+scripts/biome/sentinel.js    # detection rules
+scripts/biome/homeostat.js   # AI-lane assessment
+scripts/biome/medic.js       # remediation rules
+scripts/biome/sheaf.js       # status gluing + HTML render
+docs/biome/crew.yml          # worker registry (frontmatter per worker)
+docs/biome/README.md         # this file
+docs/biome/biome-status.json # generated feed (bootstrap committed; refreshed hourly)
+docs/biome/biome-status.html # generated human view
+tests/biome-*.test.js        # unit tests for the rule-based logic + workflow lint
+```
+
+## Tests
+
+```bash
+npm ci
+node --test tests/biome-sentinel.test.js tests/biome-homeostat.test.js \
+  tests/biome-medic.test.js tests/biome-sheaf.test.js tests/biome-workflows.test.js
+```
+
+## Status
+
+**Bootstrap (2026-06-30).** Workflows are scheduled and the feed path is seeded
+with a bootstrap snapshot; the first scheduled `biome-sheaf` run replaces it with
+live data.

--- a/docs/biome/biome-status.html
+++ b/docs/biome/biome-status.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BIOME Crew Status</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 2rem; color: #0f172a; background: #f8fafc; }
+    h1 { font-size: 1.4rem; }
+    .overall { font-size: 1.1rem; padding: .5rem .9rem; border-radius: 10px; display: inline-block; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+    table { border-collapse: collapse; margin-top: 1rem; background: #fff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.08); width: 100%; }
+    th, td { text-align: left; padding: .6rem .8rem; border-bottom: 1px solid #e2e8f0; font-size: .9rem; }
+    th { background: #0ea5e9; color: #fff; }
+    .meta { color: #64748b; font-size: .8rem; margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>🧬 BIOME Crew Status</h1>
+  <p class="overall">Overall: 🟢 <strong>healthy</strong> · credit-free: yes</p>
+  <table>
+    <thead>
+      <tr><th>Worker</th><th>Status</th><th>Summary</th><th>Counts</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>🟢 <strong>sentinel</strong></td>
+        <td>healthy</td>
+        <td>bootstrap — awaiting first scheduled scan</td>
+        <td>failed_runs: 0, total_runs: 0, stuck_issues: 0</td>
+      </tr>
+      <tr>
+        <td>🟢 <strong>homeostat</strong></td>
+        <td>healthy</td>
+        <td>bootstrap — AI-lane state reported on first run</td>
+        <td>ai_keys_present: 0, ai_keys_missing: 0</td>
+      </tr>
+      <tr>
+        <td>🟢 <strong>medic</strong></td>
+        <td>healthy</td>
+        <td>no recent run yet</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>🟢 <strong>sheaf</strong></td>
+        <td>healthy</td>
+        <td>bootstrap snapshot — replaced by first hourly run</td>
+        <td>workers: 3</td>
+      </tr>
+    </tbody>
+  </table>
+  <p class="meta">Generated 2026-06-30T00:00:00Z · schema biome-status/v1 · machine feed: <code>biome-status.json</code></p>
+</body>
+</html>

--- a/docs/biome/biome-status.json
+++ b/docs/biome/biome-status.json
@@ -1,0 +1,45 @@
+{
+  "schema": "biome-status/v1",
+  "generated_at": "2026-06-30T00:00:00Z",
+  "credit_free": true,
+  "overall": "healthy",
+  "workers": {
+    "sentinel": {
+      "status": "healthy",
+      "summary": "bootstrap — awaiting first scheduled scan",
+      "counts": {
+        "failed_runs": 0,
+        "total_runs": 0,
+        "stuck_issues": 0
+      },
+      "detail": {}
+    },
+    "homeostat": {
+      "status": "healthy",
+      "summary": "bootstrap — AI-lane state reported on first run",
+      "counts": {
+        "ai_keys_present": 0,
+        "ai_keys_missing": 0
+      },
+      "detail": {
+        "ai_lanes": "unknown"
+      }
+    },
+    "medic": {
+      "status": "healthy",
+      "summary": "no recent run yet",
+      "counts": {},
+      "detail": {
+        "last_run": null
+      }
+    },
+    "sheaf": {
+      "status": "healthy",
+      "summary": "bootstrap snapshot — replaced by first hourly run",
+      "counts": {
+        "workers": 3
+      },
+      "detail": {}
+    }
+  }
+}

--- a/docs/biome/crew.yml
+++ b/docs/biome/crew.yml
@@ -1,0 +1,58 @@
+# BIOME crew registry
+# Worker definitions following docs/Master_Inventory/AGENT_FACTORY_STANDARD.md.
+# Every worker is a credit-free GitHub Actions workflow (GITHUB_TOKEN only).
+# This file is the discoverability surface for the BIOME crew; it is additive and
+# does not replace any existing registry.
+
+crew: BIOME
+description: >-
+  Biomimetic Independent Operations & Monitoring Engine — a credit-free, additive
+  self-healing crew that keeps running when AI-lane keys are wiped by Doppler.
+credit_free: true
+preserves_history: true   # COMMENT-DONT-DELETE / PRESERVE_GOALS_AND_HISTORY
+
+workers:
+  - name: biome-sentinel
+    role: Nociceptor — rule-based fleet failure detection
+    workflow: .github/workflows/biome-sentinel.yml
+    script: scripts/biome/sentinel.js
+    models: []              # none — deterministic rules only
+    tools: [github-rest-read, github-issues-write]
+    triggers: [schedule:every-2h, workflow_dispatch]
+    inputs: recent workflow runs, open issues (GitHub API)
+    outputs: one deduped [BIOME-SENTINEL] incident issue (labels biome, scorecard, self-heal)
+    handoff_expectations: biome-medic remediates; biome-sheaf reports
+
+  - name: biome-medic
+    role: Macrophage — rule-based, storm-safe remediation
+    workflow: .github/workflows/biome-medic.yml
+    script: scripts/biome/medic.js
+    models: []
+    tools: [github-rest-read, github-issues-write]
+    triggers: [schedule:every-6h, workflow_dispatch]
+    inputs: recent failures, stuck issues, openrouter:needs-key blocks, AI-lane state
+    outputs: self-heal relabels + comments; cleared dead key-blocks (metadata only)
+    handoff_expectations: re-surfaced items flow back into the existing self-heal loop
+    notes: re-running failed runs is OFF by default (storm-prone); excludes BIOME workflows
+
+  - name: biome-homeostat
+    role: Homeostasis regulator — credit-free AI-lane status
+    workflow: .github/workflows/biome-homeostat.yml
+    script: scripts/biome/homeostat.js
+    models: []
+    tools: [github-issues-write]
+    triggers: [schedule:every-6h, workflow_dispatch]
+    inputs: presence of OPENROUTER_API_KEY / ANTHROPIC_API_KEY / PERPLEXITY_API_KEY
+    outputs: one consolidated, deduped status note; auto-resolved when keys return
+    handoff_expectations: never escalates to needs-human; crew stays healthy without keys
+
+  - name: biome-sheaf
+    role: Connective tissue — the monitor feed (single committer)
+    workflow: .github/workflows/biome-sheaf.yml
+    script: scripts/biome/sheaf.js
+    models: []
+    tools: [github-rest-read, repo-commit]
+    triggers: [schedule:hourly, workflow_dispatch]
+    inputs: local status sections from all workers
+    outputs: docs/biome/biome-status.json (schema biome-status/v1) + biome-status.html
+    handoff_expectations: external monitors (e.g. Lovable) poll the committed JSON

--- a/scripts/biome/gh.js
+++ b/scripts/biome/gh.js
@@ -41,8 +41,12 @@ async function api(path, options = {}) {
   try {
     return JSON.parse(text);
   } catch {
-    // A successful response that isn't JSON is a genuine anomaly — surface it
-    // instead of silently masking it as null (which callers read as "no match").
+    // allowError callers opted into graceful degradation — hand them null
+    // rather than throwing on an unexpected non-JSON body.
+    if (options.allowError) return null;
+    // Otherwise a successful response that isn't JSON is a genuine anomaly —
+    // surface it instead of silently masking it as null (which callers read as
+    // "no match").
     throw new Error(
       `GitHub API ${options.method || 'GET'} ${path} -> ${res.status} returned non-JSON: ${text.slice(0, 200)}`
     );

--- a/scripts/biome/gh.js
+++ b/scripts/biome/gh.js
@@ -33,7 +33,20 @@ async function api(path, options = {}) {
     throw new Error(`GitHub API ${options.method || 'GET'} ${path} -> ${res.status} ${text.slice(0, 300)}`);
   }
   if (res.status === 204) return null;
-  return res.json().catch(() => null);
+  const text = await res.text();
+  if (!text) return null; // empty body (e.g. 204-equivalent)
+  // allowError + non-ok: a 5xx may return an HTML error page. Signal "no data"
+  // (null) rather than throwing, so callers using allowError degrade gracefully.
+  if (!res.ok) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    // A successful response that isn't JSON is a genuine anomaly — surface it
+    // instead of silently masking it as null (which callers read as "no match").
+    throw new Error(
+      `GitHub API ${options.method || 'GET'} ${path} -> ${res.status} returned non-JSON: ${text.slice(0, 200)}`
+    );
+  }
 }
 
 function repoApi(path, options) {

--- a/scripts/biome/gh.js
+++ b/scripts/biome/gh.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * BIOME — minimal credit-free GitHub REST helper.
+ *
+ * Uses ONLY the free, built-in GITHUB_TOKEN (or the ADMIN_GITHUB_TOKEN PAT when
+ * present). No OpenRouter / Anthropic / paid keys are ever required. This is the
+ * shared I/O layer for every BIOME worker so the crew keeps running even when
+ * Doppler wipes the AI-lane secrets.
+ */
+
+const REPO = process.env.GITHUB_REPOSITORY || 'midnghtsapphire/revvel-standards';
+const [OWNER, NAME] = REPO.split('/');
+const TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+
+async function api(path, options = {}) {
+  const url = path.startsWith('http') ? path : `https://api.github.com${path}`;
+  const res = await fetch(url, {
+    method: options.method || 'GET',
+    body: options.body ? JSON.stringify(options.body) : undefined,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'biome-crew',
+      ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(options.headers || {}),
+    },
+  });
+  if (!res.ok && !options.allowError) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`GitHub API ${options.method || 'GET'} ${path} -> ${res.status} ${text.slice(0, 300)}`);
+  }
+  if (res.status === 204) return null;
+  return res.json().catch(() => null);
+}
+
+function repoApi(path, options) {
+  return api(`/repos/${OWNER}/${NAME}${path}`, options);
+}
+
+function hasToken() {
+  return TOKEN.trim() !== '';
+}
+
+module.exports = { OWNER, NAME, REPO, hasToken, api, repoApi };

--- a/scripts/biome/homeostat.js
+++ b/scripts/biome/homeostat.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * BIOME · homeostat — the crew's homeostasis regulator.
+ *
+ * The whole point of BIOME is that it is CREDIT-FREE: missing AI-lane keys
+ * (OpenRouter / Anthropic / Perplexity — the ones Doppler keeps wiping) must
+ * NEVER degrade the crew, because the crew runs on rule-based logic + the free
+ * GITHUB_TOKEN. So homeostat treats absent AI keys as *informational* (AI lanes
+ * offline), keeps the rule-based lanes alive, and posts ONE consolidated, deduped
+ * status note instead of spamming `needs-human` escalations.
+ *
+ * Pure functions are exported for tests; the CLI upserts/resolves the note.
+ */
+
+const TRACKED_KEYS = ['OPENROUTER_API_KEY', 'ANTHROPIC_API_KEY', 'PERPLEXITY_API_KEY'];
+const STATUS_MARKER = '<!-- biome-homeostat-status -->';
+
+function assessKeyHealth(env, keyNames = TRACKED_KEYS) {
+  const present = [];
+  const missing = [];
+  for (const k of keyNames) {
+    const v = env[k];
+    if (v !== undefined && v !== null && String(v).trim() !== '') present.push(k);
+    else missing.push(k);
+  }
+  return { present, missing, aiLanesOffline: missing.length > 0, checked: keyNames.slice() };
+}
+
+function buildHomeostatSection(assessment) {
+  const offline = assessment.aiLanesOffline;
+  return {
+    // BIOME is credit-free by design, so missing AI keys never make the crew
+    // unhealthy. Status stays "healthy"; the AI-lane state is surfaced as info.
+    worker: 'homeostat',
+    status: 'healthy',
+    summary: offline
+      ? `AI lanes offline (${assessment.missing.join(', ')} unset) — credit-free rule-based lanes active`
+      : 'AI lanes online; rule-based lanes also active',
+    counts: {
+      ai_keys_present: assessment.present.length,
+      ai_keys_missing: assessment.missing.length,
+    },
+    detail: {
+      ai_lanes: offline ? 'offline' : 'online',
+      present: assessment.present,
+      missing: assessment.missing,
+    },
+  };
+}
+
+function buildStatusBody(assessment, generatedAtIso) {
+  const offline = assessment.aiLanesOffline;
+  const lines = [
+    STATUS_MARKER,
+    '## 🌡️ BIOME Homeostat — AI-lane status',
+    '',
+    `**AI lanes:** ${offline ? '🟡 offline' : '🟢 online'}  `,
+    `**Crew health:** 🟢 healthy (credit-free — runs without AI keys)  `,
+    `**Checked:** ${generatedAtIso}`,
+    '',
+  ];
+  if (offline) {
+    lines.push(`Missing AI keys: ${assessment.missing.map((k) => `\`${k}\``).join(', ')}.`);
+    lines.push('');
+    lines.push(
+      'This is **not** an outage. The BIOME crew is credit-free and keeps healing via ' +
+        'rule-based lanes + the free `GITHUB_TOKEN`. If you want the AI lanes back, restore ' +
+        'the key(s) in Doppler — homeostat will auto-resolve this note on the next run.'
+    );
+  } else {
+    lines.push(`Present AI keys: ${assessment.present.map((k) => `\`${k}\``).join(', ') || '(none tracked)'}.`);
+    lines.push('');
+    lines.push('All tracked AI lanes are online and rule-based lanes remain active as backup.');
+  }
+  return lines.join('\n');
+}
+
+module.exports = {
+  TRACKED_KEYS,
+  STATUS_MARKER,
+  assessKeyHealth,
+  buildHomeostatSection,
+  buildStatusBody,
+};
+
+// --- CLI -------------------------------------------------------------------
+if (require.main === module) {
+  (async () => {
+    const { repoApi } = require('./gh');
+    const assessment = assessKeyHealth(process.env);
+    const generatedAt = new Date().toISOString();
+    console.log(`[biome-homeostat] ai_lanes=${assessment.aiLanesOffline ? 'offline' : 'online'} present=${assessment.present.length} missing=${assessment.missing.length}`);
+
+    const search = await repoApi('/issues?state=open&labels=biome,homeostat&per_page=50', { allowError: true });
+    const existing = Array.isArray(search)
+      ? search.find((i) => !i.pull_request && (i.body || '').includes(STATUS_MARKER))
+      : null;
+
+    if (!assessment.aiLanesOffline) {
+      // Lanes online: resolve any open status note (close is ops metadata, not a content deletion).
+      if (existing) {
+        await repoApi(`/issues/${existing.number}/comments`, {
+          method: 'POST',
+          body: { body: `${STATUS_MARKER}\n✅ AI lanes back online as of ${generatedAt}. Resolving.` },
+        });
+        await repoApi(`/issues/${existing.number}`, { method: 'PATCH', body: { state: 'closed' } });
+        console.log(`[biome-homeostat] resolved status note #${existing.number}`);
+      } else {
+        console.log('[biome-homeostat] AI lanes online — nothing to do.');
+      }
+      return;
+    }
+
+    const body = buildStatusBody(assessment, generatedAt);
+    if (existing) {
+      await repoApi(`/issues/${existing.number}/comments`, { method: 'POST', body: { body } });
+      console.log(`[biome-homeostat] refreshed consolidated status #${existing.number}`);
+    } else {
+      const created = await repoApi('/issues', {
+        method: 'POST',
+        body: {
+          title: '[BIOME-HOMEOSTAT] AI lanes offline — crew healthy (credit-free)',
+          body,
+          labels: ['biome', 'homeostat'],
+        },
+      });
+      console.log(`[biome-homeostat] opened consolidated status #${created && created.number}`);
+    }
+  })().catch((err) => {
+    console.error(`[biome-homeostat] error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/biome/medic.js
+++ b/scripts/biome/medic.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * BIOME · medic — the crew's macrophage (immune cell).
+ *
+ * Credit-free, rule-based remediation. medic does NOT call any AI. Its default
+ * remediations are deliberately storm-safe metadata operations (it never deletes
+ * content — COMMENT-DONT-DELETE / RVS-AGENT-001):
+ *   1. Re-surface stuck items by adding the `self-heal` label + a comment.
+ *   2. When AI lanes are offline, clear dead `openrouter:needs-key` blocks so the
+ *      rule-based lanes can pick the item back up (the block can never clear on
+ *      its own while the key is wiped).
+ *
+ * Re-running failed workflow runs is OFF by default (it is storm-prone). It can be
+ * enabled with caps.allowReruns and excludes BIOME's own workflows to avoid loops.
+ *
+ * Pure decision function exported for tests; CLI applies the plan.
+ */
+
+const DEFAULT_CAPS = { maxRelabels: 10, maxReruns: 3, allowReruns: false };
+
+function decideRemediations({
+  recentFailures = [],
+  stuckIssues = [],
+  keyBlockedIssues = [],
+  aiLanesOffline = false,
+  caps = DEFAULT_CAPS,
+} = {}) {
+  const c = { ...DEFAULT_CAPS, ...caps };
+
+  const relabels = stuckIssues.slice(0, c.maxRelabels).map((it) => ({
+    issue: it.number,
+    add: ['self-heal'],
+    remove: [],
+    comment: 'biome-medic: re-surfacing stuck item for the self-healing loop (rule-based, credit-free).',
+  }));
+
+  // Dead key-blocks only clear when AI lanes are offline (otherwise the real
+  // OpenRouter lane owns them). Removing a label is metadata, not content.
+  const keyUnblocks = aiLanesOffline
+    ? keyBlockedIssues.slice(0, c.maxRelabels).map((it) => ({
+        issue: it.number,
+        add: ['self-heal'],
+        remove: ['openrouter:needs-key'],
+        comment:
+          'biome-medic: AI lanes are offline, so `openrouter:needs-key` can never clear on its own. ' +
+          'Clearing the block (metadata only) and re-surfacing for the credit-free rule-based lanes.',
+      }))
+    : [];
+
+  const reruns = c.allowReruns
+    ? recentFailures
+        .filter((f) => f.id != null && !String(f.path || '').includes('biome-'))
+        .slice(0, c.maxReruns)
+        .map((f) => ({ run_id: f.id, name: f.name, reason: 'recent failure — rule-based re-run' }))
+    : [];
+
+  return {
+    relabels,
+    keyUnblocks,
+    reruns,
+    capped: {
+      relabels: stuckIssues.length > c.maxRelabels,
+      keyUnblocks: aiLanesOffline && keyBlockedIssues.length > c.maxRelabels,
+      reruns: c.allowReruns && recentFailures.length > c.maxReruns,
+    },
+  };
+}
+
+module.exports = { DEFAULT_CAPS, decideRemediations };
+
+// --- CLI -------------------------------------------------------------------
+if (require.main === module) {
+  (async () => {
+    const { repoApi } = require('./gh');
+    const { classifyRuns, detectStuckIssues } = require('./sentinel');
+    const { assessKeyHealth } = require('./homeostat');
+
+    const allowReruns = String(process.env.BIOME_ALLOW_RERUNS || '').toLowerCase() === 'true';
+
+    const runsResp = await repoApi('/actions/runs?per_page=100');
+    const issuesResp = (await repoApi('/issues?state=open&per_page=100&filter=all')) || [];
+    const runClass = classifyRuns((runsResp && runsResp.workflow_runs) || []);
+    const stuck = detectStuckIssues(issuesResp, Date.now());
+    const assessment = assessKeyHealth(process.env);
+
+    const labelNames = (it) => (it.labels || []).map((l) => (typeof l === 'string' ? l : (l && l.name) || ''));
+    const keyBlocked = issuesResp.filter(
+      (it) => !it.pull_request && it.state === 'open' && labelNames(it).includes('openrouter:needs-key')
+    );
+
+    const plan = decideRemediations({
+      recentFailures: runClass.recentFailures,
+      stuckIssues: stuck,
+      keyBlockedIssues: keyBlocked,
+      aiLanesOffline: assessment.aiLanesOffline,
+      caps: { allowReruns },
+    });
+
+    console.log(
+      `[biome-medic] relabels=${plan.relabels.length} keyUnblocks=${plan.keyUnblocks.length} reruns=${plan.reruns.length} (allowReruns=${allowReruns})`
+    );
+
+    for (const action of [...plan.relabels, ...plan.keyUnblocks]) {
+      if (action.remove && action.remove.length) {
+        for (const lbl of action.remove) {
+          await repoApi(`/issues/${action.issue}/labels/${encodeURIComponent(lbl)}`, {
+            method: 'DELETE',
+            allowError: true,
+          });
+        }
+      }
+      if (action.add && action.add.length) {
+        await repoApi(`/issues/${action.issue}/labels`, { method: 'POST', body: { labels: action.add }, allowError: true });
+      }
+      if (action.comment) {
+        await repoApi(`/issues/${action.issue}/comments`, { method: 'POST', body: { body: action.comment }, allowError: true });
+      }
+      console.log(`[biome-medic] remediated #${action.issue}`);
+    }
+
+    for (const r of plan.reruns) {
+      await repoApi(`/actions/runs/${r.run_id}/rerun`, { method: 'POST', allowError: true });
+      console.log(`[biome-medic] re-ran run ${r.run_id} (${r.name})`);
+    }
+  })().catch((err) => {
+    console.error(`[biome-medic] error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/biome/sentinel.js
+++ b/scripts/biome/sentinel.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * BIOME · sentinel — the crew's nociceptor (pain sensor).
+ *
+ * Credit-free, rule-based failure detection. Reads recent workflow runs and open
+ * issues via the GitHub API (GITHUB_TOKEN only) and decides — with deterministic
+ * rules, no AI — whether the fleet is in pain. When it is, sentinel files (or
+ * updates, deduped) a single [BIOME-SENTINEL] incident issue.
+ *
+ * Pure decision functions are exported for unit testing; the CLI at the bottom
+ * performs the actual GitHub I/O.
+ */
+
+const FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'startup_failure']);
+
+const DEFAULTS = {
+  failedRunsThreshold: 3, // matches self-healing.yml FAILED_ACTIONS_THRESHOLD
+  stuckDays: 7,
+};
+
+const STUCK_LABEL_RE = /stuck|checking|self-heal|auto-fix|won't-merge|wont-merge/i;
+const INCIDENT_MARKER = '<!-- biome-sentinel-incident -->';
+
+function labelNames(item) {
+  return (item.labels || []).map((l) => (typeof l === 'string' ? l : (l && l.name) || '')).filter(Boolean);
+}
+
+function classifyRuns(runs) {
+  const list = Array.isArray(runs) ? runs : [];
+  let failed = 0;
+  const recentFailures = [];
+  for (const r of list) {
+    if (FAILURE_CONCLUSIONS.has(r.conclusion)) {
+      failed += 1;
+      recentFailures.push({ id: r.id, name: r.name, path: r.path, url: r.html_url, conclusion: r.conclusion });
+    }
+  }
+  const total = list.length;
+  return { failed, total, failureRate: total ? failed / total : 0, recentFailures };
+}
+
+function detectStuckIssues(issues, nowMs, stuckDays = DEFAULTS.stuckDays) {
+  const cutoff = nowMs - stuckDays * 86400000;
+  const stuck = [];
+  for (const it of Array.isArray(issues) ? issues : []) {
+    if (it.pull_request) continue; // the issues endpoint also returns PRs
+    if (it.state !== 'open') continue;
+    const labels = labelNames(it);
+    if (!labels.some((n) => STUCK_LABEL_RE.test(n))) continue;
+    const updated = Date.parse(it.updated_at);
+    if (Number.isFinite(updated) && updated < cutoff) {
+      stuck.push({ number: it.number, title: it.title, updated_at: it.updated_at, labels });
+    }
+  }
+  return stuck;
+}
+
+function buildSentinelSection(runClass, stuckIssues, thresholds = DEFAULTS) {
+  const failedOverThreshold = runClass.failed >= thresholds.failedRunsThreshold;
+  const hasStuck = stuckIssues.length > 0;
+  let status = 'healthy';
+  if (failedOverThreshold || hasStuck) status = 'degraded';
+  if (failedOverThreshold && hasStuck) status = 'down';
+  return {
+    worker: 'sentinel',
+    status,
+    summary: `${runClass.failed}/${runClass.total} recent runs failed; ${stuckIssues.length} stuck item(s)`,
+    counts: {
+      failed_runs: runClass.failed,
+      total_runs: runClass.total,
+      stuck_issues: stuckIssues.length,
+    },
+    detail: {
+      recent_failures: runClass.recentFailures.slice(0, 10),
+      stuck: stuckIssues.slice(0, 10),
+    },
+  };
+}
+
+function shouldFileIncident(section) {
+  return section.status !== 'healthy';
+}
+
+function buildIncidentBody(section, generatedAtIso) {
+  const f = section.detail.recent_failures || [];
+  const s = section.detail.stuck || [];
+  const lines = [
+    INCIDENT_MARKER,
+    '## 🩹 BIOME Sentinel — fleet pain detected',
+    '',
+    `**Status:** \`${section.status}\`  `,
+    `**Detected:** ${generatedAtIso}  `,
+    `**Lane:** credit-free rule-based (no AI keys required)`,
+    '',
+    `- Failed recent runs: **${section.counts.failed_runs}/${section.counts.total_runs}**`,
+    `- Stuck items: **${section.counts.stuck_issues}**`,
+    '',
+  ];
+  if (f.length) {
+    lines.push('### Recent failed runs');
+    for (const r of f) lines.push(`- ${r.name || r.path || r.id} — \`${r.conclusion}\` ([run](${r.url}))`);
+    lines.push('');
+  }
+  if (s.length) {
+    lines.push('### Stuck items');
+    for (const it of s) lines.push(`- #${it.number} — ${it.title} (last update ${it.updated_at})`);
+    lines.push('');
+  }
+  lines.push('---');
+  lines.push('_biome-medic will attempt rule-based remediation; this issue auto-resolves when the fleet recovers._');
+  return lines.join('\n');
+}
+
+module.exports = {
+  FAILURE_CONCLUSIONS,
+  DEFAULTS,
+  INCIDENT_MARKER,
+  classifyRuns,
+  detectStuckIssues,
+  buildSentinelSection,
+  shouldFileIncident,
+  buildIncidentBody,
+  labelNames,
+};
+
+// --- CLI -------------------------------------------------------------------
+if (require.main === module) {
+  (async () => {
+    const { repoApi } = require('./gh');
+    const runsResp = await repoApi('/actions/runs?per_page=100');
+    const issuesResp = await repoApi('/issues?state=open&per_page=100&filter=all');
+    const runClass = classifyRuns((runsResp && runsResp.workflow_runs) || []);
+    const stuck = detectStuckIssues(issuesResp || [], Date.now(), DEFAULTS.stuckDays);
+    const section = buildSentinelSection(runClass, stuck);
+    const generatedAt = new Date().toISOString();
+    console.log(`[biome-sentinel] status=${section.status} ${section.summary}`);
+
+    if (!shouldFileIncident(section)) {
+      console.log('[biome-sentinel] fleet healthy — no incident filed.');
+      return;
+    }
+
+    // Dedupe: reuse an existing open incident if one is present.
+    const search = await repoApi('/issues?state=open&labels=biome,scorecard&per_page=50', { allowError: true });
+    const existing = Array.isArray(search)
+      ? search.find((i) => !i.pull_request && (i.body || '').includes(INCIDENT_MARKER))
+      : null;
+    const body = buildIncidentBody(section, generatedAt);
+
+    if (existing) {
+      await repoApi(`/issues/${existing.number}/comments`, { method: 'POST', body: { body } });
+      console.log(`[biome-sentinel] updated existing incident #${existing.number}`);
+    } else {
+      const created = await repoApi('/issues', {
+        method: 'POST',
+        body: {
+          title: `[BIOME-SENTINEL] Fleet pain detected (${section.status})`,
+          body,
+          labels: ['biome', 'scorecard', 'self-heal'],
+        },
+      });
+      console.log(`[biome-sentinel] filed incident #${created && created.number}`);
+    }
+  })().catch((err) => {
+    console.error(`[biome-sentinel] error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/biome/sheaf.js
+++ b/scripts/biome/sheaf.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * BIOME · sheaf — the crew's connective tissue (the monitor feed).
+ *
+ * In sheaf theory, local sections that agree on their overlaps glue into a single
+ * global section. Here each worker contributes a LOCAL status section; sheaf glues
+ * them into one globally-consistent fleet-health object and renders it as JSON +
+ * HTML. The overall health is the worst severity across workers.
+ *
+ * Outputs (committed by biome-sheaf.yml, single committer to avoid races):
+ *   docs/biome/biome-status.json  — machine-readable feed (Lovable reads this)
+ *   docs/biome/biome-status.html  — self-contained human view
+ *
+ * Pure functions exported for tests; CLI gathers data (read-only) and writes files.
+ */
+
+const SEVERITY = { healthy: 0, degraded: 1, down: 2 };
+
+function worseOf(a, b) {
+  const sa = SEVERITY[a] === undefined ? 1 : SEVERITY[a];
+  const sb = SEVERITY[b] === undefined ? 1 : SEVERITY[b];
+  return sa >= sb ? a : b;
+}
+
+function computeOverallHealth(sections) {
+  let overall = 'healthy';
+  for (const s of sections || []) overall = worseOf(overall, s.status);
+  return overall;
+}
+
+function glueSections(sections, generatedAtIso) {
+  const workers = {};
+  for (const s of sections || []) {
+    workers[s.worker] = {
+      status: s.status,
+      summary: s.summary || '',
+      counts: s.counts || {},
+      detail: s.detail || {},
+    };
+  }
+  return {
+    schema: 'biome-status/v1',
+    generated_at: generatedAtIso,
+    credit_free: true,
+    overall: computeOverallHealth(sections),
+    workers,
+  };
+}
+
+function badge(status) {
+  return { healthy: '🟢', degraded: '🟡', down: '🔴' }[status] || '⚪';
+}
+
+function escapeHtml(str) {
+  return String(str).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+function renderStatusHtml(status) {
+  const rows = Object.entries(status.workers || {})
+    .map(([name, w]) => {
+      const counts = Object.entries(w.counts || {})
+        .map(([k, v]) => `${escapeHtml(k)}: ${escapeHtml(v)}`)
+        .join(', ');
+      return `      <tr>
+        <td>${badge(w.status)} <strong>${escapeHtml(name)}</strong></td>
+        <td>${escapeHtml(w.status)}</td>
+        <td>${escapeHtml(w.summary)}</td>
+        <td>${escapeHtml(counts)}</td>
+      </tr>`;
+    })
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BIOME Crew Status</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 2rem; color: #0f172a; background: #f8fafc; }
+    h1 { font-size: 1.4rem; }
+    .overall { font-size: 1.1rem; padding: .5rem .9rem; border-radius: 10px; display: inline-block; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+    table { border-collapse: collapse; margin-top: 1rem; background: #fff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.08); width: 100%; }
+    th, td { text-align: left; padding: .6rem .8rem; border-bottom: 1px solid #e2e8f0; font-size: .9rem; }
+    th { background: #0ea5e9; color: #fff; }
+    .meta { color: #64748b; font-size: .8rem; margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>🧬 BIOME Crew Status</h1>
+  <p class="overall">Overall: ${badge(status.overall)} <strong>${escapeHtml(status.overall)}</strong> · credit-free: ${status.credit_free ? 'yes' : 'no'}</p>
+  <table>
+    <thead>
+      <tr><th>Worker</th><th>Status</th><th>Summary</th><th>Counts</th></tr>
+    </thead>
+    <tbody>
+${rows}
+    </tbody>
+  </table>
+  <p class="meta">Generated ${escapeHtml(status.generated_at)} · schema ${escapeHtml(status.schema)} · machine feed: <code>biome-status.json</code></p>
+</body>
+</html>
+`;
+}
+
+module.exports = { SEVERITY, worseOf, computeOverallHealth, glueSections, renderStatusHtml, badge };
+
+// --- CLI -------------------------------------------------------------------
+if (require.main === module) {
+  (async () => {
+    const fs = require('fs');
+    const path = require('path');
+    const { repoApi } = require('./gh');
+    const sentinel = require('./sentinel');
+    const homeostat = require('./homeostat');
+
+    const generatedAt = new Date().toISOString();
+
+    // Read-only data gather.
+    const runsResp = await repoApi('/actions/runs?per_page=100');
+    const issuesResp = (await repoApi('/issues?state=open&per_page=100&filter=all')) || [];
+    const runs = (runsResp && runsResp.workflow_runs) || [];
+
+    const runClass = sentinel.classifyRuns(runs);
+    const stuck = sentinel.detectStuckIssues(issuesResp, Date.now());
+    const sentinelSection = sentinel.buildSentinelSection(runClass, stuck);
+
+    const assessment = homeostat.assessKeyHealth(process.env);
+    const homeostatSection = homeostat.buildHomeostatSection(assessment);
+
+    // medic's own last-run health, derived from the recent runs list.
+    const medicRun = runs.find((r) => String(r.path || '').includes('biome-medic'));
+    const medicSection = {
+      worker: 'medic',
+      status: medicRun && sentinel.FAILURE_CONCLUSIONS.has(medicRun.conclusion) ? 'degraded' : 'healthy',
+      summary: medicRun ? `last run: ${medicRun.conclusion || medicRun.status}` : 'no recent run yet',
+      counts: {},
+      detail: { last_run: medicRun ? medicRun.html_url : null },
+    };
+
+    const sheafSection = {
+      worker: 'sheaf',
+      status: 'healthy',
+      summary: 'feed generated',
+      counts: { workers: 3 },
+      detail: {},
+    };
+
+    const status = glueSections([sentinelSection, homeostatSection, medicSection, sheafSection], generatedAt);
+
+    const outDir = path.join(process.cwd(), 'docs', 'biome');
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, 'biome-status.json'), `${JSON.stringify(status, null, 2)}\n`);
+    fs.writeFileSync(path.join(outDir, 'biome-status.html'), renderStatusHtml(status));
+    console.log(`[biome-sheaf] wrote feed: overall=${status.overall}`);
+  })().catch((err) => {
+    console.error(`[biome-sheaf] error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/tests/biome-gh.test.js
+++ b/tests/biome-gh.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+// gh.js reads global fetch at call time, so we can stub it per-case.
+const { api } = require('../scripts/biome/gh');
+
+function stubFetch({ ok, status, body }) {
+  global.fetch = async () => ({
+    ok,
+    status,
+    text: async () => body,
+    json: async () => JSON.parse(body),
+  });
+}
+
+const ORIGINAL_FETCH = global.fetch;
+test.after(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+test('204 returns null', async () => {
+  stubFetch({ ok: true, status: 204, body: '' });
+  assert.equal(await api('/x'), null);
+});
+
+test('empty body returns null', async () => {
+  stubFetch({ ok: true, status: 200, body: '' });
+  assert.equal(await api('/x'), null);
+});
+
+test('ok + valid JSON parses', async () => {
+  stubFetch({ ok: true, status: 200, body: '{"hello":"world"}' });
+  assert.deepEqual(await api('/x'), { hello: 'world' });
+});
+
+test('ok + non-JSON throws (surfaced, not silently masked as null)', async () => {
+  stubFetch({ ok: true, status: 200, body: '<html>502 Bad Gateway</html>' });
+  await assert.rejects(() => api('/x'), /returned non-JSON/);
+});
+
+test('non-ok + allowError returns null (graceful degrade, no throw on error page)', async () => {
+  stubFetch({ ok: false, status: 502, body: '<html>Bad Gateway</html>' });
+  assert.equal(await api('/x', { allowError: true }), null);
+});
+
+test('non-ok without allowError throws', async () => {
+  stubFetch({ ok: false, status: 500, body: 'boom' });
+  await assert.rejects(() => api('/x'), /-> 500/);
+});

--- a/tests/biome-gh.test.js
+++ b/tests/biome-gh.test.js
@@ -35,9 +35,14 @@ test('ok + valid JSON parses', async () => {
   assert.deepEqual(await api('/x'), { hello: 'world' });
 });
 
-test('ok + non-JSON throws (surfaced, not silently masked as null)', async () => {
+test('ok + non-JSON throws by default (surfaced, not silently masked as null)', async () => {
   stubFetch({ ok: true, status: 200, body: '<html>502 Bad Gateway</html>' });
   await assert.rejects(() => api('/x'), /returned non-JSON/);
+});
+
+test('ok + non-JSON + allowError returns null (caller opted into graceful degrade)', async () => {
+  stubFetch({ ok: true, status: 200, body: '<html>unexpected</html>' });
+  assert.equal(await api('/x', { allowError: true }), null);
 });
 
 test('non-ok + allowError returns null (graceful degrade, no throw on error page)', async () => {

--- a/tests/biome-homeostat.test.js
+++ b/tests/biome-homeostat.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  assessKeyHealth,
+  buildHomeostatSection,
+  buildStatusBody,
+  STATUS_MARKER,
+  TRACKED_KEYS,
+} = require('../scripts/biome/homeostat');
+
+test('assessKeyHealth treats empty/whitespace/undefined as missing', () => {
+  const env = { OPENROUTER_API_KEY: 'real', ANTHROPIC_API_KEY: '', PERPLEXITY_API_KEY: '   ' };
+  const a = assessKeyHealth(env);
+  assert.deepEqual(a.present, ['OPENROUTER_API_KEY']);
+  assert.deepEqual(a.missing.sort(), ['ANTHROPIC_API_KEY', 'PERPLEXITY_API_KEY'].sort());
+  assert.equal(a.aiLanesOffline, true);
+});
+
+test('assessKeyHealth all present -> lanes online', () => {
+  const env = {};
+  for (const k of TRACKED_KEYS) env[k] = 'x';
+  const a = assessKeyHealth(env);
+  assert.equal(a.aiLanesOffline, false);
+  assert.equal(a.missing.length, 0);
+});
+
+test('homeostat section stays healthy even when AI lanes are offline (credit-free by design)', () => {
+  const a = assessKeyHealth({}); // all missing
+  const section = buildHomeostatSection(a);
+  assert.equal(section.status, 'healthy');
+  assert.equal(section.detail.ai_lanes, 'offline');
+  assert.match(section.summary, /rule-based/);
+});
+
+test('status body carries dedupe marker and reassures (not an outage)', () => {
+  const a = assessKeyHealth({});
+  const body = buildStatusBody(a, '2026-06-30T00:00:00Z');
+  assert.ok(body.includes(STATUS_MARKER));
+  assert.match(body, /not\*\* an outage|not.*outage/i);
+});

--- a/tests/biome-medic.test.js
+++ b/tests/biome-medic.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { decideRemediations, DEFAULT_CAPS } = require('../scripts/biome/medic');
+
+test('reruns are OFF by default (storm-safe)', () => {
+  const plan = decideRemediations({
+    recentFailures: [{ id: 1, name: 'X', path: '.github/workflows/x.yml' }],
+  });
+  assert.equal(plan.reruns.length, 0);
+  assert.equal(DEFAULT_CAPS.allowReruns, false);
+});
+
+test('stuck issues get self-heal label + comment, never a content delete', () => {
+  const plan = decideRemediations({ stuckIssues: [{ number: 7 }, { number: 8 }] });
+  assert.equal(plan.relabels.length, 2);
+  for (const r of plan.relabels) {
+    assert.deepEqual(r.add, ['self-heal']);
+    assert.deepEqual(r.remove, []);
+    assert.ok(r.comment);
+  }
+});
+
+test('key-blocks only cleared when AI lanes are offline', () => {
+  const online = decideRemediations({ keyBlockedIssues: [{ number: 1 }], aiLanesOffline: false });
+  assert.equal(online.keyUnblocks.length, 0);
+
+  const offline = decideRemediations({ keyBlockedIssues: [{ number: 1 }], aiLanesOffline: true });
+  assert.equal(offline.keyUnblocks.length, 1);
+  assert.deepEqual(offline.keyUnblocks[0].remove, ['openrouter:needs-key']);
+  assert.deepEqual(offline.keyUnblocks[0].add, ['self-heal']);
+});
+
+test('reruns (when enabled) exclude BIOME workflows and respect cap', () => {
+  const failures = [
+    { id: 1, name: 'a', path: '.github/workflows/a.yml' },
+    { id: 2, name: 'biome-sheaf', path: '.github/workflows/biome-sheaf.yml' },
+    { id: 3, name: 'c', path: '.github/workflows/c.yml' },
+    { id: 4, name: 'd', path: '.github/workflows/d.yml' },
+    { id: 5, name: 'e', path: '.github/workflows/e.yml' },
+  ];
+  const plan = decideRemediations({ recentFailures: failures, caps: { allowReruns: true, maxReruns: 3 } });
+  assert.ok(plan.reruns.every((r) => r.name !== 'biome-sheaf'));
+  assert.equal(plan.reruns.length, 3);
+  assert.equal(plan.capped.reruns, true);
+});
+
+test('relabels respect cap', () => {
+  const stuck = Array.from({ length: 15 }, (_, i) => ({ number: i + 1 }));
+  const plan = decideRemediations({ stuckIssues: stuck, caps: { maxRelabels: 10 } });
+  assert.equal(plan.relabels.length, 10);
+  assert.equal(plan.capped.relabels, true);
+});

--- a/tests/biome-sentinel.test.js
+++ b/tests/biome-sentinel.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  classifyRuns,
+  detectStuckIssues,
+  buildSentinelSection,
+  shouldFileIncident,
+  buildIncidentBody,
+  INCIDENT_MARKER,
+  DEFAULTS,
+} = require('../scripts/biome/sentinel');
+
+const DAY = 86400000;
+const NOW = Date.parse('2026-06-30T00:00:00Z');
+
+test('classifyRuns counts failure/timed_out/startup_failure as failed', () => {
+  const runs = [
+    { id: 1, conclusion: 'success' },
+    { id: 2, conclusion: 'failure' },
+    { id: 3, conclusion: 'timed_out' },
+    { id: 4, conclusion: 'startup_failure' },
+    { id: 5, conclusion: 'cancelled' },
+  ];
+  const r = classifyRuns(runs);
+  assert.equal(r.failed, 3);
+  assert.equal(r.total, 5);
+  assert.equal(r.recentFailures.length, 3);
+});
+
+test('classifyRuns handles empty/non-array input', () => {
+  assert.deepEqual(classifyRuns([]), { failed: 0, total: 0, failureRate: 0, recentFailures: [] });
+  assert.equal(classifyRuns(undefined).total, 0);
+});
+
+test('detectStuckIssues flags only open, watched-label, old issues', () => {
+  const issues = [
+    { number: 1, state: 'open', updated_at: new Date(NOW - 10 * DAY).toISOString(), labels: ['stuck'] },
+    { number: 2, state: 'open', updated_at: new Date(NOW - 1 * DAY).toISOString(), labels: ['stuck'] }, // too recent
+    { number: 3, state: 'open', updated_at: new Date(NOW - 20 * DAY).toISOString(), labels: ['enhancement'] }, // not watched
+    { number: 4, state: 'closed', updated_at: new Date(NOW - 20 * DAY).toISOString(), labels: ['stuck'] }, // closed
+    { number: 5, state: 'open', updated_at: new Date(NOW - 20 * DAY).toISOString(), labels: [{ name: 'auto-fix' }], pull_request: {} }, // PR
+  ];
+  const stuck = detectStuckIssues(issues, NOW, 7);
+  assert.deepEqual(stuck.map((s) => s.number), [1]);
+});
+
+test('buildSentinelSection escalates healthy -> degraded -> down', () => {
+  const healthy = buildSentinelSection({ failed: 0, total: 10, failureRate: 0, recentFailures: [] }, []);
+  assert.equal(healthy.status, 'healthy');
+  assert.equal(shouldFileIncident(healthy), false);
+
+  const degradedByRuns = buildSentinelSection({ failed: 3, total: 10, failureRate: 0.3, recentFailures: [] }, []);
+  assert.equal(degradedByRuns.status, 'degraded');
+
+  const degradedByStuck = buildSentinelSection({ failed: 0, total: 10, failureRate: 0, recentFailures: [] }, [{ number: 9 }]);
+  assert.equal(degradedByStuck.status, 'degraded');
+
+  const down = buildSentinelSection({ failed: 5, total: 10, failureRate: 0.5, recentFailures: [] }, [{ number: 9 }]);
+  assert.equal(down.status, 'down');
+  assert.equal(shouldFileIncident(down), true);
+});
+
+test('failedRunsThreshold matches self-healing.yml (3)', () => {
+  assert.equal(DEFAULTS.failedRunsThreshold, 3);
+});
+
+test('buildIncidentBody embeds dedupe marker', () => {
+  const section = buildSentinelSection({ failed: 4, total: 5, failureRate: 0.8, recentFailures: [{ id: 1, name: 'X', url: 'u', conclusion: 'failure' }] }, []);
+  const body = buildIncidentBody(section, '2026-06-30T00:00:00Z');
+  assert.ok(body.includes(INCIDENT_MARKER));
+  assert.ok(body.includes('credit-free'));
+});

--- a/tests/biome-sheaf.test.js
+++ b/tests/biome-sheaf.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { worseOf, computeOverallHealth, glueSections, renderStatusHtml } = require('../scripts/biome/sheaf');
+
+test('worseOf returns the more severe status', () => {
+  assert.equal(worseOf('healthy', 'degraded'), 'degraded');
+  assert.equal(worseOf('down', 'degraded'), 'down');
+  assert.equal(worseOf('healthy', 'healthy'), 'healthy');
+});
+
+test('computeOverallHealth is the worst across sections (sheaf gluing)', () => {
+  assert.equal(computeOverallHealth([{ status: 'healthy' }, { status: 'degraded' }]), 'degraded');
+  assert.equal(computeOverallHealth([{ status: 'healthy' }, { status: 'down' }, { status: 'degraded' }]), 'down');
+  assert.equal(computeOverallHealth([{ status: 'healthy' }]), 'healthy');
+});
+
+test('glueSections produces a credit-free v1 status object keyed by worker', () => {
+  const status = glueSections(
+    [
+      { worker: 'sentinel', status: 'healthy', summary: 's', counts: { a: 1 } },
+      { worker: 'homeostat', status: 'degraded', summary: 'h' },
+    ],
+    '2026-06-30T00:00:00Z'
+  );
+  assert.equal(status.schema, 'biome-status/v1');
+  assert.equal(status.credit_free, true);
+  assert.equal(status.generated_at, '2026-06-30T00:00:00Z');
+  assert.equal(status.overall, 'degraded');
+  assert.ok(status.workers.sentinel);
+  assert.equal(status.workers.sentinel.counts.a, 1);
+  assert.deepEqual(status.workers.homeostat.counts, {});
+});
+
+test('renderStatusHtml is self-contained and escapes content', () => {
+  const status = glueSections([{ worker: 'x<script>', status: 'healthy', summary: 'a & b' }], '2026-06-30T00:00:00Z');
+  const html = renderStatusHtml(status);
+  assert.ok(html.startsWith('<!DOCTYPE html>'));
+  assert.ok(html.includes('BIOME Crew Status'));
+  assert.ok(html.includes('x&lt;script&gt;'));
+  assert.ok(html.includes('a &amp; b'));
+  assert.ok(!html.includes('<script>'));
+});

--- a/tests/biome-workflows.test.js
+++ b/tests/biome-workflows.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('yaml');
+
+const WF_DIR = path.join(__dirname, '..', '.github', 'workflows');
+const BIOME_WORKFLOWS = ['biome-sentinel.yml', 'biome-homeostat.yml', 'biome-medic.yml', 'biome-sheaf.yml'];
+
+const TOKEN_FALLBACK = "secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN";
+
+function readWf(file) {
+  const raw = fs.readFileSync(path.join(WF_DIR, file), 'utf8');
+  return { raw, doc: yaml.parse(raw) };
+}
+
+for (const file of BIOME_WORKFLOWS) {
+  test(`${file} parses and declares name + trigger`, () => {
+    const { doc } = readWf(file);
+    assert.ok(doc.name, 'missing name');
+    // yaml parses bare `on:` as the boolean key true
+    assert.ok(doc.on || doc.true, 'missing on: trigger');
+  });
+
+  test(`${file} sets GH_REPO and the token-with-fallback pattern`, () => {
+    const { raw } = readWf(file);
+    assert.ok(raw.includes('GH_REPO: ${{ github.repository }}'), 'missing GH_REPO env');
+    assert.ok(raw.includes(TOKEN_FALLBACK), 'missing token-with-fallback pattern');
+  });
+
+  test(`${file} declares an explicit permissions block`, () => {
+    const { doc } = readWf(file);
+    assert.ok(doc.permissions && typeof doc.permissions === 'object', 'missing permissions block');
+  });
+
+  test(`${file} does not interpolate untrusted github.event.* into run: shells`, () => {
+    const { doc } = readWf(file);
+    const jobs = doc.jobs || {};
+    for (const job of Object.values(jobs)) {
+      for (const step of job.steps || []) {
+        if (typeof step.run === 'string') {
+          assert.ok(
+            !/\$\{\{\s*github\.event\./.test(step.run),
+            `step "${step.name}" interpolates github.event.* directly into run:`
+          );
+        }
+      }
+    }
+  });
+}
+
+test('biome-sheaf is the only worker granted contents: write (single committer)', () => {
+  const writers = [];
+  for (const file of BIOME_WORKFLOWS) {
+    const { doc } = readWf(file);
+    if (doc.permissions && doc.permissions.contents === 'write') writers.push(file);
+  }
+  assert.deepEqual(writers, ['biome-sheaf.yml']);
+});


### PR DESCRIPTION
## Summary

Adds **BIOME** (Biomimetic Independent Operations & Monitoring Engine) — a new self-healing crew that runs *alongside* the existing ~70-workflow fleet and keeps healing **when Doppler wipes the AI-lane keys**. Every worker is rule-based and uses only the free, built-in `GITHUB_TOKEN`; no OpenRouter/Anthropic/Perplexity credits are ever required. This is the layer that stops the loop collapsing to a dead "static-fallback · needs-human" stub when secrets disappear.

**Additive only** — no existing workflow, script, or doc is edited, renamed, or deleted (per `COMMENT-DONT-DELETE` / `PRESERVE_GOALS_AND_HISTORY`). Workers only add labels/comments and close resolved ops issues; they never delete content (removing a stale *label* is metadata, not a content deletion).

No associated issue.

## Changes

- **Workers** (new workflows + scripts, all credit-free):
  - `biome-sentinel` — nociceptor: rule-based failure/stuck detection; files one deduped `[BIOME-SENTINEL]` incident.
  - `biome-medic` — macrophage: storm-safe remediation (re-label + comment; clear dead `openrouter:needs-key` blocks when AI lanes are offline). Re-running failed runs is **off by default** and excludes BIOME's own workflows.
  - `biome-homeostat` — homeostasis: treats missing AI keys as *informational*, posts **one** consolidated deduped status note, auto-resolves when keys return.
  - `biome-sheaf` — connective tissue: glues each worker's local status section into one global feed (`docs/biome/biome-status.json` + `.html`). Single committer (only worker with `contents: write`).
- **Monitor feed** — `docs/biome/biome-status.json` (schema `biome-status/v1`) committed so an external monitor (e.g. Lovable) can poll the raw JSON. A bootstrap snapshot is seeded; the first hourly `biome-sheaf` run replaces it with live data.
- **Docs** — `docs/biome/README.md` (design + the sheaf/biomimicry metaphor + loop) and `docs/biome/crew.yml` (worker registry with the AGENT_FACTORY_STANDARD frontmatter).
- **Tests** — `tests/biome-{sentinel,homeostat,medic,sheaf}.test.js` (rule-based logic) + `tests/biome-workflows.test.js` (asserts GH_REPO, token-with-fallback, narrow permissions, no untrusted `github.event.*` interpolation, single committer).

## Validation

- `npm test` → **271 pass / 0 fail** (adds 36 BIOME tests; nothing else regressed).
- All 4 new workflows parse via `yaml.safe_load`.
- `docs/biome/biome-status.json` is valid JSON; `markdownlint-cli2` on `docs/biome/README.md` → 0 errors (mirrors the CircleCI changed-Markdown gate).
- Conventions verified by `biome-workflows.test.js`: `GH_REPO`, token-with-fallback, explicit narrow permissions, no `${{ github.event.* }}` in `run:` shells, and `biome-sheaf` as the sole `contents: write` committer.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — N/A, no associated issue
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtW5jiCNuzxDCW4tjSkZ66)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces **BIOME** (Biomimetic Independent Operations & Monitoring Engine), a new credit-free self-healing system that operates alongside the existing ~70-workflow fleet. BIOME provides resilience when AI service API keys are missing or rotated by using only rule-based logic and the built-in `GITHUB_TOKEN`. The system consists of four workers: `biome-sentinel` (detects failures and stuck issues), `biome-homeostat` (monitors AI key availability), `biome-medic` (performs safe remediation like re-labeling), and `biome-sheaf` (aggregates status into a machine-readable feed). The implementation is entirely additive with no modifications to existing workflows, includes comprehensive test coverage (36 new tests), and publishes a JSON/HTML status feed that external monitors can poll.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/biome/README.md` |
| 2 | `docs/biome/crew.yml` |
| 3 | `docs/biome/biome-status.json` |
| 4 | `docs/biome/biome-status.html` |
| 5 | `scripts/biome/gh.js` |
| 6 | `scripts/biome/sentinel.js` |
| 7 | `scripts/biome/homeostat.js` |
| 8 | `scripts/biome/medic.js` |
| 9 | `scripts/biome/sheaf.js` |
| 10 | `.github/workflows/biome-sentinel.yml` |
| 11 | `.github/workflows/biome-homeostat.yml` |
| 12 | `.github/workflows/biome-medic.yml` |
| 13 | `.github/workflows/biome-sheaf.yml` |
| 14 | `tests/biome-sentinel.test.js` |
| 15 | `tests/biome-homeostat.test.js` |
| 16 | `tests/biome-medic.test.js` |
| 17 | `tests/biome-sheaf.test.js` |
| 18 | `tests/biome-workflows.test.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add BIOME, a credit‑free self‑healing crew that runs alongside the workflow fleet and keeps recovery going when external keys are missing. Includes four rule‑based workers and an hourly committed status feed, plus a hardened and unit‑tested GitHub API helper to prevent duplicate incidents.

- **New Features**
  - New workflows: `biome-sentinel` (detect failures/stuck), `biome-medic` (safe relabel/unblock), `biome-homeostat` (consolidated external‑key status), `biome-sheaf` (status feed).
  - Status feed committed at `docs/biome/biome-status.json` (+ `.html`), single committer (`biome-sheaf`), pollable by external monitors.
  - Additive only; workers use `GITHUB_TOKEN` (admin PAT fallback) with narrow permissions; no untrusted `${{ github.event.* }}` in shells.

- **Bug Fixes**
  - `scripts/biome/gh.js`: stricter JSON handling — surface non‑JSON on success by default; with `allowError`, return null for error pages and unexpected non‑JSON to degrade gracefully and avoid duplicate incidents.
  - `tests/biome-gh.test.js`: add unit coverage for 204/empty, ok+non‑JSON throws by default, ok+non‑JSON with `allowError` → null, and non‑ok with/without `allowError`.
  - `docs/PROVENANCE_STANDARD.md`: register BIOME crew and its status feed.

<sup>Written for commit df4a8ed86973e44fc91cf84d6101af5757777bb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

