### PR TITLE
feat(biome): homeostat triggers Doppler→Actions key recovery when AI lanes drop

### DIFF
--- a/.github/workflows/biome-homeostat.yml
+++ b/.github/workflows/biome-homeostat.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: write   # dispatch the existing Doppler->Actions recovery workflow when keys are missing
 
 concurrency:
   group: biome-homeostat
@@ -46,4 +47,8 @@ jobs:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          # When AI lanes are offline, dispatch the existing reviewed recovery
+          # workflow to pull the key(s) back from Doppler promptly (it no-ops if
+          # Doppler has no value, preserving its don't-overwrite-good-tokens rule).
+          BIOME_RECOVER_KEYS: 'true'
         run: node scripts/biome/homeostat.js

--- a/scripts/biome/homeostat.js
+++ b/scripts/biome/homeostat.js
@@ -77,12 +77,22 @@ function buildStatusBody(assessment, generatedAtIso) {
   return lines.join('\n');
 }
 
+// When AI lanes are offline, homeostat can promptly trigger the EXISTING
+// Doppler->Actions recovery workflow (secret-persistence-guard) instead of
+// waiting for that workflow's own daily cron. Gated behind BIOME_RECOVER_KEYS so
+// it only fires when the workflow explicitly opts in; homeostat never handles
+// secret values itself — it just dispatches the reviewed recovery workflow.
+function shouldTriggerRecovery(assessment, env) {
+  return assessment.aiLanesOffline === true && String((env && env.BIOME_RECOVER_KEYS) || '').toLowerCase() === 'true';
+}
+
 module.exports = {
   TRACKED_KEYS,
   STATUS_MARKER,
   assessKeyHealth,
   buildHomeostatSection,
   buildStatusBody,
+  shouldTriggerRecovery,
 };
 
 // --- CLI -------------------------------------------------------------------
@@ -127,6 +137,18 @@ if (require.main === module) {
         },
       });
       console.log(`[biome-homeostat] opened consolidated status #${created && created.number}`);
+    }
+
+    // Promptly rehydrate the wiped key(s) by dispatching the existing reviewed
+    // Doppler->Actions recovery workflow (no-ops if Doppler has no value).
+    if (shouldTriggerRecovery(assessment, process.env)) {
+      const recoveryWorkflow = process.env.BIOME_RECOVERY_WORKFLOW || 'secret-persistence-guard.yml';
+      await repoApi(`/actions/workflows/${recoveryWorkflow}/dispatches`, {
+        method: 'POST',
+        body: { ref: 'main', inputs: { force_recovery: 'true' } },
+        allowError: true,
+      });
+      console.log(`[biome-homeostat] dispatched ${recoveryWorkflow} to rehydrate keys from Doppler`);
     }
   })().catch((err) => {
     console.error(`[biome-homeostat] error: ${err.message}`);

--- a/tests/biome-homeostat.test.js
+++ b/tests/biome-homeostat.test.js
@@ -6,6 +6,7 @@ const {
   assessKeyHealth,
   buildHomeostatSection,
   buildStatusBody,
+  shouldTriggerRecovery,
   STATUS_MARKER,
   TRACKED_KEYS,
 } = require('../scripts/biome/homeostat');
@@ -39,4 +40,13 @@ test('status body carries dedupe marker and reassures (not an outage)', () => {
   const body = buildStatusBody(a, '2026-06-30T00:00:00Z');
   assert.ok(body.includes(STATUS_MARKER));
   assert.match(body, /not\*\* an outage|not.*outage/i);
+});
+
+test('shouldTriggerRecovery: only when AI lanes offline AND opt-in flag enabled', () => {
+  const offline = { aiLanesOffline: true };
+  const online = { aiLanesOffline: false };
+  assert.equal(shouldTriggerRecovery(offline, { BIOME_RECOVER_KEYS: 'true' }), true);
+  assert.equal(shouldTriggerRecovery(offline, { BIOME_RECOVER_KEYS: 'false' }), false);
+  assert.equal(shouldTriggerRecovery(offline, {}), false); // flag absent => off by default
+  assert.equal(shouldTriggerRecovery(online, { BIOME_RECOVER_KEYS: 'true' }), false);
 });


### PR DESCRIPTION
## Summary

Closes the recurring gap you hit: *"I put the key in Doppler"* but the fleet's GitHub Actions secrets stay stale until the next daily/hourly guard run, so triage keeps dropping to `static-fallback`.

Rather than write new secret-copy code (which would duplicate the existing `secrets-guardian`/`secret-persistence-guard` and re-introduce the stale-overwrite footgun they deliberately avoided), this makes **`biome-homeostat`** — which already detects every 6h when an AI-lane key is missing from Actions — **dispatch the existing reviewed recovery workflow** (`secret-persistence-guard.yml`, `force_recovery=true`) so the key is pulled back from Doppler **promptly** instead of waiting for that workflow's own daily cron.

Key safety properties:
- **homeostat never handles secret values** — it only *dispatches* the reviewed workflow. That workflow writes a secret only when Doppler returns a non-empty value, so its "don't overwrite a good token with a stale one" rule is untouched.
- **Opt-in & off by default** — gated behind `BIOME_RECOVER_KEYS` (the workflow sets it `true`); the pure `shouldTriggerRecovery()` returns false unless lanes are offline *and* the flag is on.
- **Surgical** — touches only `homeostat.js`, its workflow, and its test; **no overlap** with the in-flight inspector PR #14860.

> ⚠️ **Leaving auto-merge OFF on this one** — it touches secret-recovery infra (adds `actions: write` so homeostat can dispatch the guard), so I'd like your eyes before it merges.

No associated issue.

## Changes

- `scripts/biome/homeostat.js` — add pure `shouldTriggerRecovery(assessment, env)`; in the offline path, dispatch `secret-persistence-guard.yml` (override via `BIOME_RECOVERY_WORKFLOW`) with `allowError` so a dispatch hiccup never crashes the worker.
- `.github/workflows/biome-homeostat.yml` — add `actions: write` (to dispatch) and `BIOME_RECOVER_KEYS: 'true'`.
- `tests/biome-homeostat.test.js` — cover the gating logic (offline + flag only).

## Validation

- `npm test` → **279 pass / 0 fail**.
- `biome-homeostat.yml` parses via `yaml.safe_load`; `biome-workflows.test.js` still passes (homeostat keeps `GH_REPO` + token-fallback + permissions; not a `contents: write` committer).

<!-- docs-freshness: internal behavior change to an existing worker (dispatches an existing workflow); no new external surface or app to document. -->

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — N/A, no associated issue
- [x] No hardcoded secrets or credentials (no secret values are read or written by this code)
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtW5jiCNuzxDCW4tjSkZ66)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/midnghtsapphire/revvel-standards/pull/14862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->