### PR TITLE
fix(ci): add timeout-minutes to 29 jobs so workflows:validate is green

### DIFF
--- a/.github/workflows/agent-fingerprint-gate.yml
+++ b/.github/workflows/agent-fingerprint-gate.yml
@@ -20,6 +20,7 @@ jobs:
   scan:
     name: Scan changed files for agent fingerprints
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { fetch-depth: 0 }

--- a/.github/workflows/app-artifact-audit.yml
+++ b/.github/workflows/app-artifact-audit.yml
@@ -27,6 +27,7 @@ concurrency:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-error-prevention.yml
+++ b/.github/workflows/ci-error-prevention.yml
@@ -20,6 +20,7 @@ jobs:
   error-prevention-tests:
     name: Error Prevention
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,6 +43,7 @@ jobs:
   lint-workflows:
     name: Workflow Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -84,6 +86,7 @@ jobs:
   token-security-check:
     name: Token Security
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -114,6 +117,7 @@ jobs:
   wr-lint-check:
     name: WR Lint Gate
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
@@ -144,6 +148,7 @@ jobs:
   automation-health:
     name: Automation Health Check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -165,6 +170,7 @@ jobs:
     name: Test Summary
     needs: [error-prevention-tests, lint-workflows, token-security-check, automation-health]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: always()
     steps:
       - name: Summary

--- a/.github/workflows/credential-autonomy-agent.yml
+++ b/.github/workflows/credential-autonomy-agent.yml
@@ -36,6 +36,7 @@ jobs:
   autonomy:
     name: 🤖 Credential Autonomy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       actions_taken: ${{ steps.autonomy.outputs.actions_taken }}
       status: ${{ steps.autonomy.outputs.status }}
@@ -90,6 +91,7 @@ jobs:
     needs: autonomy
     if: needs.autonomy.result == 'failure'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       issues: write
     steps:

--- a/.github/workflows/daily-news-briefing.yml
+++ b/.github/workflows/daily-news-briefing.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   news:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch headlines

--- a/.github/workflows/fix-wr-gate.yml
+++ b/.github/workflows/fix-wr-gate.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { fetch-depth: 0 }

--- a/.github/workflows/free-llm-router.yml
+++ b/.github/workflows/free-llm-router.yml
@@ -13,6 +13,7 @@ jobs:
   route:
     name: Route LLM Call
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check OpenRouter credits
         id: check_credits

--- a/.github/workflows/mirror-malama.yml
+++ b/.github/workflows/mirror-malama.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   mirror:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Check mirror is configured
         id: gate

--- a/.github/workflows/news-with-cache.yml
+++ b/.github/workflows/news-with-cache.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   fetch:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/no-root-junk.yml
+++ b/.github/workflows/no-root-junk.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   no-root-junk:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { fetch-depth: 0 }

--- a/.github/workflows/octopus-route.yml
+++ b/.github/workflows/octopus-route.yml
@@ -72,6 +72,7 @@ jobs:
       (github.event.action == 'opened' ||
        (github.event.action == 'labeled' && github.event.label.name == 'recovery:translate-me'))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Translate labels + ensure [WR] title prefix
         uses: actions/github-script@v9.0.0
@@ -132,6 +133,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.backfill == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Walk open octopus-review[bot] issues
         uses: actions/github-script@v9.0.0

--- a/.github/workflows/patch-agent.yml
+++ b/.github/workflows/patch-agent.yml
@@ -24,6 +24,7 @@ jobs:
   patch:
     name: Scan advisories and (optionally) patch
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/repo-self-healer.yml
+++ b/.github/workflows/repo-self-healer.yml
@@ -24,6 +24,7 @@ jobs:
   self-heal:
     name: 🔧 Repo Self-Healer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       closed: ${{ steps.cleanup.outputs.closed }}
       labeled: ${{ steps.cleanup.outputs.labeled }}
@@ -60,6 +61,7 @@ jobs:
     needs: self-heal
     if: needs.self-heal.outputs.closed != '0' || needs.self-heal.outputs.duplicates != '0'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       issues: write
     steps:

--- a/.github/workflows/reset-self-heal-issue.yml
+++ b/.github/workflows/reset-self-heal-issue.yml
@@ -20,6 +20,7 @@ jobs:
   reset-issue:
     name: Reset Issue #${{ inputs.issue_number }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Validate issue exists
         id: validate

