### PR TITLE
docs: audit OIDC id-token permissions across workflow fleet

### DIFF
--- a/.github/workflows/ship-to-market.yml
+++ b/.github/workflows/ship-to-market.yml
@@ -451,7 +451,6 @@ jobs:
     permissions:
       contents: write
       pages: write
-      id-token: write
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Detect framework and build

--- a/docs/OIDC_PERMISSIONS_AUDIT.md
+++ b/docs/OIDC_PERMISSIONS_AUDIT.md
@@ -1,0 +1,77 @@
+# OIDC Permissions Audit
+
+Audit of GitHub Actions OIDC (`id-token`) usage across the workflow fleet.
+
+Triggered by the `Could not fetch an OIDC token. Did you remember to add
+'id-token: write' to your workflow permissions?` error, which GitHub Actions
+raises when a step requests a short-lived OIDC token but the job lacks the
+`id-token: write` permission.
+
+## What requires `id-token: write`
+
+A job needs the `id-token: write` permission only when a step asks GitHub for an
+OIDC token. The common triggers are:
+
+- `actions/deploy-pages` — GitHub Pages deployments via the Pages API.
+- `actions/attest-*` (build provenance, SBOM) and sigstore/cosign keyless signing.
+- Keyless cloud auth: `aws-actions/configure-aws-credentials`,
+  `google-github-actions/auth`, `azure/login`, `hashicorp/vault-action`.
+- `npm publish --provenance` and any flow calling `core.getIDToken()`.
+
+Setting any `permissions:` block resets every unlisted scope to `none`, so a job
+that adds `id-token: write` must also re-declare the other scopes it uses (for
+example `contents: read`, `pages: write`). Grant the scope at the job level when
+only one job needs it.
+
+## Scan scope
+
+- 175 workflow files under `.github/workflows/`.
+- No reusable workflow calls (`uses: ./.github/workflows/...`) and no composite
+  actions under `.github/actions/`, so there is no OIDC passthrough to trace.
+
+## Findings
+
+| Workflow | OIDC-requiring step | `id-token: write` present | Status |
+| --- | --- | --- | --- |
+| `static.yml` | `actions/deploy-pages` | Yes (workflow level) | Correct |
+| `ship-to-market.yml` | None (uses `peaceiris/actions-gh-pages`, token-based) | Was granted on `deliver-docs` | Over-grant removed |
+
+No workflow was missing `id-token: write` where an OIDC token is actually
+requested. The lone OIDC consumer, `actions/deploy-pages` in `static.yml`,
+already declares the permission.
+
+Steps reviewed and confirmed to NOT need OIDC:
+
+- `ship-to-market.yml` `deliver-cli` / npm publish — uses `NODE_AUTH_TOKEN`, no
+  `--provenance` flag.
+- `ship-to-market.yml` `deliver-docker` — `docker/build-push-action` with no
+  `provenance: true` / attestation step; BuildKit provenance is baked into the
+  image and does not use the GitHub OIDC token.
+- `ship-to-market.yml` `deliver-docs` — `peaceiris/actions-gh-pages` pushes to
+  the `gh-pages` branch with `contents: write`; it never requests an OIDC token.
+
+## Change applied
+
+Removed the unused `id-token: write` from the `deliver-docs` job in
+`ship-to-market.yml` to honor least-privilege (CLAUDE.md gotcha #3). The job
+keeps `contents: write` (for the branch push) and `pages: write`.
+
+## How to fix the error if it appears again
+
+Add the scope to the job that runs the OIDC step (preferred) or to the whole
+workflow, re-declaring any other scopes the job needs:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+Notes:
+
+- `id-token` only supports `write` or `none` — there is no `read`.
+- OIDC is unavailable for `pull_request` events from forks regardless of
+  permissions.
+- If it still fails after adding the scope, check
+  Settings -> Actions -> Workflow permissions (and any org policy) is not
+  forcing read-only tokens.


### PR DESCRIPTION
## Summary

Audits GitHub Actions OIDC (`id-token`) usage across all 175 workflows, triggered by the `Could not fetch an OIDC token. Did you remember to add 'id-token: write' to your workflow permissions?` error. The scan found **no workflow missing the permission** where an OIDC token is actually requested — the only consumer, `actions/deploy-pages` in `static.yml`, already declares `id-token: write`. The one cleanup was an over-grant in `ship-to-market.yml`.

## Changes

- Remove the unused `id-token: write` from the `deliver-docs` job in `ship-to-market.yml`. That job publishes via `peaceiris/actions-gh-pages`, which pushes to the `gh-pages` branch using `contents: write` and never requests an OIDC token — so the scope was dead (least-privilege, CLAUDE.md gotcha #3). `contents: write` and `pages: write` are retained.
- Add `docs/OIDC_PERMISSIONS_AUDIT.md` documenting what requires `id-token: write`, the scan scope, the findings table, the steps confirmed NOT to need OIDC (npm publish without `--provenance`, `docker/build-push-action` without `provenance: true`, peaceiris), and a fix-it runbook for the error.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` on the edited `ship-to-market.yml` → `YAML OK`.
- `npx markdownlint-cli2 docs/OIDC_PERMISSIONS_AUDIT.md` → `0 error(s)`.
- Scan was exhaustive: no reusable workflow calls and no composite actions under `.github/actions/`, so there is no OIDC passthrough left to trace.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2jHwBV7FkKtoqsPyLHdFd)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR audits OIDC `id-token` permissions across 175 GitHub Actions workflows to identify missing or incorrect grants. The audit found that all workflows correctly declare `id-token: write` where needed (only `static.yml` uses `actions/deploy-pages`), but discovered one over-grant: the `deliver-docs` job in `ship-to-market.yml` was unnecessarily granted `id-token: write` despite using `peaceiris/actions-gh-pages` which only needs `contents: write`. The PR removes this unused permission following least-privilege principles and adds comprehensive documentation explaining when OIDC permissions are required, the audit findings, and a troubleshooting runbook.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/OIDC_PERMISSIONS_AUDIT.md` |
| 2 | `.github/workflows/ship-to-market.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audited OIDC `id-token` permissions across 175 GitHub Actions workflows; removed an unused grant and added documentation. Only `actions/deploy-pages` in `static.yml` needs OIDC and already declares `id-token: write`.

- **Bug Fixes**
  - Removed `id-token: write` from `deliver-docs` in `.github/workflows/ship-to-market.yml` (uses `peaceiris/actions-gh-pages`; keeps `contents: write` and `pages: write`).

<sup>Written for commit 285de1347923490673d40ca2e959b5d3cabf43f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR performs an OIDC permission audit across 175 GitHub Actions workflows following a GitHub Actions error. The audit confirmed that only `static.yml` legitimately requires `id-token: write` permission for `actions/deploy-pages`, while removing an unnecessary `id-token: write` permission from `ship-to-market.yml`. Comprehensive documentation was added explaining OIDC requirements, audit findings, and a fix-it runbook for future reference.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Security: Removed unnecessary `id-token: write` permission from `deliver-docs` job in `ship-to-market.yml` following least-privilege principle</li>

<li>Verified that only `static.yml` workflow legitimately requires `id-token: write` for `actions/deploy-pages` operation</li>

<li>Documentation: Added comprehensive OIDC documentation explaining token permissions, audit findings, and a fix-it runbook</li>

</ul>
</details>

</div>