### PR TITLE
feat(biome): biome-inspector — credit-free Definition-of-Done completion auditor

### DIFF
--- a/.github/workflows/biome-inspector.yml
+++ b/.github/workflows/biome-inspector.yml
@@ -1,0 +1,60 @@
+name: BIOME Inspector
+
+# Credit-free completion auditor (the crew's "is it actually alive?" sense).
+# HTTP-checks every app's live Vercel URL from docs/app-deployments.yml (2xx =
+# testable-live), publishes docs/biome/app-completion.json (+ .html), and files a
+# deduped worklist of projects that are missing or unreachable so the self-heal
+# loop drives them to completion. No AI keys — GITHUB_TOKEN + plain HTTP only.
+
+on:
+  schedule:
+    - cron: '30 */6 * * *'  # every 6 hours, offset from sheaf (hourly :00) to avoid a push race
+  workflow_dispatch: {}
+
+permissions:
+  contents: write   # commits the completion scoreboard
+  issues: write     # files/resolves the worklist
+
+concurrency:
+  group: biome-inspector
+  cancel-in-progress: false
+
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  inspect:
+    name: Verify live links + completion
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install deps (for YAML parsing)
+        run: npm ci
+
+      - name: Run inspector
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: node scripts/biome/inspector.js
+
+      - name: Commit scoreboard if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/biome/app-completion.json docs/biome/app-completion.html
+          if git diff --cached --quiet; then
+            echo "No completion change."
+          else
+            git commit -m "chore(biome): refresh app-completion scoreboard [skip ci]"
+            # Rebase onto any concurrent sheaf commit before pushing.
+            git pull --rebase --autostash origin "${GITHUB_REF_NAME}" || true
+            git push
+          fi

--- a/docs/AUTOMATION_AUDIT.md
+++ b/docs/AUTOMATION_AUDIT.md
@@ -282,6 +282,7 @@ The issue says "@why is this not autoprocessing please fix and do this WR" — l
 | `stale-docs-check.yml` | Weekly | Check doc freshness | ✅ Active |
 | `workflow-health-dashboard.yml` | Daily | Monitor workflows | ✅ Active |
 | `ai-weekly-changelog.yml` | Weekly | Generate changelog | ✅ Active |
+| `biome-inspector.yml` | Every 6h | Credit-free completion auditor — HTTP-checks each app's live link, files a worklist of unfinished projects | ✅ Active |
 
 **Assessment:** ✅ All critical cron jobs are configured and active.
 
@@ -382,3 +383,27 @@ Safety properties:
   and fails the job if a credential-shaped string is found.
 - Triggers: `workflow_dispatch` (manual) and `push` to `main` touching
   `skills/malama/**`. Companion local tool: `scripts/publish-malama.sh`.
+
+---
+
+## Update — June 30, 2026: BIOME Inspector (completion auditor)
+
+Added **`.github/workflows/biome-inspector.yml`** (+ `scripts/biome/inspector.js`),
+a fifth credit-free BIOME worker that closes the Definition-of-Done enforcement gap:
+DoD #1 says "every deliverable ships a live Vercel deployment — no live URL = not
+done", `app_artifact_auditor.py` records each URL but never pings it, and
+`deployment-health-check.yml` only checks 4 hardcoded URLs.
+
+Every 6h, `biome-inspector`:
+
+- Reads `docs/app-deployments.yml`, derives each app's live URL
+  (`<base_url>/docs/<app>/` or an explicit `live_url`), and **HTTP-checks it**
+  (2xx = testable-live). Credit-free — plain HTTP + `GITHUB_TOKEN`, no AI keys.
+- Publishes `docs/biome/app-completion.json` (schema `biome-app-completion/v1`) +
+  `app-completion.html` — the "what's actually testable right now" scoreboard,
+  pollable by an external monitor (e.g. Lovable).
+- Files one deduped `[BIOME-INSPECTOR]` worklist issue (labels `biome`, `dod-gap`,
+  `self-heal`) for projects that are missing or unreachable, so the existing
+  self-heal loop drives them to completion; auto-resolves when all apps are live.
+
+Read-only on the registry/auditor; additive; nothing existing was changed.

--- a/docs/biome/README.md
+++ b/docs/biome/README.md
@@ -33,9 +33,9 @@ every worker runs on deterministic rules + the free, built-in `GITHUB_TOKEN`.
 | `biome-medic` | macrophage (immune cell) | every 6h | Re-surfaces stuck items (`self-heal` label + comment); when AI lanes are offline, clears dead `openrouter:needs-key` blocks. Storm-safe; never deletes content. |
 | `biome-homeostat` | homeostasis regulator | every 6h | Detects missing AI keys (the Doppler-wipe case); posts ONE consolidated, deduped status note and auto-resolves it when keys return. No `needs-human` spam. |
 | `biome-sheaf` | connective tissue | hourly | Glues every worker's local section into `biome-status.json` + `biome-status.html` and commits them (single committer — no commit races). |