--- a/.github/workflows/revvel-engine-spine.yml
+++ b/.github/workflows/revvel-engine-spine.yml
@@ -39,6 +39,7 @@ jobs:
   engine-spine:
     name: Intake → Router → BOM → Orchestrator
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/secrets-backup-daily.yml
+++ b/.github/workflows/secrets-backup-daily.yml
@@ -13,6 +13,7 @@ jobs:
   backup-secrets:
     name: Backup critical secrets to protected location
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     steps:
       - name: Checkout
@@ -99,6 +100,7 @@ jobs:
   verify-protection:
     name: Verify secret protection status
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event_name == 'workflow_dispatch'
     steps:
       - name: Check critical secrets

--- a/.github/workflows/secrets-guardian.yml
+++ b/.github/workflows/secrets-guardian.yml
@@ -20,6 +20,7 @@ jobs:
   guardian:
     name: 🔒 Secrets Guardian
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       restored: ${{ steps.scan.outputs.restored }}
       missing: ${{ steps.scan.outputs.missing }}
@@ -71,6 +72,7 @@ jobs:
     needs: guardian
     if: failure()
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Create issue if guardian keeps failing
         if: github.event.inputs.dry_run != 'true'

--- a/.github/workflows/verify-security-fix.yml
+++ b/.github/workflows/verify-security-fix.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/wr-lint.yml
+++ b/.github/workflows/wr-lint.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { fetch-depth: 0 }

--- a/learnings.md
+++ b/learnings.md
@@ -391,3 +391,17 @@ This file tracks autonomous executions, failures, root causes, and locked-in sol
 **Self-Healing Fix / Learned Lesson:** A line-by-line `gh` scanner produces false positives on multiline commands where `--repo` sits on a continuation line (`reset-self-heal-issue.yml`, `secret-persistence-guard.yml` ×4) and on `echo "...gh issue create..."` strings (`eeat-trust-cron.yml`) — always hand-verify each hit against the full step before claiming a bug. Apply the repo-standard PAT-with-fallback `GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}` (required for any step that uses `gh workflow run` to cascade) and `GH_REPO: ${{ github.repository }}` for checkout-less jobs; grant `issues: write` at the narrowest (job) scope.
 
 **Next Action:** Open the PR for these 5 fixes. Follow-up batch: add `timeout-minutes` to the 19 jobs flagged by `workflows:validate` across the untouched files.
