### PR TITLE
fix: gh CLI auth + repo-target failures in 5 agent-routing workflows

### DIFF
--- a/.github/workflows/agent-dispatcher.yml
+++ b/.github/workflows/agent-dispatcher.yml
@@ -39,7 +39,12 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GH_TOKEN: ${{ github.token }}
+  # PAT-with-fallback so `gh workflow run` can cascade-trigger the downstream
+  # agent workflows (the default GITHUB_TOKEN cannot trigger other workflows).
+  GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+  # gh infers the repo from the local git remote; this job has no checkout, so
+  # set GH_REPO explicitly or every gh call fails with "not a git repository".
+  GH_REPO: ${{ github.repository }}
 
 jobs:
   dispatch:

--- a/.github/workflows/api-rate-limit-handler.yml
+++ b/.github/workflows/api-rate-limit-handler.yml
@@ -24,6 +24,11 @@ permissions:
   contents: read
   issues: write
   actions: write
+env:
+  # This workflow has no checkout, so gh cannot infer the repo from a git
+  # remote; set it explicitly or gh issue/workflow calls fail with
+  # "not a git repository" (CLAUDE.md gotcha #1).
+  GH_REPO: ${{ github.repository }}
 jobs:
   handle-rate-limit:
     runs-on: ubuntu-latest
@@ -41,7 +46,7 @@ jobs:
       - name: Create WR if rate limited
         if: steps.check.outputs.is_rate_limit == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           # Prevent duplicate - check if WR already exists for this workflow
           EXISTING=$(gh search issues --repo ${{ github.repository }} \
@@ -72,7 +77,7 @@ jobs:
       - name: Trigger fallback agent
         if: steps.check.outputs.is_rate_limit == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           # Trigger OpenRouter fallback workflow
           gh workflow run openrouter-coder.yml \

--- a/.github/workflows/budget-aware-agent.yml
+++ b/.github/workflows/budget-aware-agent.yml
@@ -58,7 +58,8 @@ jobs:
             echo "status=low" >> $GITHUB_OUTPUT
             echo "budget_remaining=low" >> $GITHUB_OUTPUT
           else
-            echo "status=critical" >> $GITHUB_OUTPUT            echo "budget_remaining=exhausted" >> $GITHUB_OUTPUT
+            echo "status=critical" >> $GITHUB_OUTPUT
+            echo "budget_remaining=exhausted" >> $GITHUB_OUTPUT
           fi
           
           echo "Budget: $PERCENT% used"
@@ -139,8 +140,14 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Try next cheapest agent
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           FAILED_AGENT="${{ needs.assess-budget.outputs.selected_agent }}"
           

--- a/.github/workflows/credential-label-router.yml
+++ b/.github/workflows/credential-label-router.yml
@@ -86,6 +86,7 @@ jobs:
         id: trigger-agent-hq
         if: steps.check.outputs.needs_routing == 'true' && env.AGENT_HQ_TOKEN != ''
         env:
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           AGENT_HQ_TOKEN: ${{ secrets.AGENT_HQ_TOKEN }}
           AGENT_HQ_URL: ${{ secrets.AGENT_HQ_URL || 'https://agent-hq.revvel.co' }}
           ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}

--- a/.github/workflows/weekly-research.yml
+++ b/.github/workflows/weekly-research.yml
@@ -196,6 +196,7 @@ jobs:
       - name: Trigger 49Agents research (if configured)
         if: env.AGENT_HQ_TOKEN != ''
         env:
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           AGENT_HQ_TOKEN: ${{ secrets.AGENT_HQ_TOKEN }}
           AGENT_HQ_URL: ${{ secrets.AGENT_HQ_URL || 'https://agent-hq.revvel.co' }}
         run: |

--- a/learnings.md
+++ b/learnings.md
@@ -377,3 +377,17 @@ This file tracks autonomous executions, failures, root causes, and locked-in sol
 5. **`openrouter/fusion` slug is unverified** against the live OpenRouter catalog — do not assume valid. Confirm before any deep-search routing edit.
 
 **Next Action:** Rebase PR #14772 to clear `has-conflicts`; retitle to match real scope (workflow cleanup, not image upload) or split; confirm `openrouter/fusion` before any model-routing change. Recommend building the SHA-pinned verdict-validation gate and the non-author-approval merge guard before scaling automation to additional repos.
