### PR TITLE
docs: BNAT-UTEN Vercel link in READMEs + fix AUTOMATION_AUDIT lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Curated reading list — sorted by *when you'll need it*, not by topic. Open the
 | Designing project delivery orchestration and completion gates | [`docs/orchestration/project-orchestration-standard.md`](docs/orchestration/project-orchestration-standard.md) | Standard |
 | Setting up the Notion knowledge layer | [`docs/notion-structure.md`](docs/notion-structure.md) | Spec |
 | Adding a new MCP server to the WR/PR control plane | [`docs/Master_Inventory/MCP_STANDARD.md`](docs/Master_Inventory/MCP_STANDARD.md) + [`docs/MCP_REVVEL_CATALOG.md`](docs/MCP_REVVEL_CATALOG.md) | Standard + catalog |
+| Exploring the BNAT-UTEN data-center waste-heat reuse initiative | [`docs/grok/uten/Colorado/README.md`](docs/grok/uten/Colorado/README.md) · [live dashboard](https://revvel-standards.vercel.app/docs/grok/uten/Colorado/dashboard.html) | Design + interactive dashboard |
 
 When you add a new reference doc, add a row to this table. The table is the index — keep it short, keep it sorted by *trigger*, and link directly to the source. See [`REMINDERS.md`](./REMINDERS.md) for the matching activity-based reminders index.
 
@@ -168,7 +169,7 @@ Zero-downtime automation when AI agents hit rate limits — the orchestrator can
 📖 **Documentation:**
 - [`docs/DEFINITION_OF_DONE.md`](docs/DEFINITION_OF_DONE.md) — one-iteration build scope
 - [`projects/agent-generated/_examples/`](projects/agent-generated/_examples/) — Example projects
-- [`docs/30Dayiteration/`](docs/30Dayiteration/) — _archived_ 30-day launch framework (superseded, kept for reference)
+- [`docs/30Dayiteration/`](docs/30Dayiteration/) — *archived* 30-day launch framework (superseded, kept for reference)
 
 **Marketing rollout** (the build itself is one iteration; promotion plays out over time):
 - **Research & validate** — confirm demand, build waitlist (30-50 signups)
@@ -197,25 +198,25 @@ Zero-downtime automation when AI agents hit rate limits — the orchestrator can
 
 ### Essential AI & Development Tools
 **Multi-Agent AI Systems:**
-- **OpenRouter** (https://openrouter.ai) - Unified API for multiple LLMs, cost-effective routing
+- **OpenRouter** (<https://openrouter.ai>) - Unified API for multiple LLMs, cost-effective routing
 - **Anthropic Claude** (Sonnet 4, 4.5) - Advanced reasoning, long context windows up to 200k tokens
-- **DeepSeek** (https://deepseek.com) - Cutting-edge open models with competitive performance
-- **Grok** (https://grok.x.ai) - Fast inference, real-time data access
-- **Kimi** (https://kimi.ai) - Long-context Chinese/English model (200k+ tokens)
-- **Venice.ai** (https://venice.ai) - Privacy-focused AI with uncensored models
+- **DeepSeek** (<https://deepseek.com>) - Cutting-edge open models with competitive performance
+- **Grok** (<https://grok.x.ai>) - Fast inference, real-time data access
+- **Kimi** (<https://kimi.ai>) - Long-context Chinese/English model (200k+ tokens)
+- **Venice.ai** (<https://venice.ai>) - Privacy-focused AI with uncensored models
 
 **Development & Coding Assistants:**
-- **Cursor** (https://cursor.sh) - AI-first code editor with GPT-4 integration
+- **Cursor** (<https://cursor.sh>) - AI-first code editor with GPT-4 integration
 - **GitHub Copilot** - Context-aware code completion
-- **Codeium** (https://codeium.com) - Free AI autocomplete for 70+ languages
-- **Tabnine** (https://tabnine.com) - Privacy-focused code completion
+- **Codeium** (<https://codeium.com>) - Free AI autocomplete for 70+ languages
+- **Tabnine** (<https://tabnine.com>) - Privacy-focused code completion
 - **Replit Ghostwriter** - AI pair programmer for collaborative coding
 
 **Research & Knowledge Tools:**
-- **Perplexity no-key research** (https://github.com/helallao/perplexity-ai) - Perplexity-backed issue research without a required official API key
-- **Elicit** (https://elicit.org) - AI research assistant for academic papers
-- **Consensus** (https://consensus.app) - Evidence-based answers from research papers
-- **Scite** (https://scite.ai) - Smart citations showing supporting/contrasting evidence
+- **Perplexity no-key research** (<https://github.com/helallao/perplexity-ai>) - Perplexity-backed issue research without a required official API key
+- **Elicit** (<https://elicit.org>) - AI research assistant for academic papers
+- **Consensus** (<https://consensus.app>) - Evidence-based answers from research papers
+- **Scite** (<https://scite.ai>) - Smart citations showing supporting/contrasting evidence
 
 ### The 8-Phase Lifecycle
 | Phase | Name | Focus | Key Deliverable |
@@ -227,97 +228,96 @@ Zero-downtime automation when AI agents hit rate limits — the orchestrator can
 ### Frontend Frameworks & Libraries
 
 **React Ecosystem:**
-- **React** (https://react.dev) - Component-based UI library
-- **Next.js** (https://nextjs.org) - Full-stack React framework (recommended)
-- **Remix** (https://remix.run) - Full-stack web framework
-- **Gatsby** (https://gatsbyjs.com) - Static site generator
+- **React** (<https://react.dev>) - Component-based UI library
+- **Next.js** (<https://nextjs.org>) - Full-stack React framework (recommended)
+- **Remix** (<https://remix.run>) - Full-stack web framework
+- **Gatsby** (<https://gatsbyjs.com>) - Static site generator
 - **Create React App** (deprecated - use Vite instead)
 
 **Vue Ecosystem:**
-- **Vue 3** (https://vuejs.org) - Progressive JavaScript framework
-- **Nuxt 3** (https://nuxt.com) - Vue meta-framework
-- **Vite** (https://vitejs.dev) - Next-generation build tool
-- **Quasar** (https://quasar.dev) - Vue component framework
+- **Vue 3** (<https://vuejs.org>) - Progressive JavaScript framework
+- **Nuxt 3** (<https://nuxt.com>) - Vue meta-framework
+- **Vite** (<https://vitejs.dev>) - Next-generation build tool
+- **Quasar** (<https://quasar.dev>) - Vue component framework
 
 **Other Frameworks:**
-- **Svelte** (https://svelte.dev) - Compiled framework (no virtual DOM)
-- **SvelteKit** (https://kit.svelte.dev) - Svelte application framework
-- **Solid.js** (https://solidjs.com) - Reactive UI library
-- **Angular** (https://angular.io) - Full-featured framework by Google
-- **Preact** (https://preactjs.com) - 3KB React alternative
-- **Alpine.js** (https://alpinejs.dev) - Lightweight JavaScript framework
-- **Astro** (https://astro.build) - Content-focused web framework
-- **Qwik** (https://qwik.builder.io) - Resumable web framework
+- **Svelte** (<https://svelte.dev>) - Compiled framework (no virtual DOM)
+- **SvelteKit** (<https://kit.svelte.dev>) - Svelte application framework
+- **Solid.js** (<https://solidjs.com>) - Reactive UI library
+- **Angular** (<https://angular.io>) - Full-featured framework by Google
+- **Preact** (<https://preactjs.com>) - 3KB React alternative
+- **Alpine.js** (<https://alpinejs.dev>) - Lightweight JavaScript framework
+- **Astro** (<https://astro.build>) - Content-focused web framework
+- **Qwik** (<https://qwik.builder.io>) - Resumable web framework
 
 **UI Component Libraries:**
-- **shadcn/ui** (https://ui.shadcn.com) - Re-usable components (Radix + Tailwind)
-- **Radix UI** (https://radix-ui.com) - Unstyled, accessible components
-- **Headless UI** (https://headlessui.com) - Unstyled components by Tailwind Labs
-- **Material UI** (https://mui.com) - React components implementing Material Design
-- **Ant Design** (https://ant.design) - Enterprise-class UI design system
-- **Chakra UI** (https://chakra-ui.com) - Simple and modular components
-- **Mantine** (https://mantine.dev) - Fully-featured React components library
-- **Daisy UI** (https://daisyui.com) - Tailwind CSS component library
+- **shadcn/ui** (<https://ui.shadcn.com>) - Re-usable components (Radix + Tailwind)
+- **Radix UI** (<https://radix-ui.com>) - Unstyled, accessible components
+- **Headless UI** (<https://headlessui.com>) - Unstyled components by Tailwind Labs
+- **Material UI** (<https://mui.com>) - React components implementing Material Design
+- **Ant Design** (<https://ant.design>) - Enterprise-class UI design system
+- **Chakra UI** (<https://chakra-ui.com>) - Simple and modular components
+- **Mantine** (<https://mantine.dev>) - Fully-featured React components library
+- **Daisy UI** (<https://daisyui.com>) - Tailwind CSS component library
 
 **CSS Frameworks:**
-- **Tailwind CSS** (https://tailwindcss.com) - Utility-first CSS framework (recommended)
-- **UnoCSS** (https://unocss.dev) - Instant on-demand atomic CSS
-- **Bootstrap** (https://getbootstrap.com) - Classic responsive framework
-- **Bulma** (https://bulma.io) - Modern CSS framework
-- **Foundation** (https://get.foundation) - Responsive front-end framework
+- **Tailwind CSS** (<https://tailwindcss.com>) - Utility-first CSS framework (recommended)
+- **UnoCSS** (<https://unocss.dev>) - Instant on-demand atomic CSS
+- **Bootstrap** (<https://getbootstrap.com>) - Classic responsive framework
+- **Bulma** (<https://bulma.io>) - Modern CSS framework
+- **Foundation** (<https://get.foundation>) - Responsive front-end framework
 | **3** | Development | Rapid Coding | Functional MVP, GitHub Repo |
 | **4** | Testing | QA & Security | Unit/E2E Tests, Security Scan |
 
 ### Testing & Quality Assurance Tools
 
 **Unit Testing:**
-- **Vitest** (https://vitest.dev) - Fast unit test framework (Vite-powered)
-- **Jest** (https://jestjs.io) - JavaScript testing framework
-- **Mocha** (https://mochajs.org) - Feature-rich test framework
-- **Chai** (https://chaijs.com) - BDD/TDD assertion library
-- **AVA** (https://avajs.dev) - Minimalist testing framework
+- **Vitest** (<https://vitest.dev>) - Fast unit test framework (Vite-powered)
+- **Jest** (<https://jestjs.io>) - JavaScript testing framework
+- **Mocha** (<https://mochajs.org>) - Feature-rich test framework
+- **Chai** (<https://chaijs.com>) - BDD/TDD assertion library
+- **AVA** (<https://avajs.dev>) - Minimalist testing framework
 
 **End-to-End Testing:**
-- **Playwright** (https://playwright.dev) - Cross-browser automation (recommended)
-- **Cypress** (https://cypress.io) - Front-end testing tool
-- **Puppeteer** (https://pptr.dev) - Chrome DevTools Protocol automation
-- **WebdriverIO** (https://webdriver.io) - Next-gen browser automation
-- **TestCafe** (https://testcafe.io) - Node.js E2E testing framework
+- **Playwright** (<https://playwright.dev>) - Cross-browser automation (recommended)
+- **Cypress** (<https://cypress.io>) - Front-end testing tool
+- **Puppeteer** (<https://pptr.dev>) - Chrome DevTools Protocol automation
+- **WebdriverIO** (<https://webdriver.io>) - Next-gen browser automation
+- **TestCafe** (<https://testcafe.io>) - Node.js E2E testing framework
 
 **API Testing:**
-- **Postman** (https://postman.com) - API development and testing platform
-- **Insomnia** (https://insomnia.rest) - API client and testing tool
-- **HTTPie** (https://httpie.io) - Human-friendly HTTP client
+- **Postman** (<https://postman.com>) - API development and testing platform
+- **Insomnia** (<https://insomnia.rest>) - API client and testing tool
+- **HTTPie** (<https://httpie.io>) - Human-friendly HTTP client
 - **REST Client** (VS Code extension) - Send HTTP requests from editor
-- **Hoppscotch** (https://hoppscotch.io) - Open-source API development ecosystem
+- **Hoppscotch** (<https://hoppscotch.io>) - Open-source API development ecosystem
 
 **Security Testing:**
-- **OWASP ZAP** (https://zaproxy.org) - Web app security scanner (FREE, open source)
-- **Snyk** (https://snyk.io) - Dependency vulnerability scanning (FREE tier)
-- **Semgrep** (https://semgrep.dev) - Static analysis for code security
+- **OWASP ZAP** (<https://zaproxy.org>) - Web app security scanner (FREE, open source)
+- **Snyk** (<https://snyk.io>) - Dependency vulnerability scanning (FREE tier)
+- **Semgrep** (<https://semgrep.dev>) - Static analysis for code security
 - **npm audit** - Built-in npm vulnerability checker
-- **Trivy** (https://trivy.dev) - Container and dependency scanner
-- **SonarQube** (https://sonarqube.org) - Code quality and security analysis
+- **Trivy** (<https://trivy.dev>) - Container and dependency scanner
+- **SonarQube** (<https://sonarqube.org>) - Code quality and security analysis
 
 **Performance Testing:**
 - **Lighthouse** (Chrome DevTools) - Web performance auditing
-- **WebPageTest** (https://webpagetest.org) - Website performance testing
-- **k6** (https://k6.io) - Load testing tool for developers
-- **Artillery** (https://artillery.io) - Load testing and smoke testing
-- **Locust** (https://locust.io) - Python-based load testing tool
+- **WebPageTest** (<https://webpagetest.org>) - Website performance testing
+- **k6** (<https://k6.io>) - Load testing tool for developers
+- **Artillery** (<https://artillery.io>) - Load testing and smoke testing
+- **Locust** (<https://locust.io>) - Python-based load testing tool
 
 **Code Quality:**
-- **ESLint** (https://eslint.org) - JavaScript linting
-- **Biome** (https://biomejs.dev) - Fast linter/formatter (Rust-based)
-- **Prettier** (https://prettier.io) - Code formatter
+- **ESLint** (<https://eslint.org>) - JavaScript linting
+- **Biome** (<https://biomejs.dev>) - Fast linter/formatter (Rust-based)
+- **Prettier** (<https://prettier.io>) - Code formatter
 - **SonarLint** (VS Code extension) - Real-time code analysis
-- **CodeClimate** (https://codeclimate.com) - Automated code review
+- **CodeClimate** (<https://codeclimate.com>) - Automated code review
 | **5** | Deployment | Production Launch | App Store/Web Deployment |
 | **6** | Compliance | Legal & Ethics | Privacy Policy, SOC2/HIPAA |
 | **7** | Maintenance | Continuous Improvement | Monitoring, Patches, Updates |
 
 ---
-
 
 **For comprehensive lists of AI tools, development frameworks, testing tools, databases, and learning resources, see [PORTFOLIO.md](docs/PORTFOLIO.md).**
 
@@ -341,24 +341,24 @@ Zero-downtime automation when AI agents hit rate limits — the orchestrator can
 
 ### SEO & Trend Research Tools
 **Keyword Research:**
-- **Ahrefs** (https://ahrefs.com) - Comprehensive SEO toolkit, keyword difficulty, backlink analysis
-- **SEMrush** (https://semrush.com) - All-in-one marketing toolkit, competitor analysis
-- **Google Keyword Planner** (https://ads.google.com/keywordplanner) - Free keyword volume data
-- **Ubersuggest** (https://neilpatel.com/ubersuggest) - Free keyword suggestions and SEO data
-- **AnswerThePublic** (https://answerthepublic.com) - Visualize search questions and autocomplete
+- **Ahrefs** (<https://ahrefs.com>) - Comprehensive SEO toolkit, keyword difficulty, backlink analysis
+- **SEMrush** (<https://semrush.com>) - All-in-one marketing toolkit, competitor analysis
+- **Google Keyword Planner** (<https://ads.google.com/keywordplanner>) - Free keyword volume data
+- **Ubersuggest** (<https://neilpatel.com/ubersuggest>) - Free keyword suggestions and SEO data
+- **AnswerThePublic** (<https://answerthepublic.com>) - Visualize search questions and autocomplete
 
 **Trend Analysis:**
-- **Google Trends** (https://trends.google.com) - Real-time search trend data
-- **Exploding Topics** (https://explodingtopics.com) - Identify trending topics before they peak
-- **TrendHunter** (https://trendhunter.com) - Crowdsourced trend spotting
-- **Product Hunt** (https://producthunt.com) - Daily trending products and startups
-- **Hacker News** (https://news.ycombinator.com) - Tech industry trends and discussions
+- **Google Trends** (<https://trends.google.com>) - Real-time search trend data
+- **Exploding Topics** (<https://explodingtopics.com>) - Identify trending topics before they peak
+- **TrendHunter** (<https://trendhunter.com>) - Crowdsourced trend spotting
+- **Product Hunt** (<https://producthunt.com>) - Daily trending products and startups
+- **Hacker News** (<https://news.ycombinator.com>) - Tech industry trends and discussions
 
 **Domain Tools:**
-- **Namecheap** (https://namecheap.com) - Domain registration with privacy protection
+- **Namecheap** (<https://namecheap.com>) - Domain registration with privacy protection
 - **GoDaddy Domain Search** - Bulk domain availability checking
-- **Lean Domain Search** (https://leandomainsearch.com) - Domain name generator
-- **Instant Domain Search** (https://instantdomainsearch.com) - Real-time domain availability
+- **Lean Domain Search** (<https://leandomainsearch.com>) - Domain name generator
+- **Instant Domain Search** (<https://instantdomainsearch.com>) - Real-time domain availability
 
 ---
 
@@ -376,28 +376,28 @@ All Revvel applications must implement the following accessibility modes to serv
 
 ### Accessibility Resources & Tools
 **Accessibility Testing:**
-- **axe DevTools** (https://deque.com/axe) - Browser extension for automated accessibility testing
-- **WAVE** (https://wave.webaim.org) - Web accessibility evaluation tool
+- **axe DevTools** (<https://deque.com/axe>) - Browser extension for automated accessibility testing
+- **WAVE** (<https://wave.webaim.org>) - Web accessibility evaluation tool
 - **Lighthouse** (Chrome DevTools) - Built-in accessibility auditing
-- **Pa11y** (https://pa11y.org) - Automated accessibility testing tool
-- **Tenon.io** (https://tenon.io) - Accessibility as a service API
+- **Pa11y** (<https://pa11y.org>) - Automated accessibility testing tool
+- **Tenon.io** (<https://tenon.io>) - Accessibility as a service API
 
 **Font Resources:**
-- **OpenDyslexic** (https://opendyslexic.org) - Free font for dyslexic readers
-- **Atkinson Hyperlegible** (https://brailleinstitute.org/freefont) - Free, highly readable font
-- **Lexend** (https://lexend.com) - Font family designed to reduce visual stress
-- **Google Fonts** (https://fonts.google.com) - Filter by readability and accessibility
+- **OpenDyslexic** (<https://opendyslexic.org>) - Free font for dyslexic readers
+- **Atkinson Hyperlegible** (<https://brailleinstitute.org/freefont>) - Free, highly readable font
+- **Lexend** (<https://lexend.com>) - Font family designed to reduce visual stress
+- **Google Fonts** (<https://fonts.google.com>) - Filter by readability and accessibility
 
 **Color & Contrast Tools:**
-- **WebAIM Contrast Checker** (https://webaim.org/resources/contrastchecker) - WCAG compliance checking
-- **Contrast Ratio** (https://contrast-ratio.com) - Real-time contrast calculation
-- **Colorable** (https://colorable.jxnblk.com) - Color palette contrast tester
-- **Who Can Use** (https://whocanuse.com) - Vision simulator for color combinations
+- **WebAIM Contrast Checker** (<https://webaim.org/resources/contrastchecker>) - WCAG compliance checking
+- **Contrast Ratio** (<https://contrast-ratio.com>) - Real-time contrast calculation
+- **Colorable** (<https://colorable.jxnblk.com>) - Color palette contrast tester
+- **Who Can Use** (<https://whocanuse.com>) - Vision simulator for color combinations
 
 **Accessibility Guidelines:**
-- **WCAG 2.2 Guidelines** (https://w3.org/WAI/WCAG22/quickref) - Official accessibility standards
-- **A11y Project** (https://a11yproject.com) - Community-driven accessibility resource
-- **Inclusive Components** (https://inclusive-components.design) - Accessible UI patterns
+- **WCAG 2.2 Guidelines** (<https://w3.org/WAI/WCAG22/quickref>) - Official accessibility standards
+- **A11y Project** (<https://a11yproject.com>) - Community-driven accessibility resource
+- **Inclusive Components** (<https://inclusive-components.design>) - Accessible UI patterns
 
 ---
 
@@ -425,12 +425,12 @@ Every Revvel application MUST include a built-in affiliate marketing automation 
 | Platform | URL | Code |
 |---|---|---|
 | **Amazon** | Auto-generated per product | Tag: `meetaudreyeva-20` |
-| **Make.com** | https://www.make.com/en/register?pc=risingaloha | risingaloha |
-| **GoHighLevel** | https://www.gohighlevel.com/?fp_ref=audrey51 | audrey51 |
-| **VideoGen** | https://videogen.io/?fpr=audrey21 | audrey21 |
-| **Chime** | https://www.chime.com/r/audreyevans44/?c=s | audreyevans44 |
-| **DigitalOcean** | https://m.do.co/c/fe8240d60588 | fe8240d60588 |
-| **Monday.com** | https://try.monday.com/9828lfh0uct0 | 9828lfh0uct0 |
+| **Make.com** | <https://www.make.com/en/register?pc=risingaloha> | risingaloha |
+| **GoHighLevel** | <https://www.gohighlevel.com/?fp_ref=audrey51> | audrey51 |
+| **VideoGen** | <https://videogen.io/?fpr=audrey21> | audrey21 |
+| **Chime** | <https://www.chime.com/r/audreyevans44/?c=s> | audreyevans44 |
+| **DigitalOcean** | <https://m.do.co/c/fe8240d60588> | fe8240d60588 |
+| **Monday.com** | <https://try.monday.com/9828lfh0uct0> | 9828lfh0uct0 |
 
 #### Auto-Campaign Generator
 Every app must include a Marketing Dashboard with campaign generation buttons at these tiers:
@@ -450,40 +450,40 @@ Each campaign auto-generates using OpenRouter LLM:
 ### Marketing & Automation Tools
 
 **Marketing Automation:**
-- **Make.com** (https://make.com) - Visual automation platform (FREE tier: 1000 ops/month)
-- **Zapier** (https://zapier.com) - App integration and workflow automation
-- **n8n** (https://n8n.io) - Open-source workflow automation (self-hostable)
-- **Pipedream** (https://pipedream.com) - Developer-first automation platform
-- **ActivePieces** (https://activepieces.com) - Open-source Zapier alternative
+- **Make.com** (<https://make.com>) - Visual automation platform (FREE tier: 1000 ops/month)
+- **Zapier** (<https://zapier.com>) - App integration and workflow automation
+- **n8n** (<https://n8n.io>) - Open-source workflow automation (self-hostable)
+- **Pipedream** (<https://pipedream.com>) - Developer-first automation platform
+- **ActivePieces** (<https://activepieces.com>) - Open-source Zapier alternative
 
 **Email Marketing:**
-- **SendGrid** (https://sendgrid.com) - Email delivery service (FREE: 100 emails/day)
-- **Mailgun** (https://mailgun.com) - Developer-focused email API
-- **Postmark** (https://postmarkapp.com) - Transactional email service
-- **Resend** (https://resend.com) - Modern email API for developers (FREE: 3000/month)
-- **Loops** (https://loops.so) - Email for SaaS products
-- **Brevo** (https://brevo.com) - All-in-one marketing platform (FREE tier)
+- **SendGrid** (<https://sendgrid.com>) - Email delivery service (FREE: 100 emails/day)
+- **Mailgun** (<https://mailgun.com>) - Developer-focused email API
+- **Postmark** (<https://postmarkapp.com>) - Transactional email service
+- **Resend** (<https://resend.com>) - Modern email API for developers (FREE: 3000/month)
+- **Loops** (<https://loops.so>) - Email for SaaS products
+- **Brevo** (<https://brevo.com>) - All-in-one marketing platform (FREE tier)
 
 **Social Media Management:**
-- **Buffer** (https://buffer.com) - Social media scheduling (FREE: 3 channels)
-- **Hootsuite** (https://hootsuite.com) - Social media management suite
-- **Later** (https://later.com) - Visual social media planner
-- **Metricool** (https://metricool.com) - Social media analytics and scheduling
-- **Publer** (https://publer.io) - Multi-platform social media manager
+- **Buffer** (<https://buffer.com>) - Social media scheduling (FREE: 3 channels)
+- **Hootsuite** (<https://hootsuite.com>) - Social media management suite
+- **Later** (<https://later.com>) - Visual social media planner
+- **Metricool** (<https://metricool.com>) - Social media analytics and scheduling
+- **Publer** (<https://publer.io>) - Multi-platform social media manager
 
 **Analytics & Tracking:**
-- **Google Analytics 4** (https://analytics.google.com) - Web analytics (FREE)
-- **Plausible** (https://plausible.io) - Privacy-friendly analytics
-- **Umami** (https://umami.is) - Open-source web analytics
-- **PostHog** (https://posthog.com) - Product analytics platform (FREE tier)
-- **Mixpanel** (https://mixpanel.com) - User behavior analytics
-- **Hotjar** (https://hotjar.com) - Heatmaps and user recordings
+- **Google Analytics 4** (<https://analytics.google.com>) - Web analytics (FREE)
+- **Plausible** (<https://plausible.io>) - Privacy-friendly analytics
+- **Umami** (<https://umami.is>) - Open-source web analytics
+- **PostHog** (<https://posthog.com>) - Product analytics platform (FREE tier)
+- **Mixpanel** (<https://mixpanel.com>) - User behavior analytics
+- **Hotjar** (<https://hotjar.com>) - Heatmaps and user recordings
 
 **Affiliate Management:**
-- **Tapfiliate** (https://tapfiliate.com) - Affiliate tracking software
-- **Rewardful** (https://rewardful.com) - Stripe-based affiliate program
-- **FirstPromoter** (https://firstpromoter.com) - SaaS affiliate management
-- **Refersion** (https://refersion.com) - Affiliate and influencer platform
+- **Tapfiliate** (<https://tapfiliate.com>) - Affiliate tracking software
+- **Rewardful** (<https://rewardful.com>) - Stripe-based affiliate program
+- **FirstPromoter** (<https://firstpromoter.com>) - SaaS affiliate management
+- **Refersion** (<https://refersion.com>) - Affiliate and influencer platform
 
 #### Social Media Distribution
 Campaigns must support posting to ALL platforms or individually:
@@ -597,38 +597,38 @@ Every app must have a deep About section with multiple sub-pages:
 
 ### Deployment & DevOps Tools
 **CI/CD Platforms:**
-- **GitHub Actions** (https://github.com/features/actions) - Native GitHub automation (FREE for public repos)
-- **GitLab CI/CD** (https://gitlab.com) - Comprehensive DevOps platform
-- **CircleCI** (https://circleci.com) - Fast, scalable CI/CD
-- **Travis CI** (https://travis-ci.org) - Classic open-source CI tool
-- **Jenkins** (https://jenkins.io) - Self-hosted automation server
+- **GitHub Actions** (<https://github.com/features/actions>) - Native GitHub automation (FREE for public repos)
+- **GitLab CI/CD** (<https://gitlab.com>) - Comprehensive DevOps platform
+- **CircleCI** (<https://circleci.com>) - Fast, scalable CI/CD
+- **Travis CI** (<https://travis-ci.org>) - Classic open-source CI tool
+- **Jenkins** (<https://jenkins.io>) - Self-hosted automation server
 
 **Mobile Deployment:**
-- **Fastlane** (https://fastlane.tools) - iOS/Android automation toolkit
-- **App Center** (https://appcenter.ms) - Microsoft's mobile DevOps platform
-- **Bitrise** (https://bitrise.io) - Mobile-focused CI/CD
-- **Codemagic** (https://codemagic.io) - Flutter and native app CI/CD
+- **Fastlane** (<https://fastlane.tools>) - iOS/Android automation toolkit
+- **App Center** (<https://appcenter.ms>) - Microsoft's mobile DevOps platform
+- **Bitrise** (<https://bitrise.io>) - Mobile-focused CI/CD
+- **Codemagic** (<https://codemagic.io>) - Flutter and native app CI/CD
 
 **Desktop Packaging:**
-- **Electron Builder** (https://electron.build) - Complete Electron packaging solution
-- **Tauri** (https://tauri.app) - Lightweight alternative to Electron (Rust-based)
-- **Neutralinojs** (https://neutralino.js.org) - Lightweight cross-platform framework
-- **NW.js** (https://nwjs.io) - Node.js + Chromium desktop apps
+- **Electron Builder** (<https://electron.build>) - Complete Electron packaging solution
+- **Tauri** (<https://tauri.app>) - Lightweight alternative to Electron (Rust-based)
+- **Neutralinojs** (<https://neutralino.js.org>) - Lightweight cross-platform framework
+- **NW.js** (<https://nwjs.io>) - Node.js + Chromium desktop apps
 
 **Container & Orchestration:**
-- **Docker** (https://docker.com) - Industry standard containerization
-- **Kubernetes** (https://kubernetes.io) - Container orchestration
+- **Docker** (<https://docker.com>) - Industry standard containerization
+- **Kubernetes** (<https://kubernetes.io>) - Container orchestration
 - **Docker Compose** - Multi-container application deployment
-- **Podman** (https://podman.io) - Daemonless container engine
+- **Podman** (<https://podman.io>) - Daemonless container engine
 
 **Cloud Platforms:**
-- **DigitalOcean** (https://digitalocean.com) - Developer-friendly cloud (from $4/month)
-- **Vercel** (https://vercel.com) - Zero-config deployment for Next.js/React (FREE tier)
-- **Netlify** (https://netlify.com) - JAMstack deployment platform (FREE tier)
-- **Cloudflare Pages** (https://pages.cloudflare.com) - Edge deployment (FREE)
-- **Railway** (https://railway.app) - Modern app deployment with $5/month free credit
-- **Render** (https://render.com) - Alternative to Heroku (FREE tier available)
-- **Fly.io** (https://fly.io) - Global app deployment platform
+- **DigitalOcean** (<https://digitalocean.com>) - Developer-friendly cloud (from $4/month)
+- **Vercel** (<https://vercel.com>) - Zero-config deployment for Next.js/React (FREE tier)
+- **Netlify** (<https://netlify.com>) - JAMstack deployment platform (FREE tier)
+- **Cloudflare Pages** (<https://pages.cloudflare.com>) - Edge deployment (FREE)
+- **Railway** (<https://railway.app>) - Modern app deployment with $5/month free credit
+- **Render** (<https://render.com>) - Alternative to Heroku (FREE tier available)
+- **Fly.io** (<https://fly.io>) - Global app deployment platform
 
 ### Required Artifacts for Every Project
 - **README.md:** Standard project overview.
@@ -650,37 +650,37 @@ Every app must have a deep About section with multiple sub-pages:
 ### Design & Prototyping Tools
 
 **UI/UX Design:**
-- **Figma** (https://figma.com) - Industry-standard collaborative design (FREE for individuals)
-- **Penpot** (https://penpot.app) - Open-source Figma alternative
-- **Sketch** (https://sketch.com) - macOS-native design tool
-- **Adobe XD** (https://adobe.com/xd) - Adobe's UI/UX design platform
-- **Lunacy** (https://icons8.com/lunacy) - Free Sketch alternative for Windows
+- **Figma** (<https://figma.com>) - Industry-standard collaborative design (FREE for individuals)
+- **Penpot** (<https://penpot.app>) - Open-source Figma alternative
+- **Sketch** (<https://sketch.com>) - macOS-native design tool
+- **Adobe XD** (<https://adobe.com/xd>) - Adobe's UI/UX design platform
+- **Lunacy** (<https://icons8.com/lunacy>) - Free Sketch alternative for Windows
 
 **Prototyping:**
-- **Framer** (https://framer.com) - Interactive prototyping with code
-- **ProtoPie** (https://protopie.io) - Advanced interaction prototyping
-- **Principle** (https://principleformac.com) - Animated design tool
-- **InVision** (https://invisionapp.com) - Digital product design platform
+- **Framer** (<https://framer.com>) - Interactive prototyping with code
+- **ProtoPie** (<https://protopie.io>) - Advanced interaction prototyping
+- **Principle** (<https://principleformac.com>) - Animated design tool
+- **InVision** (<https://invisionapp.com>) - Digital product design platform
 
 **Wireframing:**
-- **Excalidraw** (https://excalidraw.com) - Hand-drawn style diagrams (FREE, open source)
-- **Balsamiq** (https://balsamiq.com) - Rapid wireframing tool
-- **Whimsical** (https://whimsical.com) - Visual workspace for diagrams
-- **Draw.io / diagrams.net** (https://diagrams.net) - Free diagramming tool
+- **Excalidraw** (<https://excalidraw.com>) - Hand-drawn style diagrams (FREE, open source)
+- **Balsamiq** (<https://balsamiq.com>) - Rapid wireframing tool
+- **Whimsical** (<https://whimsical.com>) - Visual workspace for diagrams
+- **Draw.io / diagrams.net** (<https://diagrams.net>) - Free diagramming tool
 
 **Design Systems:**
-- **Storybook** (https://storybook.js.org) - Component library documentation
-- **Zero Height** (https://zeroheight.com) - Design system documentation platform
-- **Supernova** (https://supernova.io) - Design system platform with code export
+- **Storybook** (<https://storybook.js.org>) - Component library documentation
+- **Zero Height** (<https://zeroheight.com>) - Design system documentation platform
+- **Supernova** (<https://supernova.io>) - Design system platform with code export
 
 **Asset & Icon Libraries:**
-- **Iconify** (https://iconify.design) - 200,000+ open source icons
-- **Heroicons** (https://heroicons.com) - Beautiful hand-crafted SVG icons
-- **Lucide** (https://lucide.dev) - Community-driven icon library
-- **Phosphor Icons** (https://phosphoricons.com) - Flexible icon family
-- **Feather Icons** (https://feathericons.com) - Simply beautiful icons
-- **Unsplash** (https://unsplash.com) - Free high-resolution photos
-- **Pexels** (https://pexels.com) - Free stock photos and videos
+- **Iconify** (<https://iconify.design>) - 200,000+ open source icons
+- **Heroicons** (<https://heroicons.com>) - Beautiful hand-crafted SVG icons
+- **Lucide** (<https://lucide.dev>) - Community-driven icon library
+- **Phosphor Icons** (<https://phosphoricons.com>) - Flexible icon family
+- **Feather Icons** (<https://feathericons.com>) - Simply beautiful icons
+- **Unsplash** (<https://unsplash.com>) - Free high-resolution photos
+- **Pexels** (<https://pexels.com>) - Free stock photos and videos
 
 ### Auto-Documentation (MANDATORY)
 - Every change to any repo, droplet, config, or deployment MUST be auto-logged with timestamp, what changed, and who/what made the change.
@@ -701,48 +701,48 @@ Current high-priority innovation sectors for MIDNGHTSAPPHIRE:
 ### Database & Backend Resources
 
 **SQL Databases:**
-- **PostgreSQL** (https://postgresql.org) - Advanced open-source relational database
-- **MySQL** (https://mysql.com) - Popular open-source database
-- **SQLite** (https://sqlite.org) - Embedded database (perfect for small apps)
-- **MariaDB** (https://mariadb.org) - MySQL fork with enhanced features
-- **CockroachDB** (https://cockroachlabs.com) - Distributed SQL database
+- **PostgreSQL** (<https://postgresql.org>) - Advanced open-source relational database
+- **MySQL** (<https://mysql.com>) - Popular open-source database
+- **SQLite** (<https://sqlite.org>) - Embedded database (perfect for small apps)
+- **MariaDB** (<https://mariadb.org>) - MySQL fork with enhanced features
+- **CockroachDB** (<https://cockroachlabs.com>) - Distributed SQL database
 
 **NoSQL Databases:**
-- **MongoDB** (https://mongodb.com) - Document database (FREE tier: Atlas)
-- **Redis** (https://redis.io) - In-memory data store and cache
-- **Cassandra** (https://cassandra.apache.org) - Distributed wide-column database
-- **Couchbase** (https://couchbase.com) - NoSQL cloud database
-- **ArangoDB** (https://arangodb.com) - Multi-model database
+- **MongoDB** (<https://mongodb.com>) - Document database (FREE tier: Atlas)
+- **Redis** (<https://redis.io>) - In-memory data store and cache
+- **Cassandra** (<https://cassandra.apache.org>) - Distributed wide-column database
+- **Couchbase** (<https://couchbase.com>) - NoSQL cloud database
+- **ArangoDB** (<https://arangodb.com>) - Multi-model database
 
 **Modern Database Options:**
-- **Supabase** (https://supabase.com) - Open-source Firebase alternative (Postgres)
-- **PocketBase** (https://pocketbase.io) - Open-source backend in one file (Go + SQLite)
-- **Appwrite** (https://appwrite.io) - Open-source backend server
-- **Firebase** (https://firebase.google.com) - Google's backend platform (FREE tier)
-- **Convex** (https://convex.dev) - Real-time backend with TypeScript
+- **Supabase** (<https://supabase.com>) - Open-source Firebase alternative (Postgres)
+- **PocketBase** (<https://pocketbase.io>) - Open-source backend in one file (Go + SQLite)
+- **Appwrite** (<https://appwrite.io>) - Open-source backend server
+- **Firebase** (<https://firebase.google.com>) - Google's backend platform (FREE tier)
+- **Convex** (<https://convex.dev>) - Real-time backend with TypeScript
 
 **ORMs & Query Builders:**
-- **Prisma** (https://prisma.io) - Next-generation TypeScript ORM
-- **Drizzle** (https://orm.drizzle.team) - TypeScript ORM for edge
-- **Kysely** (https://kysely.dev) - Type-safe SQL query builder
-- **TypeORM** (https://typeorm.io) - ORM for TypeScript and JavaScript
-- **Sequelize** (https://sequelize.org) - Promise-based Node.js ORM
-- **Knex.js** (https://knexjs.org) - SQL query builder for Node.js
+- **Prisma** (<https://prisma.io>) - Next-generation TypeScript ORM
+- **Drizzle** (<https://orm.drizzle.team>) - TypeScript ORM for edge
+- **Kysely** (<https://kysely.dev>) - Type-safe SQL query builder
+- **TypeORM** (<https://typeorm.io>) - ORM for TypeScript and JavaScript
+- **Sequelize** (<https://sequelize.org>) - Promise-based Node.js ORM
+- **Knex.js** (<https://knexjs.org>) - SQL query builder for Node.js
 
 **Backend Frameworks:**
-- **Express.js** (https://expressjs.com) - Minimalist Node.js framework
-- **Fastify** (https://fastify.dev) - Fast and low-overhead web framework
-- **NestJS** (https://nestjs.com) - Progressive Node.js framework
-- **Hono** (https://hono.dev) - Ultrafast web framework for edges
-- **Elysia** (https://elysiajs.com) - Ergonomic Bun framework
-- **tRPC** (https://trpc.io) - End-to-end typesafe APIs
+- **Express.js** (<https://expressjs.com>) - Minimalist Node.js framework
+- **Fastify** (<https://fastify.dev>) - Fast and low-overhead web framework
+- **NestJS** (<https://nestjs.com>) - Progressive Node.js framework
+- **Hono** (<https://hono.dev>) - Ultrafast web framework for edges
+- **Elysia** (<https://elysiajs.com>) - Ergonomic Bun framework
+- **tRPC** (<https://trpc.io>) - End-to-end typesafe APIs
 
 **API Development:**
-- **GraphQL** (https://graphql.org) - Query language for APIs
-- **Apollo Server** (https://apollographql.com/server) - GraphQL server
+- **GraphQL** (<https://graphql.org>) - Query language for APIs
+- **Apollo Server** (<https://apollographql.com/server>) - GraphQL server
 - **REST** (RESTful architecture principles)
-- **gRPC** (https://grpc.io) - High-performance RPC framework
-- **OpenAPI/Swagger** (https://swagger.io) - API documentation standard
+- **gRPC** (<https://grpc.io>) - High-performance RPC framework
+- **OpenAPI/Swagger** (<https://swagger.io>) - API documentation standard
 
 ---
 
@@ -755,7 +755,6 @@ All Revvel projects enforce strict documentation standards:
 - **REPO_CATALOG.md** in revvel-standards catalogs every repository with description and status.
 
 ---
-
 
 ---
 

--- a/docs/AUTOMATION_AUDIT.md
+++ b/docs/AUTOMATION_AUDIT.md
@@ -40,77 +40,77 @@ The revvel-standards repository has extensive automation infrastructure:
 7. ✅ `jules-feedback.yml` — Jules feedback loop
 
 #### PR & Code Review
-8. ✅ `ai-pr-review-openrouter.yml` — AI-powered PR review
-9. ✅ `pr-review-status.yml` — PR review status automation
-10. ✅ `match-labels.yml` — Label matching for routing
-11. ✅ `ready-for-review.yml` — PR ready state handler
-12. ✅ `close-linked-issue.yml` — Auto-close issues when PR merges
+1. ✅ `ai-pr-review-openrouter.yml` — AI-powered PR review
+2. ✅ `pr-review-status.yml` — PR review status automation
+3. ✅ `match-labels.yml` — Label matching for routing
+4. ✅ `ready-for-review.yml` — PR ready state handler
+5. ✅ `close-linked-issue.yml` — Auto-close issues when PR merges
 
 #### CI/CD & Quality
-13. ✅ `ai-ci-failure-helper.yml` — CI failure auto-fix
-14. ✅ `ralph-loop.yml` — Self-healing loop for failures
-15. ✅ `auto-error-handler.yml` — Automatic error handling
-16. ✅ `compliance-check.yml` — Compliance validation
-17. ✅ `compliance-watcher.yml` — Compliance monitoring
+1. ✅ `ai-ci-failure-helper.yml` — CI failure auto-fix
+2. ✅ `ralph-loop.yml` — Self-healing loop for failures
+3. ✅ `auto-error-handler.yml` — Automatic error handling
+4. ✅ `compliance-check.yml` — Compliance validation
+5. ✅ `compliance-watcher.yml` — Compliance monitoring
 
 #### Label & Triage Management
-18. ✅ `arsc-labels.yml` — ARSC label management (Add/Remove/Set/Clear)
-19. ✅ `sync-labels.yml` — Sync canonical labels across repos
-20. ✅ `priority-router.yml` — Priority-based routing
-21. ✅ `triage-cron.yml` — Scheduled triage sweep
-22. ✅ `credential-label-router.yml` — **NEW** Auto-routes credentials-missing issues to desktop agents
+1. ✅ `arsc-labels.yml` — ARSC label management (Add/Remove/Set/Clear)
+2. ✅ `sync-labels.yml` — Sync canonical labels across repos
+3. ✅ `priority-router.yml` — Priority-based routing
+4. ✅ `triage-cron.yml` — Scheduled triage sweep
+5. ✅ `credential-label-router.yml` — **NEW** Auto-routes credentials-missing issues to desktop agents
 
 #### Branch & Issue Management
-22. ✅ `create-issue-branch.yml` — Auto-create branches from issues
-23. ✅ `stale-branch-cleanup.yml` — Clean up stale branches
-24. ✅ `stale-docs-check.yml` — Check for outdated docs
+1. ✅ `create-issue-branch.yml` — Auto-create branches from issues
+2. ✅ `stale-branch-cleanup.yml` — Clean up stale branches
+3. ✅ `stale-docs-check.yml` — Check for outdated docs
 
 #### Merge & Deployment
-25. ✅ `auto-merge.yml` — Automatic PR merging
-26. ✅ `commit-queue-monitor.yml` — Monitor merge queue
-27. ✅ `mergify-merge-queue-labels-copier.yml` — Mergify integration
+1. ✅ `auto-merge.yml` — Automatic PR merging
+2. ✅ `commit-queue-monitor.yml` — Monitor merge queue
+3. ✅ `mergify-merge-queue-labels-copier.yml` — Mergify integration
 
 #### Security & Secrets
-28. ✅ `credential-gatekeeper.yml` — Credential detection and BOM generation
-29. ✅ `credential-label-router.yml` — **NEW** Auto-assignment to agents with desktop access
-30. ✅ `doppler-secrets-sync.yml` — Doppler secrets sync
-31. ✅ `secret-lifecycle.yml` — Secret rotation management
-32. ✅ `secrets-health-check.yml` — Secret health monitoring
-33. ✅ `saml-sso-registration.yml` — SAML SSO automation
+1. ✅ `credential-gatekeeper.yml` — Credential detection and BOM generation
+2. ✅ `credential-label-router.yml` — **NEW** Auto-assignment to agents with desktop access
+3. ✅ `doppler-secrets-sync.yml` — Doppler secrets sync
+4. ✅ `secret-lifecycle.yml` — Secret rotation management
+5. ✅ `secrets-health-check.yml` — Secret health monitoring
+6. ✅ `saml-sso-registration.yml` — SAML SSO automation
 
 #### Monitoring & Analytics
-33. ✅ `amplitude-events.yml` — Amplitude analytics events
-34. ✅ `amplitude-to-notion.yml` — Amplitude → Notion sync
-35. ⏸ `mabl.yml` — Mabl test automation (PAUSED 2026-05-27; replaced by Keploy. Auto-triggers commented; manual `workflow_dispatch` still works. See header notes in the workflow file for the full evaluation.)
-36. ✅ `workflow-health-dashboard.yml` — Workflow monitoring
-37. ✅ `proof-of-life.yml` — App health checks
+1. ✅ `amplitude-events.yml` — Amplitude analytics events
+2. ✅ `amplitude-to-notion.yml` — Amplitude → Notion sync
+3. ⏸ `mabl.yml` — Mabl test automation (PAUSED 2026-05-27; replaced by Keploy. Auto-triggers commented; manual `workflow_dispatch` still works. See header notes in the workflow file for the full evaluation.)
+4. ✅ `workflow-health-dashboard.yml` — Workflow monitoring
+5. ✅ `proof-of-life.yml` — App health checks
 
 #### Deployment & Infrastructure
-38. ✅ `deploy-oaudrey.yml` — oAudrey deployment
-39. ✅ `oaudrey-retro.yml` — oAudrey retrospective
-40. ✅ `sync-oaudrey-dns.yml` — oAudrey DNS sync
-41. ✅ `durability-mirror.yml` — Backup/mirror automation
-42. ✅ `migration-cron.yml` — Migration scheduling
-43. ✅ `static.yml` — Static site deployment
-44. ✅ `app-artifact-audit.yml` — **NEW** Enforces Definition of Done every 6h: refreshes `docs/<app>/ARTIFACTS.md`, README live-deployment links, and `docs/APP_DELIVERY_STATUS.md` (Vercel auto-fill when `VERCEL_TOKEN` is set)
+1. ✅ `deploy-oaudrey.yml` — oAudrey deployment
+2. ✅ `oaudrey-retro.yml` — oAudrey retrospective
+3. ✅ `sync-oaudrey-dns.yml` — oAudrey DNS sync
+4. ✅ `durability-mirror.yml` — Backup/mirror automation
+5. ✅ `migration-cron.yml` — Migration scheduling
+6. ✅ `static.yml` — Static site deployment
+7. ✅ `app-artifact-audit.yml` — **NEW** Enforces Definition of Done every 6h: refreshes `docs/<app>/ARTIFACTS.md`, README live-deployment links, and `docs/APP_DELIVERY_STATUS.md` (Vercel auto-fill when `VERCEL_TOKEN` is set)
 
 #### Documentation & Changelog
-44. ✅ `ai-weekly-changelog.yml` — Auto-generated changelogs
-45. ✅ `flow-chart-sync.yml` — Flow chart updates
-46. ✅ `template-sync-check.yml` — Template consistency
+1. ✅ `ai-weekly-changelog.yml` — Auto-generated changelogs
+2. ✅ `flow-chart-sync.yml` — Flow chart updates
+3. ✅ `template-sync-check.yml` — Template consistency
 
 #### Special Purpose
-47. ✅ `fork-audit-bot.yml` — Fork evaluation
-48. ✅ `panda-ops.yml` — PandaOps integration
-49. ✅ `proposal-prosecution.yml` — Proposal handling
-50. ✅ `research-module.yml` — Research automation
-51. ✅ `recurse-ml.yml` — RecurseML integration
-52. ✅ `run-human-testing-api.yml` — Human testing API
-53. ✅ `ship-status-audit.yml` — Ship status tracking
-54. ✅ `project-board-sync.yml` — Project board automation
+1. ✅ `fork-audit-bot.yml` — Fork evaluation
+2. ✅ `panda-ops.yml` — PandaOps integration
+3. ✅ `proposal-prosecution.yml` — Proposal handling
+4. ✅ `research-module.yml` — Research automation
+5. ✅ `recurse-ml.yml` — RecurseML integration
+6. ✅ `run-human-testing-api.yml` — Human testing API
+7. ✅ `ship-status-audit.yml` — Ship status tracking
+8. ✅ `project-board-sync.yml` — Project board automation
 
 #### Cron Jobs
-55. ✅ `cron/*` — Multiple scheduled maintenance tasks
+1. ✅ `cron/*` — Multiple scheduled maintenance tasks
 
 ---
 

--- a/docs/grok/uten/Colorado/README.md
+++ b/docs/grok/uten/Colorado/README.md
@@ -57,7 +57,9 @@ Detailed profiles for Virginia, Texas, Arizona, Georgia, California + others inc
 
 ## Live Public Dashboard
 
-Open `dashboard.html` directly in a browser. It includes:
+**Live (Vercel):** <https://revvel-standards.vercel.app/docs/grok/uten/Colorado/dashboard.html>
+
+Or open `dashboard.html` directly in a browser. It includes:
 - Interactive state table with filtering
 - Charts for electricity and heat recovery
 - Colorado-specific deep dive


### PR DESCRIPTION
## Summary

Adds the live BNAT-UTEN dashboard link to the READMEs and clears the pre-existing Markdown lint debt that touching those files surfaces in the blocking changed-Markdown CI gate. Docs-only; no code or workflow behavior changes.

The live URL is `https://revvel-standards.vercel.app/docs/grok/uten/Colorado/dashboard.html` — confirmed against `docs/app-deployments.yml` (`base_url`) and `scripts/build-static.sh` (which copies `docs/` → `public/docs`, so the dashboard is served at that path).

No associated issue.

## Changes

- **BNAT project README** (`docs/grok/uten/Colorado/README.md`) — add the live Vercel dashboard URL to the "Live Public Dashboard" section.
- **Main README** (`README.md`) — add a BNAT-UTEN row (project README + live dashboard link) to the Reference Materials table.
- **`README.md` lint normalization** — ran `markdownlint-cli2 --fix` to clear 209 pre-existing errors (bare URLs wrapped in `<>`, emphasis style normalized, list prefixes, trailing newlines). Mechanical only — no wording changes. Required because the CI gate lints the whole changed file.
- **`docs/AUTOMATION_AUDIT.md`** — fix all 51 pre-existing `MD029/ol-prefix` errors by restarting each section's ordered list at 1 (renders identically; no content change).

## Validation

- `npx markdownlint-cli2` on all three changed files → **0 errors** (mirrors the CircleCI changed-Markdown gate, which lints whole changed files and is blocking).
- `npm test` → **278 pass / 0 fail**.
- Live-link path cross-checked against `build-static.sh` (`docs/` → `public/docs`).

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — N/A, no associated issue
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtW5jiCNuzxDCW4tjSkZ66)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds the live Vercel dashboard link for the BNAT-UTEN (data-center waste-heat reuse) project to both the project README and the main repository reference table, then clears pre-existing Markdown lint violations that surface when those files are touched. All changes are documentation-only: the BNAT project README gains a live dashboard URL, the main README adds a reference-table row for BNAT-UTEN and wraps 209 bare URLs in angle brackets (plus minor formatting normalization), and `AUTOMATION_AUDIT.md` fixes 51 ordered-list numbering errors. No code, workflow logic, or content changes—purely mechanical lint fixes required by the blocking CI gate that lints entire changed files.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/grok/uten/Colorado/README.md` |
| 2 | `README.md` |
| 3 | `docs/AUTOMATION_AUDIT.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the live BNAT-UTEN dashboard link to the Colorado project README and the root README: <https://revvel-standards.vercel.app/docs/grok/uten/Colorado/dashboard.html>. Cleaned up markdown lint issues so the changed-Markdown CI gate passes; docs-only, no code or workflow changes.

- **Bug Fixes**
  - `README.md`: ran `markdownlint-cli2 --fix` (mechanical formatting only).
  - `docs/AUTOMATION_AUDIT.md`: resolved `MD029/ol-prefix` by restarting each ordered list at 1 (no content change).

<sup>Written for commit 421d838eacee9e1d102f3e4342c765d58725d9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds the live Vercel dashboard link for the BNAT-UTEN data-center waste-heat reuse initiative to the repository's Reference Materials table in README.md. It also clears pre-existing Markdown lint violations (209 bare URL errors in README.md, 51 ordered list prefix errors in AUTOMATION_AUDIT.md) required by the blocking changed-Markdown CI gate. All changes are documentation-only mechanical formatting fixes with no content or functionality modifications.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds verified live Vercel dashboard URL for BNAT-UTEN data-center waste-heat reuse initiative to the Reference Materials table in README.md</li>

<li>Fixes 209 MD034/bare-URL violations in README.md by wrapping bare URLs in angle brackets across multiple sections including Frontend Frameworks, Vue Ecosystem, databases, backend frameworks, and API development tools</li>

<li>Fixes 51 MD029/ordered-list-prefix violations in AUTOMATION_AUDIT.md by normalizing list numbering</li>

</ul>
</details>

</div>