+
+---
+
+**Date/Time:** 2026-06-30T00:00:00Z
+
+**Task Attempted:** Follow-up batch from the gh-CLI audit — add `timeout-minutes` to every job flagged by `npm run workflows:validate` so the fleet-wide validator returns green.
+
+**Outcome:** Success — added `timeout-minutes: 30` to 29 jobs across 19 workflow files. `workflows:validate` now reports `Jobs missing timeout: 0` and exits 0; `npm test` passes (291); all 19 files parse as valid YAML. The diff is purely the 29 timeout additions (verified no other lines changed).
+
+**Root Cause of Failure (If any):** 29 jobs across 19 workflows omitted `timeout-minutes`, so they inherited the GitHub Actions default of 360 minutes — a runaway job could burn 6h of runner time, and the repo's own `automation-doctor --validate` gate counts these as failures (this baseline had been carried for a while; see prior learnings entries citing "jobs without timeout-minutes").
+
+**Self-Healing Fix / Learned Lesson:** When bulk-editing many workflow files, insert via a raw line-based patch (anchor on each target job's `runs-on:` line) rather than a YAML round-trip, which would reflow formatting and strip comments. A column-0 line inside a job's block-scalar `run:` body can fool a naive "am I still inside `jobs:`" tracker into stopping early (it skipped `secrets-guardian.yml`'s `alert-on-failure` job) — always reconcile the patched set against the target set and hand-fix the remainder. `30` is a safe uniform cap for these automation/label/lint/heal jobs (all finish in 1-3 min; well under the 360-min default) and `automation-doctor` only checks for the field's presence.
+
+**Next Action:** Open the PR for these 29 timeout additions. The fleet-wide `workflows:validate` gate is now green end-to-end.


### PR DESCRIPTION
## Summary

Follow-up to the gh-CLI audit (#14861). `npm run workflows:validate` (automation-doctor) was failing on a long-standing baseline: **29 jobs across 19 workflows omitted `timeout-minutes`**, so they inherited the GitHub Actions default of **360 minutes** — a runaway job could burn 6h of runner time, and the validator counts each omission as a failure. This PR adds `timeout-minutes: 30` to every flagged job, turning the fleet-wide validator green.

`30` is a safe uniform cap for these automation / label / lint / heal jobs (all finish in 1–3 minutes; far under the prior 6h default). `automation-doctor` only checks that the field is present.

## Changes

Added `timeout-minutes: 30` to the flagged job(s) in:

`agent-fingerprint-gate.yml`, `app-artifact-audit.yml`, `ci-error-prevention.yml` (×6), `credential-autonomy-agent.yml` (×2), `daily-news-briefing.yml`, `fix-wr-gate.yml`, `free-llm-router.yml`, `mirror-malama.yml`, `news-with-cache.yml`, `no-root-junk.yml`, `octopus-route.yml` (×2), `patch-agent.yml`, `repo-self-healer.yml` (×2), `reset-self-heal-issue.yml`, `revvel-engine-spine.yml`, `secrets-backup-daily.yml` (×2), `secrets-guardian.yml` (×2), `verify-security-fix.yml`, `wr-lint.yml`.

Also appended a `learnings.md` entry per the append-only self-healing-log standard.

## Validation

- `npm run workflows:validate` → **"Jobs missing timeout: 0"**, **exit 0** (was exit 1 on this baseline).
- `npm test` → **291 passed, 0 failed**.
- All 19 edited files parse as valid YAML.
- Diff is **exactly the 29 `timeout-minutes: 30` additions** — verified no other lines changed.

docs-freshness: CI-hardening only (adds a job-level timeout cap); no workflow added or removed, and no routing lane or documented behavior changed, so the SYSTEM_MAP / AUTOMATION_AUDIT / AGENT_MONITORING catalogs need no update.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2jHwBV7FkKtoqsPyLHdFd)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds `timeout-minutes: 30` to 29 jobs across 19 GitHub Actions workflow files to prevent runaway jobs from consuming excessive runner time (previously defaulting to 360 minutes). This change makes the repository's `workflows:validate` automation-doctor gate pass by ensuring all jobs explicitly declare a timeout. The uniform 30-minute cap is safe for these automation, label, lint, and heal jobs which typically complete in 1-3 minutes. A corresponding entry has been added to the self-healing log (`learnings.md`) documenting the fix.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `learnings.md` |
| 2 | `.github/workflows/ci-error-prevention.yml` |
| 3 | `.github/workflows/credential-autonomy-agent.yml` |
| 4 | `.github/workflows/secrets-guardian.yml` |
| 5 | `.github/workflows/secrets-backup-daily.yml` |
| 6 | `.github/workflows/repo-self-healer.yml` |
| 7 | `.github/workflows/octopus-route.yml` |
| 8 | `.github/workflows/agent-fingerprint-gate.yml` |
| 9 | `.github/workflows/app-artifact-audit.yml` |
| 10 | `.github/workflows/daily-news-briefing.yml` |
| 11 | `.github/workflows/fix-wr-gate.yml` |
| 12 | `.github/workflows/free-llm-router.yml` |
| 13 | `.github/workflows/mirror-malama.yml` |
| 14 | `.github/workflows/news-with-cache.yml` |
| 15 | `.github/workflows/no-root-junk.yml` |
| 16 | `.github/workflows/patch-agent.yml` |
| 17 | `.github/workflows/reset-self-heal-issue.yml` |
| 18 | `.github/workflows/revvel-engine-spine.yml` |
| 19 | `.github/workflows/verify-security-fix.yml` |
| 20 | `.github/workflows/wr-lint.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `timeout-minutes: 30` to 29 GitHub Actions jobs across 19 workflows to cap runaway jobs and make the `workflows:validate` gate pass. No workflow behavior changes.

- **Bug Fixes**
  - Added `timeout-minutes: 30` to all validator-flagged jobs (29 across 19 files).
  - `npm run workflows:validate` now passes; YAML validation and tests are green.
  - Added a `learnings.md` entry documenting the change.

<sup>Written for commit 59944a366900568733f22184a14fc1a64082c92c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds 30-minute timeouts to 29 GitHub Actions jobs across 19 workflow files to prevent runaway jobs from consuming excessive runner time. The change addresses a validation failure where jobs defaulted to 360-minute timeouts and applies uniform caps across automation, lint, heal, and monitoring jobs that typically complete in 1-3 minutes.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Security improvement: Adds `timeout-minutes: 30` to 29 jobs in 19 workflow files, capping runaway job potential from default 360 minutes to prevent excessive runner time consumption</li>

<li>Infrastructure: Applies uniform 30-minute timeout across automation, label, lint, and heal jobs that typically complete in 1-3 minutes</li>

<li>Documentation: Appends learnings.md entry documenting the fix approach and lessons learned about bulk-editing workflow files</li>

<li>Validation: Resolves `workflows:validate` automation-doctor gate by applying consistent timeout configuration</li>

</ul>
</details>

</div>