-| `biome-inspector` | proprioception (is it alive?) | every 6h | HTTP-checks every app's live Vercel URL from `docs/app-deployments.yml` (2xx = testable-live), publishes `app-completion.json` (+ `.html`), and files a deduped worklist of missing/unreachable projects so they get finished. Enforces DEFINITION_OF_DONE #1. |
+| `biome-inspector` | proprioception (is it alive?) | every 6h | HTTP-checks every app's live URL from `docs/app-deployments.yml` (2xx = testable-live), publishes `app-completion.json` (+ `.html`), and files a deduped worklist of missing/unreachable projects so they get finished. Enforces DEFINITION_OF_DONE #1. |
 
-## The loop (detect → remediate → monitor → reset)
+## The loop (detect → remediate → regulate → monitor → inspect → reset)
 
 1. **Detect** — `biome-sentinel` finds failures/stuck items via the GitHub API and
    files a deduped incident labeled `biome`, `scorecard`, `self-heal`.
@@ -52,7 +52,8 @@ every worker runs on deterministic rules + the free, built-in `GITHUB_TOKEN`.
 
 ## The monitor feed (for Lovable)
 
-`biome-sheaf` commits a stable, machine-readable feed:
+Two workers commit stable, machine-readable feeds: `biome-sheaf` writes the
+fleet-health status, and `biome-inspector` writes the app-completion scoreboard.
 
 - `docs/biome/biome-status.json` — schema `biome-status/v1` (fleet health)
 - `docs/biome/biome-status.html` — self-contained human view
@@ -94,8 +95,11 @@ AI key keeps `overall` healthy by design.
 - **Token-with-fallback** — every worker uses
   `secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN`.
 - **`GH_REPO`** — set so `gh`/API calls resolve the repo without a remote.
-- **Narrow permissions** — least privilege per worker; only `biome-sheaf` gets
-  `contents: write` (it is the single committer of the feed).
+- **Narrow permissions** — least privilege per worker. Only `biome-sheaf` and
+  `biome-inspector` get `contents: write`, and each commits its *own* feed file
+  (`biome-status.*` vs `app-completion.*`) on offset schedules (sheaf hourly at
+  :00, inspector every 6h at :30); `biome-inspector` also rebases before pushing,
+  so the two never race.
 - **No untrusted interpolation** — no `${{ github.event.* }}` is interpolated into
   any `run:` shell.
 

--- a/docs/biome/README.md
+++ b/docs/biome/README.md
@@ -33,6 +33,7 @@ every worker runs on deterministic rules + the free, built-in `GITHUB_TOKEN`.
 | `biome-medic` | macrophage (immune cell) | every 6h | Re-surfaces stuck items (`self-heal` label + comment); when AI lanes are offline, clears dead `openrouter:needs-key` blocks. Storm-safe; never deletes content. |
 | `biome-homeostat` | homeostasis regulator | every 6h | Detects missing AI keys (the Doppler-wipe case); posts ONE consolidated, deduped status note and auto-resolves it when keys return. No `needs-human` spam. |
 | `biome-sheaf` | connective tissue | hourly | Glues every worker's local section into `biome-status.json` + `biome-status.html` and commits them (single committer — no commit races). |
+| `biome-inspector` | proprioception (is it alive?) | every 6h | HTTP-checks every app's live Vercel URL from `docs/app-deployments.yml` (2xx = testable-live), publishes `app-completion.json` (+ `.html`), and files a deduped worklist of missing/unreachable projects so they get finished. Enforces DEFINITION_OF_DONE #1. |
 
 ## The loop (detect → remediate → monitor → reset)
 
@@ -43,15 +44,21 @@ every worker runs on deterministic rules + the free, built-in `GITHUB_TOKEN`.
 3. **Regulate** — `biome-homeostat` keeps the crew "healthy" even with AI lanes
    offline and surfaces a single, calm status note.
 4. **Monitor** — `biome-sheaf` publishes the glued status feed every hour.
-5. **Reset** — incidents/status notes auto-resolve (close) when the fleet recovers;
-   nothing is force-deleted.
+5. **Inspect** — `biome-inspector` HTTP-checks every app's live Vercel URL, publishes
+   the completion scoreboard, and files a worklist of projects that aren't
+   testable-live yet so the loop drives them to done.
+6. **Reset** — incidents/status notes/worklists auto-resolve (close) when the fleet
+   recovers; nothing is force-deleted.
 
 ## The monitor feed (for Lovable)
 
 `biome-sheaf` commits a stable, machine-readable feed:
 
-- `docs/biome/biome-status.json` — schema `biome-status/v1`
+- `docs/biome/biome-status.json` — schema `biome-status/v1` (fleet health)
 - `docs/biome/biome-status.html` — self-contained human view
+- `docs/biome/app-completion.json` — schema `biome-app-completion/v1` (which apps are
+  testable-live right now — written by `biome-inspector`)
+- `docs/biome/app-completion.html` — self-contained human view
 
 Lovable (or any external monitor) can poll the raw JSON, e.g.:
 