+
+---
+
+**Date/Time:** 2026-06-30T00:00:00Z
+
+**Task Attempted:** Code-review the agent-routing/self-heal workflow fleet for the documented `gh`-CLI failure modes (no auth, no repo target, too-narrow permissions) and fix the real ones via PR.
+
+**Outcome:** Success — scanned all 174 workflows with a verifier script, hand-confirmed 5 genuinely broken workflows, and fixed them. `npm test` (278 pass) and YAML validation are green; `workflows:validate` shows `Invalid workflows: 0` (the pre-existing 19 missing-`timeout-minutes` jobs are in untouched files and are deferred to a follow-up PR).
+
+**Root Cause of Failure (If any):** Five workflows invoked the `gh` CLI without satisfying its runtime requirements: `budget-aware-agent.yml` (`fallback-handler`) ran `gh issue create` with no `GH_TOKEN`, no `GH_REPO`/checkout, and workflow `permissions: contents: read` (missing `issues: write`) — and had two `echo` statements collapsed onto one line, corrupting the `critical` budget output; `credential-label-router.yml` and `weekly-research.yml` each had one step calling `gh api`/`gh issue` with only a vendor token in `env:` (no `GH_TOKEN`); `agent-dispatcher.yml` and `api-rate-limit-handler.yml` ran `gh workflow run`/`gh issue create` with no `GH_REPO` and no checkout (and used the default token, which cannot cascade-trigger downstream workflows).
+
+**Self-Healing Fix / Learned Lesson:** A line-by-line `gh` scanner produces false positives on multiline commands where `--repo` sits on a continuation line (`reset-self-heal-issue.yml`, `secret-persistence-guard.yml` ×4) and on `echo "...gh issue create..."` strings (`eeat-trust-cron.yml`) — always hand-verify each hit against the full step before claiming a bug. Apply the repo-standard PAT-with-fallback `GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}` (required for any step that uses `gh workflow run` to cascade) and `GH_REPO: ${{ github.repository }}` for checkout-less jobs; grant `issues: write` at the narrowest (job) scope.
+
+**Next Action:** Open the PR for these 5 fixes. Follow-up batch: add `timeout-minutes` to the 19 jobs flagged by `workflows:validate` across the untouched files.


### PR DESCRIPTION
## Summary

Code-reviewed the agent-routing/self-heal workflow fleet for the `gh`-CLI failure modes documented in `CLAUDE.md` (gotchas #1–3: missing repo target, unauthenticated `gh`, too-narrow permissions). All 174 workflows were scanned with a verifier script, then **every hit was hand-confirmed against the full step** — rejecting false positives where `--repo` sits on a multiline continuation (`reset-self-heal-issue.yml`, `secret-persistence-guard.yml` ×4) or where a `gh` command only appears inside an `echo` string (`eeat-trust-cron.yml`). This PR fixes the 5 genuinely broken workflows.

## Changes

- **`budget-aware-agent.yml`** (`fallback-handler`): ran `gh issue create` unauthenticated, with no repo target, and without issue-write permission. Added `GH_TOKEN` (PAT-with-fallback), `GH_REPO`, and job-level `issues: write`. Also fixed two `echo` statements collapsed onto one line (line 61) that corrupted the `critical` budget output.
- **`agent-dispatcher.yml`**: added `GH_REPO` and upgraded `GH_TOKEN` to the PAT-with-fallback pattern so `gh workflow run` can cascade-trigger downstream agent workflows (the default `GITHUB_TOKEN` cannot, per gotcha #2).
- **`api-rate-limit-handler.yml`**: added workflow-level `GH_REPO` and upgraded both steps' `GH_TOKEN` to PAT-with-fallback (the fallback step uses `gh workflow run`).
- **`credential-label-router.yml`** / **`weekly-research.yml`**: added `GH_TOKEN` to the "Trigger Agent HQ" / "Trigger 49Agents" steps, which called `gh api`/`gh issue` with only a vendor token in `env:`.
- **`learnings.md`**: appended a self-healing-log entry per the append-only standard.

All fixes use the repo-standard token pattern `${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}` and grant `issues: write` at the narrowest (job) scope.

docs-freshness: bug-fix to existing-workflow plumbing (gh auth / repo-target / permissions) only — no workflow added or removed, and no routing lane or documented behavior changed, so the SYSTEM_MAP / AUTOMATION_AUDIT / AGENT_MONITORING catalogs need no update.

## Validation

- `npm test` → **278 passed, 0 failed**.
- `python3 -c "import yaml; yaml.safe_load(...)"` on all 5 edited files → all OK.
- `npm run workflows:validate` → **Invalid workflows: 0**. The validator's exit 1 comes from a **pre-existing** baseline of 19 jobs missing `timeout-minutes` in **untouched** files (none of the 5 edited here) — deferred to a follow-up PR.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes gh CLI authentication and repository-targeting failures across 5 self-healing agent workflows by implementing a standardized PAT-with-fallback token pattern, explicitly setting repository context for jobs without checkout steps, and narrowing GitHub token permission scope to the minimum required level.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces PAT-with-fallback token pattern `${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}` for gh CLI commands across 5 workflows to fix authentication failures</li>

<li>Adds explicit GH_REPO environment variable for checkout-less jobs to resolve repository-targeting failures</li>

<li>Narrows 'issues: write' permission to narrowest job-level scope for security hardening</li>

<li>Fixes corrupted echo statements in budget-aware-agent.yml and updates learnings.md with root cause analysis</li>

</ul>
</details>

</div>