--- a/docs/biome/app-completion.html
+++ b/docs/biome/app-completion.html
@@ -15,7 +15,7 @@
 </head>
 <body>
   <h1>🔬 BIOME — App Completion</h1>
-  <p class="overall">Overall: <strong>all-testable-live</strong> · 0/0 testable-live · 0 unreachable · 0 no link</p>
+  <p class="overall">Overall: <strong>pending</strong> · 0/0 testable-live · 0 unreachable · 0 no link</p>
   <table>
     <thead><tr><th>App</th><th>State</th><th>HTTP</th><th>Live URL</th></tr></thead>
     <tbody>

--- a/docs/biome/app-completion.html
+++ b/docs/biome/app-completion.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BIOME — App Completion</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 2rem; color: #0f172a; background: #f8fafc; }
+    .overall { font-size: 1.1rem; padding: .5rem .9rem; border-radius: 10px; display: inline-block; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+    table { border-collapse: collapse; margin-top: 1rem; background: #fff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.08); width: 100%; }
+    th, td { text-align: left; padding: .6rem .8rem; border-bottom: 1px solid #e2e8f0; font-size: .9rem; }
+    th { background: #0ea5e9; color: #fff; }
+    .meta { color: #64748b; font-size: .8rem; margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>🔬 BIOME — App Completion</h1>
+  <p class="overall">Overall: <strong>all-testable-live</strong> · 0/0 testable-live · 0 unreachable · 0 no link</p>
+  <table>
+    <thead><tr><th>App</th><th>State</th><th>HTTP</th><th>Live URL</th></tr></thead>
+    <tbody>
+
+    </tbody>
+  </table>
+  <p class="meta">Generated 2026-06-30T00:00:00Z · schema biome-app-completion/v1 · machine feed: <code>app-completion.json</code></p>
+</body>
+</html>

--- a/docs/biome/app-completion.json
+++ b/docs/biome/app-completion.json
@@ -1,0 +1,15 @@
+{
+  "schema": "biome-app-completion/v1",
+  "generated_at": "2026-06-30T00:00:00Z",
+  "credit_free": true,
+  "base_url": "https://revvel-standards.vercel.app",
+  "overall": "all-testable-live",
+  "summary": {
+    "total": 0,
+    "live": 0,
+    "unreachable": 0,
+    "no_link": 0,
+    "external": 0
+  },
+  "apps": []
+}

--- a/docs/biome/app-completion.json
+++ b/docs/biome/app-completion.json
@@ -3,7 +3,7 @@
   "generated_at": "2026-06-30T00:00:00Z",
   "credit_free": true,
   "base_url": "https://revvel-standards.vercel.app",
-  "overall": "all-testable-live",
+  "overall": "pending",
   "summary": {
     "total": 0,
     "live": 0,

--- a/docs/biome/crew.yml
+++ b/docs/biome/crew.yml
@@ -56,3 +56,14 @@ workers:
     inputs: local status sections from all workers
     outputs: docs/biome/biome-status.json (schema biome-status/v1) + biome-status.html
     handoff_expectations: external monitors (e.g. Lovable) poll the committed JSON
+
+  - name: biome-inspector
+    role: Proprioception — credit-free completion auditor (is each app actually live?)
+    workflow: .github/workflows/biome-inspector.yml
+    script: scripts/biome/inspector.js
+    models: []
+    tools: [github-rest-read, github-issues-write, repo-commit, http-get]
+    triggers: [schedule:every-6h, workflow_dispatch]
+    inputs: docs/app-deployments.yml (apps + base_url); live HTTP status of each app URL
+    outputs: docs/biome/app-completion.json (schema biome-app-completion/v1) + .html; deduped [BIOME-INSPECTOR] worklist issue
+    handoff_expectations: missing/unreachable apps routed into the self-heal loop via biome + dod-gap + self-heal labels; enforces DEFINITION_OF_DONE #1

--- a/scripts/biome/inspector.js
+++ b/scripts/biome/inspector.js
@@ -24,8 +24,8 @@ function isExternal(meta) {
 
 function deriveLiveUrl(name, meta, baseUrl) {
   const explicit = ((meta && meta.live_url) || '').trim();
-  if (explicit) return explicit;
-  if (!isExternal(meta) && baseUrl) return `${baseUrl.replace(/\/+$/, '')}/docs/${name}/`;
+  if (explicit) return /^https?:\/\//i.test(explicit) ? explicit : ''; // ignore non-http(s) values
+  if (!isExternal(meta) && baseUrl && /^https?:\/\//i.test(baseUrl)) return `${baseUrl.replace(/\/+$/, '')}/docs/${name}/`;
   return '';
 }
 
@@ -62,7 +62,7 @@ function buildScoreboard(apps, generatedAtIso, baseUrl) {
     generated_at: generatedAtIso,
     credit_free: true,
     base_url: baseUrl || '',
-    overall: summary.unreachable + summary.no_link > 0 ? 'incomplete' : 'all-testable-live',
+    overall: apps.length === 0 ? 'pending' : summary.unreachable + summary.no_link > 0 ? 'incomplete' : 'all-testable-live',
     summary,
     apps: apps.slice().sort((a, b) => a.name.localeCompare(b.name)),
   };
@@ -128,9 +128,9 @@ function buildWorklistBody(apps, generatedAtIso) {
   ];
   for (const a of incomplete) {
     if (a.state === 'no-link') {
-      lines.push(`- **${a.name}** — 🟠 no live URL derived. Ensure \`docs/${a.name}/index.html\` exists and the app is in \`docs/app-deployments.yml\`.`);
+      lines.push(`- **${a.name}** — 🟠 no live URL could be derived. Set \`deployment.base_url\` in \`docs/app-deployments.yml\` (or give the app an explicit \`live_url\`).`);
     } else {
-      lines.push(`- **${a.name}** — 🔴 live URL returns \`${a.http_status}\`: ${a.url} . Deploy/fix the page so it serves 2xx.`);
+      lines.push(`- **${a.name}** — 🔴 live URL ${a.url} returns \`${a.http_status}\`; deploy/fix the page so it serves 2xx.`);
     }
   }
   lines.push('');
@@ -164,17 +164,31 @@ if (require.main === module) {
     const baseUrl = (manifest.deployment && manifest.deployment.base_url) || '';
     const appsManifest = manifest.apps || {};
 
-    async function checkUrl(url) {
-      if (!url) return undefined;
+    async function attempt(url, method) {
       const ctrl = new AbortController();
       const timer = setTimeout(() => ctrl.abort(), 8000);
       try {
-        const res = await fetch(url, { method: 'GET', redirect: 'follow', signal: ctrl.signal, headers: { 'User-Agent': 'biome-inspector' } });
+        const res = await fetch(url, { method, redirect: 'follow', signal: ctrl.signal, headers: { 'User-Agent': 'biome-inspector' } });
         return res.status;
-      } catch {
-        return 0; // network error / timeout => unreachable
       } finally {
         clearTimeout(timer);
+      }
+    }
+
+    async function checkUrl(url) {
+      if (!url) return undefined;
+      // HEAD first to avoid downloading full pages every 6h; fall back to GET
+      // when HEAD is unsupported (405/501) or errors.
+      try {
+        const head = await attempt(url, 'HEAD');
+        if (head === 405 || head === 501) return await attempt(url, 'GET');
+        return head;
+      } catch {
+        try {
+          return await attempt(url, 'GET');
+        } catch {
+          return 0; // network error / timeout => unreachable
+        }
       }
     }
 

--- a/scripts/biome/inspector.js
+++ b/scripts/biome/inspector.js
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * BIOME · inspector — the crew's "is it actually alive?" sense.
+ *
+ * Credit-free completion auditor. Bridges the gap the existing pipeline leaves:
+ * DEFINITION_OF_DONE.md says "every deliverable ships a live Vercel deployment —
+ * no live URL = not done", and app_artifact_auditor.py records each app's URL,
+ * but NOTHING pings the URL to confirm it is reachable, and deployment-health-
+ * check.yml only checks 4 hardcoded URLs. inspector HTTP-checks every app's live
+ * URL (2xx = testable-live), publishes a completion scoreboard, and files a
+ * deduped worklist of unfinished projects so the self-heal loop drives them done.
+ *
+ * Credit-free: HTTP fetch + GITHUB_TOKEN only. No AI keys.
+ * Pure functions exported for tests; CLI does the I/O.
+ */
+
+const WORKLIST_MARKER = '<!-- biome-inspector-worklist -->';
+
+function isExternal(meta) {
+  return !!(meta && (meta.repo || meta.path === 'external' || meta.type === 'external'));
+}
+
+function deriveLiveUrl(name, meta, baseUrl) {
+  const explicit = ((meta && meta.live_url) || '').trim();
+  if (explicit) return explicit;
+  if (!isExternal(meta) && baseUrl) return `${baseUrl.replace(/\/+$/, '')}/docs/${name}/`;
+  return '';
+}
+
+// status: HTTP status code (number); 0/undefined means the request failed.
+function classifyApp({ name, url, status, external }) {
+  if (!url) {
+    return { name, url: '', external: !!external, http_status: null, reachable: false, state: external ? 'external-no-link' : 'no-link' };
+  }
+  const reachable = typeof status === 'number' && status >= 200 && status < 300;
+  return { name, url, external: !!external, http_status: status ?? 0, reachable, state: reachable ? 'live' : 'unreachable' };
+}
+
+// Apps that should be testable-live but aren't. External-no-link is informational
+// (the code lives in another repo), so it is not part of the actionable worklist.
+function isIncomplete(app) {
+  return app.state === 'no-link' || app.state === 'unreachable';
+}
+
+function summarize(apps) {
+  const s = { total: apps.length, live: 0, unreachable: 0, no_link: 0, external: 0 };
+  for (const a of apps) {
+    if (a.state === 'live') s.live += 1;
+    else if (a.state === 'unreachable') s.unreachable += 1;
+    else if (a.state === 'no-link') s.no_link += 1;
+    else if (a.state === 'external-no-link') s.external += 1;
+  }
+  return s;
+}
+
+function buildScoreboard(apps, generatedAtIso, baseUrl) {
+  const summary = summarize(apps);
+  return {
+    schema: 'biome-app-completion/v1',
+    generated_at: generatedAtIso,
+    credit_free: true,
+    base_url: baseUrl || '',
+    overall: summary.unreachable + summary.no_link > 0 ? 'incomplete' : 'all-testable-live',
+    summary,
+    apps: apps.slice().sort((a, b) => a.name.localeCompare(b.name)),
+  };
+}
+
+function badge(state) {
+  return { live: '🟢', unreachable: '🔴', 'no-link': '🟠', 'external-no-link': '⚪' }[state] || '⚪';
+}
+
+function escapeHtml(str) {
+  return String(str).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+function renderScoreboardHtml(sb) {
+  const rows = sb.apps
+    .map((a) => {
+      const link = a.url ? `<a href="${escapeHtml(a.url)}">${escapeHtml(a.url)}</a>` : '<em>— none —</em>';
+      return `      <tr><td>${badge(a.state)} <strong>${escapeHtml(a.name)}</strong></td><td>${escapeHtml(a.state)}</td><td>${a.http_status ?? ''}</td><td>${link}</td></tr>`;
+    })
+    .join('\n');
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>BIOME — App Completion</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 2rem; color: #0f172a; background: #f8fafc; }
+    .overall { font-size: 1.1rem; padding: .5rem .9rem; border-radius: 10px; display: inline-block; background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,.08); }
+    table { border-collapse: collapse; margin-top: 1rem; background: #fff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,.08); width: 100%; }
+    th, td { text-align: left; padding: .6rem .8rem; border-bottom: 1px solid #e2e8f0; font-size: .9rem; }
+    th { background: #0ea5e9; color: #fff; }
+    .meta { color: #64748b; font-size: .8rem; margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>🔬 BIOME — App Completion</h1>
+  <p class="overall">Overall: <strong>${escapeHtml(sb.overall)}</strong> · ${sb.summary.live}/${sb.summary.total} testable-live · ${sb.summary.unreachable} unreachable · ${sb.summary.no_link} no link</p>
+  <table>
+    <thead><tr><th>App</th><th>State</th><th>HTTP</th><th>Live URL</th></tr></thead>
+    <tbody>
+${rows}
+    </tbody>
+  </table>
+  <p class="meta">Generated ${escapeHtml(sb.generated_at)} · schema ${escapeHtml(sb.schema)} · machine feed: <code>app-completion.json</code></p>
+</body>
+</html>
+`;
+}
+
+function buildWorklistBody(apps, generatedAtIso) {
+  const incomplete = apps.filter(isIncomplete);
+  const lines = [
+    WORKLIST_MARKER,
+    '## 🔬 BIOME Inspector — projects not testable-live',
+    '',
+    `**Detected:** ${generatedAtIso}  `,
+    '**Rule:** DEFINITION_OF_DONE #1 — "every deliverable ships a live Vercel deployment; no live URL = not done."  ',
+    '**Lane:** credit-free rule-based (HTTP check + GITHUB_TOKEN only)',
+    '',
+    `${incomplete.length} project(s) need finishing:`,
+    '',
+  ];
+  for (const a of incomplete) {
+    if (a.state === 'no-link') {
+      lines.push(`- **${a.name}** — 🟠 no live URL derived. Ensure \`docs/${a.name}/index.html\` exists and the app is in \`docs/app-deployments.yml\`.`);
+    } else {
+      lines.push(`- **${a.name}** — 🔴 live URL returns \`${a.http_status}\`: ${a.url} . Deploy/fix the page so it serves 2xx.`);
+    }
+  }
+  lines.push('');
+  lines.push('---');
+  lines.push('_Auto-resolves when every project is testable-live. Full board: `docs/biome/app-completion.json`._');
+  return lines.join('\n');
+}
+
+module.exports = {
+  WORKLIST_MARKER,
+  isExternal,
+  deriveLiveUrl,
+  classifyApp,
+  isIncomplete,
+  summarize,
+  buildScoreboard,
+  renderScoreboardHtml,
+  buildWorklistBody,
+};
+
+// --- CLI -------------------------------------------------------------------
+if (require.main === module) {
+  (async () => {
+    const fs = require('fs');
+    const path = require('path');
+    const YAML = require('yaml');
+    const { repoApi } = require('./gh');
+
+    const generatedAt = new Date().toISOString();
+    const manifest = YAML.parse(fs.readFileSync(path.join(process.cwd(), 'docs', 'app-deployments.yml'), 'utf8')) || {};
+    const baseUrl = (manifest.deployment && manifest.deployment.base_url) || '';
+    const appsManifest = manifest.apps || {};
+
+    async function checkUrl(url) {
+      if (!url) return undefined;
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), 8000);
+      try {
+        const res = await fetch(url, { method: 'GET', redirect: 'follow', signal: ctrl.signal, headers: { 'User-Agent': 'biome-inspector' } });
+        return res.status;
+      } catch {
+        return 0; // network error / timeout => unreachable
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    const results = [];
+    for (const [name, meta] of Object.entries(appsManifest)) {
+      const url = deriveLiveUrl(name, meta, baseUrl);
+      const status = await checkUrl(url);
+      results.push(classifyApp({ name, url, status, external: isExternal(meta) }));
+    }
+
+    const scoreboard = buildScoreboard(results, generatedAt, baseUrl);
+    const outDir = path.join(process.cwd(), 'docs', 'biome');
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, 'app-completion.json'), `${JSON.stringify(scoreboard, null, 2)}\n`);
+    fs.writeFileSync(path.join(outDir, 'app-completion.html'), renderScoreboardHtml(scoreboard));
+    console.log(`[biome-inspector] ${scoreboard.summary.live}/${scoreboard.summary.total} testable-live · ${scoreboard.summary.unreachable} unreachable · ${scoreboard.summary.no_link} no-link`);
+
+    // Worklist: upsert/resolve a single deduped issue.
+    const search = await repoApi('/issues?state=open&labels=biome,dod-gap&per_page=50', { allowError: true });
+    const existing = Array.isArray(search)
+      ? search.find((i) => !i.pull_request && (i.body || '').includes(WORKLIST_MARKER))
+      : null;
+    const incomplete = results.filter(isIncomplete);
+
+    if (incomplete.length === 0) {
+      if (existing) {
+        await repoApi(`/issues/${existing.number}/comments`, { method: 'POST', body: { body: `${WORKLIST_MARKER}\n✅ All projects testable-live as of ${generatedAt}. Resolving.` }, allowError: true });
+        await repoApi(`/issues/${existing.number}`, { method: 'PATCH', body: { state: 'closed' }, allowError: true });
+        console.log(`[biome-inspector] resolved worklist #${existing.number}`);
+      } else {
+        console.log('[biome-inspector] all projects testable-live — no worklist.');
+      }
+      return;
+    }
+
+    const body = buildWorklistBody(results, generatedAt);
+    if (existing) {
+      await repoApi(`/issues/${existing.number}/comments`, { method: 'POST', body: { body }, allowError: true });
+      console.log(`[biome-inspector] refreshed worklist #${existing.number} (${incomplete.length} incomplete)`);
+    } else {
+      const created = await repoApi('/issues', {
+        method: 'POST',
+        body: { title: `[BIOME-INSPECTOR] ${incomplete.length} project(s) not testable-live`, body, labels: ['biome', 'dod-gap', 'self-heal'] },
+      });
+      console.log(`[biome-inspector] filed worklist #${created && created.number}`);
+    }
+  })().catch((err) => {
+    console.error(`[biome-inspector] error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/biome/inspector.js
+++ b/scripts/biome/inspector.js
@@ -181,7 +181,10 @@ if (require.main === module) {
       // when HEAD is unsupported (405/501) or errors.
       try {
         const head = await attempt(url, 'HEAD');
-        if (head === 405 || head === 501) return await attempt(url, 'GET');
+        // Fall back to GET on any non-2xx HEAD — some hosts answer HEAD with
+        // 4xx/5xx (405/501/403/404…) yet serve the page fine via GET, and we
+        // don't want to falsely mark a reachable app unreachable.
+        if (head < 200 || head >= 300) return await attempt(url, 'GET');
         return head;
       } catch {
         try {

--- a/tests/biome-inspector.test.js
+++ b/tests/biome-inspector.test.js
@@ -28,6 +28,11 @@ test('deriveLiveUrl: external app with no explicit url derives nothing', () => {
   assert.equal(deriveLiveUrl('sessiono', { path: 'external', repo: 'midnghtsapphire/sessiono', live_url: '' }, BASE), '');
 });
 
+test('deriveLiveUrl: non-http(s) values are ignored (not counted as live)', () => {
+  assert.equal(deriveLiveUrl('x', { live_url: 'ftp://x' }, BASE), '');
+  assert.equal(deriveLiveUrl('x', { path: 'x', live_url: '' }, 'javascript:alert(1)'), '');
+});
+
 test('isExternal detects repo/path/type', () => {
   assert.equal(isExternal({ repo: 'a/b' }), true);
   assert.equal(isExternal({ path: 'external' }), true);
@@ -66,6 +71,12 @@ test('summarize + scoreboard overall reflects incompleteness', () => {
 test('scoreboard overall is all-testable-live when nothing incomplete', () => {
   const apps = [classifyApp({ name: 'a', url: 'u', status: 200 }), classifyApp({ name: 'b', url: '', external: true })];
   assert.equal(buildScoreboard(apps, 't', BASE).overall, 'all-testable-live');
+});
+
+test('scoreboard overall is pending when no apps checked yet (no false-green seed)', () => {
+  const sb = buildScoreboard([], 't', BASE);
+  assert.equal(sb.overall, 'pending');
+  assert.equal(sb.summary.total, 0);
 });
 
 test('worklist body carries marker and lists the gap per app', () => {

--- a/tests/biome-inspector.test.js
+++ b/tests/biome-inspector.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  isExternal,
+  deriveLiveUrl,
+  classifyApp,
+  isIncomplete,
+  summarize,
+  buildScoreboard,
+  renderScoreboardHtml,
+  buildWorklistBody,
+  WORKLIST_MARKER,
+} = require('../scripts/biome/inspector');
+
+const BASE = 'https://revvel-standards.vercel.app';
+
+test('deriveLiveUrl: explicit live_url wins', () => {
+  assert.equal(deriveLiveUrl('x', { live_url: 'https://x.dev' }, BASE), 'https://x.dev');
+});
+
+test('deriveLiveUrl: internal app derives /docs/<app>/', () => {
+  assert.equal(deriveLiveUrl('osint-hub', { path: 'osint-hub', type: 'web', live_url: '' }, BASE), `${BASE}/docs/osint-hub/`);
+});
+
+test('deriveLiveUrl: external app with no explicit url derives nothing', () => {
+  assert.equal(deriveLiveUrl('sessiono', { path: 'external', repo: 'midnghtsapphire/sessiono', live_url: '' }, BASE), '');
+});
+
+test('isExternal detects repo/path/type', () => {
+  assert.equal(isExternal({ repo: 'a/b' }), true);
+  assert.equal(isExternal({ path: 'external' }), true);
+  assert.equal(isExternal({ path: 'products/x', type: 'web' }), false);
+});
+
+test('classifyApp: 2xx is live, others unreachable, missing url is no-link', () => {
+  assert.equal(classifyApp({ name: 'a', url: 'u', status: 200 }).state, 'live');
+  assert.equal(classifyApp({ name: 'a', url: 'u', status: 404 }).state, 'unreachable');
+  assert.equal(classifyApp({ name: 'a', url: 'u', status: 0 }).state, 'unreachable');
+  assert.equal(classifyApp({ name: 'a', url: '', external: false }).state, 'no-link');
+  assert.equal(classifyApp({ name: 'a', url: '', external: true }).state, 'external-no-link');
+});
+
+test('isIncomplete flags no-link and unreachable only (external-no-link excluded)', () => {
+  assert.equal(isIncomplete({ state: 'no-link' }), true);
+  assert.equal(isIncomplete({ state: 'unreachable' }), true);
+  assert.equal(isIncomplete({ state: 'live' }), false);
+  assert.equal(isIncomplete({ state: 'external-no-link' }), false);
+});
+
+test('summarize + scoreboard overall reflects incompleteness', () => {
+  const apps = [
+    classifyApp({ name: 'a', url: 'u', status: 200 }),
+    classifyApp({ name: 'b', url: 'u', status: 503 }),
+    classifyApp({ name: 'c', url: '', external: false }),
+    classifyApp({ name: 'd', url: '', external: true }),
+  ];
+  const sb = buildScoreboard(apps, '2026-06-30T00:00:00Z', BASE);
+  assert.equal(sb.schema, 'biome-app-completion/v1');
+  assert.equal(sb.credit_free, true);
+  assert.deepEqual(sb.summary, { total: 4, live: 1, unreachable: 1, no_link: 1, external: 1 });
+  assert.equal(sb.overall, 'incomplete');
+});
+
+test('scoreboard overall is all-testable-live when nothing incomplete', () => {
+  const apps = [classifyApp({ name: 'a', url: 'u', status: 200 }), classifyApp({ name: 'b', url: '', external: true })];
+  assert.equal(buildScoreboard(apps, 't', BASE).overall, 'all-testable-live');
+});
+
+test('worklist body carries marker and lists the gap per app', () => {
+  const apps = [
+    classifyApp({ name: 'good', url: 'u', status: 200 }),
+    classifyApp({ name: 'broke', url: 'https://x/docs/broke/', status: 404 }),
+    classifyApp({ name: 'missing', url: '', external: false }),
+  ];
+  const body = buildWorklistBody(apps, '2026-06-30T00:00:00Z');
+  assert.ok(body.includes(WORKLIST_MARKER));
+  assert.ok(body.includes('broke'));
+  assert.ok(body.includes('missing'));
+  assert.ok(!body.includes('- **good**')); // live app not listed
+});
+
+test('renderScoreboardHtml escapes and is self-contained', () => {
+  const sb = buildScoreboard([classifyApp({ name: 'x<b>', url: 'u', status: 200 })], 't', BASE);
+  const html = renderScoreboardHtml(sb);
+  assert.ok(html.startsWith('<!DOCTYPE html>'));
+  assert.ok(html.includes('x&lt;b&gt;'));
+});


### PR DESCRIPTION
## Summary

Adds a 5th BIOME worker, **`biome-inspector`**, that makes "did the project actually finish, and is the live link real?" a verified, every-cycle fact — directly addressing *"the agents create a website, I test the Vercel link… right now it's missing; sometimes I get a link, sometimes not."*

It closes a concrete gap found by reading the existing pipeline:
- `DEFINITION_OF_DONE.md` #1: *"every deliverable ships a live Vercel deployment — no live URL = not done"* — but nothing enforced reachability.
- `app_artifact_auditor.py` records each app's URL but **never pings it** (regex-validates only).
- `deployment-health-check.yml` *does* HTTP-check — but only **4 hardcoded URLs**, not the `docs/<app>/` apps.

Credit-free and additive (BIOME philosophy): plain HTTP + `GITHUB_TOKEN`, no AI keys; nothing existing is edited or deleted.

No associated issue.

## Changes

- **`.github/workflows/biome-inspector.yml`** (every 6h) + **`scripts/biome/inspector.js`** — reads `docs/app-deployments.yml`, derives each app's live URL (`<base_url>/docs/<app>/` or explicit `live_url`), **HTTP-checks it (2xx = testable-live)**, and:
  - Publishes **`docs/biome/app-completion.json`** (schema `biome-app-completion/v1`) + **`app-completion.html`** — the "what's actually testable right now" scoreboard, pollable by an external monitor (e.g. Lovable).
  - Files one deduped **`[BIOME-INSPECTOR]`** worklist issue (labels `biome`, `dod-gap`, `self-heal`) for missing/unreachable projects so the self-heal loop drives them to completion; auto-resolves (closes) when all apps are live.
- **`tests/biome-inspector.test.js`** — 10 unit tests for the pure logic (URL derivation, reachability classification, scoreboard, worklist, HTML escaping).
- Registered the worker in **`docs/biome/README.md`**, **`docs/biome/crew.yml`**, and **`docs/AUTOMATION_AUDIT.md`** (cron table + dated update — also satisfies docs-freshness for the new workflow).
- Bootstrap `app-completion.{json,html}` seeded so the feed path exists; first scheduled run replaces it with live data.

## Validation

- `npm test` → **288 pass / 0 fail** (adds 10 inspector tests; nothing else regressed).
- `biome-inspector.yml` and `docs/biome/crew.yml` parse via `yaml.safe_load`.
- `app-completion.json` valid JSON; `markdownlint-cli2` on changed docs → **0 errors**.
- Conventions: `GH_REPO`, token-with-fallback, narrow permissions (`contents: write` only to commit its own scoreboard; `issues: write` for the worklist), no untrusted `${{ github.event.* }}` in `run:`, single committer with rebase-before-push to avoid racing `biome-sheaf`.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — N/A, no associated issue
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtW5jiCNuzxDCW4tjSkZ66)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces `biome-inspector`, a fifth credit-free BIOME worker that enforces Definition-of-Done #1 by HTTP-checking every app's live Vercel URL to verify deployments are actually reachable. Every 6 hours, it reads `docs/app-deployments.yml`, derives each app's live URL, checks for 2xx responses, publishes a completion scoreboard (`app-completion.json` + `.html`), and files a deduped worklist issue for missing or unreachable projects so the self-heal loop can drive them to completion. The worker uses only `GITHUB_TOKEN` and plain HTTP (no AI keys), closing the gap where existing auditors record URLs but never ping them, and health checks only cover 4 hardcoded URLs.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/biome/crew.yml` |
| 2 | `docs/biome/README.md` |
| 3 | `docs/biome/app-completion.json` |
| 4 | `docs/biome/app-completion.html` |
| 5 | `scripts/biome/inspector.js` |
| 6 | `tests/biome-inspector.test.js` |
| 7 | `.github/workflows/biome-inspector.yml` |
| 8 | `docs/AUTOMATION_AUDIT.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `biome-inspector`, a credit-free auditor that verifies each app’s live URL and publishes a completion scoreboard. It makes “is it actually live?” a continuous check and routes gaps into the self-heal loop, enforcing DoD #1.

- **New Features**
  - Adds `.github/workflows/biome-inspector.yml` (every 6h or manual) running `scripts/biome/inspector.js`.
  - Reads `docs/app-deployments.yml`, derives live URLs (`<base_url>/docs/<app>/` or `live_url`), and HTTP-checks them (2xx = live).
  - Commits `docs/biome/app-completion.json` (schema `biome-app-completion/v1`) and `app-completion.html`.
  - Opens/updates one `[BIOME-INSPECTOR]` issue (labels `biome`, `dod-gap`, `self-heal`) for missing/unreachable apps; auto-closes when all are live. Uses `GITHUB_TOKEN` with narrow permissions; docs updated.

- **Bug Fixes**
  - HEAD-first reachability check with GET fallback on any non-2xx HEAD or network error to avoid false negatives and reduce bandwidth.
  - Ignores non-http(s) `live_url`/`base_url` values so they aren’t counted live or emitted.
  - Empty app lists now report `overall: pending` (seed files updated).

<sup>Written for commit 192e17a53f1bac65a9bf968174a78433a28bc474. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

