### PR TITLE
feat(rnd-research-fleet): live twin-LLM search runner (twin_llm_adjudicated)

### DIFF
--- a/products/rnd-research-fleet/deep-search-router.js
+++ b/products/rnd-research-fleet/deep-search-router.js
@@ -115,35 +115,37 @@ async function deepSearch(query, profileName = 'deep_search') {
   return result;
 }
 
-// CLI
-const query = process.argv.slice(2).join(' ');
-const profile = process.argv[2] === '--profile' ? process.argv[3] : null;
-const actualQuery = profile ? process.argv.slice(4).join(' ') : query;
+// CLI — guarded so the module can be safely required (e.g. by twin-search.js)
+// without executing a search on import.
+if (require.main === module) {
+  const query = process.argv.slice(2).join(' ');
+  const profile = process.argv[2] === '--profile' ? process.argv[3] : null;
+  const actualQuery = profile ? process.argv.slice(4).join(' ') : query;
 
-if (!actualQuery) {
-  console.log(`
+  if (!actualQuery) {
+    console.log(`
 🔬 Deep Search Router
 
 Usage:
   node deep-search-router.js "your research question"
   node deep-search-router.js --profile market "your question"
-  
+
 Profiles:
   deep_search (default) - DOE, TRIZ, MEErP, LCA, BNAT
-  market_research       - TAM, competitors, trends  
+  market_research       - TAM, competitors, trends
   technical            - Feasibility, architecture
 
 Models:
   Primary: anthropic/claude-3.5-sonnet
   Fallback: openrouter/fusion
 `);
-  process.exit(0);
-}
+    process.exit(0);
+  }
 
-deepSearch(actualQuery, profile || 'deep_search')
-  .catch(e => {
+  deepSearch(actualQuery, profile || 'deep_search').catch((e) => {
     console.error('❌ Error:', e.message);
     process.exit(1);
   });
+}
 
-module.exports = { deepSearch, callOpenRouter, ROUTING_PROFILES };
+module.exports = { deepSearch, callOpenRouter, ROUTING_PROFILES, MASTER_PROMPT };

--- a/products/rnd-research-fleet/package.json
+++ b/products/rnd-research-fleet/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node perplexity-research.js",
     "deep-search": "node deep-search-router.js",
+    "twin:search": "node twin-search.js",
     "persona": "node persona-loader.js",
     "install-all": "./install.sh",
     "setup": "node auto-github-join.js",

--- a/products/rnd-research-fleet/standards/SEARCH_EVALUATION.md
+++ b/products/rnd-research-fleet/standards/SEARCH_EVALUATION.md
@@ -280,6 +280,35 @@ adjudication quality and zero unsupported-claim flags. (Against the already-stro
 baseline the same twin run scores `tune_twin`, since its rubric edge there is
 below the keep threshold - exactly the kind of nuance this report surfaces.)
 
+### Running the twin LIVE (real API)
+
+`twin-search.js` is the live runner. It sends the query to two independent models
+in parallel, adjudicates/synthesizes a source-backed answer, and prints a report
+in the twin JSON schema above — so its output feeds straight into the offline
+comparator. Requires `OPENROUTER_API_KEY` (this is the product's paid search lane,
+not the credit-free BIOME crew).
+
+```bash
+cd products/rnd-research-fleet
+
+# Live twin run -> capture as a fixture
+OPENROUTER_API_KEY=... node twin-search.js "your research question" > /tmp/twin-live.json
+# (override models if desired)
+#   TWIN_MODEL_A=openai/gpt-4o-search-preview TWIN_MODEL_B=anthropic/claude-3.5-sonnet \
+#   TWIN_ADJUDICATOR=openai/gpt-4o node twin-search.js "..."
+
+# Then score it against Fable/baseline with the same comparator:
+node eval/search-eval.js \
+  --fixtures eval/fixtures/queries.json \
+  --baseline eval/fixtures/baseline.example.json \
+  --fable    eval/fixtures/fable.example.json \
+  --twin-adjudicated /tmp/twin-live.json \
+  --md /tmp/strategy-report.md
+```
+
+The live run still has to **earn `keep_twin`** on the comparator before it becomes
+the default — the runner produces the data; the eval makes the call.
+
 ### Twin run JSON schema (per result)
 
 ```json

--- a/products/rnd-research-fleet/twin-search.js
+++ b/products/rnd-research-fleet/twin-search.js
@@ -22,11 +22,13 @@
 
 const { MASTER_PROMPT } = require('./deep-search-router');
 
-const DEFAULTS = {
+// Frozen so a consumer mutating the shared export can't bleed into other uses;
+// the CLI spreads a copy (`{ ...DEFAULTS }`) before per-run tweaks.
+const DEFAULTS = Object.freeze({
   modelA: process.env.TWIN_MODEL_A || 'openai/gpt-4o-search-preview',
   modelB: process.env.TWIN_MODEL_B || 'anthropic/claude-3.5-sonnet',
   adjudicator: process.env.TWIN_ADJUDICATOR || 'openai/gpt-4o',
-};
+});
 
 // The twin's two arms apply the SAME R&D frameworks as the deep-search lane —
 // DOE Screening, TRIZ, MEErP, LCA, and BNAT (Best Not Yet Available Technology) —
@@ -198,8 +200,14 @@ if (require.main === module) {
 {"answer": "<merged source-backed answer>", "citations": ["<url>", ...], "agreement_score": <0..1>, "disagreements": <int>, "adjudication_quality": <0..1>, "unsupported_claims": <int>}`;
 
   async function callModel(model, messages) {
+    // OpenRouter needs a FUNDED key — even ":free" models require credits — so a
+    // missing/unfunded/unverified key returns 401/402/403/429 rather than an
+    // answer. Troubleshooting if a call fails: check the key AND the account
+    // balance at https://openrouter.ai/credits.
     const apiKey = process.env.OPENROUTER_API_KEY;
-    if (!apiKey) throw new Error('OPENROUTER_API_KEY required');
+    if (!apiKey) {
+      throw new Error('OPENROUTER_API_KEY required (must be a funded/verified key — see https://openrouter.ai/credits)');
+    }
     const started = Date.now();
     const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
       method: 'POST',
@@ -209,12 +217,18 @@ if (require.main === module) {
         'HTTP-Referer': 'https://rnd-research-fleet',
         'X-Title': 'R&D Research Fleet — Twin Search',
       },
+      // `usage: { include: true }` is OpenRouter's accounting extension — it
+      // returns spend on `usage.cost` (USD) in the response. Best-effort: if the
+      // field is absent, cost stays null and the eval's cost dimension is simply
+      // not populated for this run (never a crash).
       body: JSON.stringify({ model, messages, max_tokens: 4000, temperature: 0.3, usage: { include: true } }),
     });
     const latency_ms = Date.now() - started;
     if (!res.ok) {
       const t = await res.text().catch(() => '');
-      throw new Error(`${model} -> ${res.status} ${t.slice(0, 200)}`);
+      // 401/402/403/429 almost always = missing/unfunded key or rate limit —
+      // check the key and balance at https://openrouter.ai/credits.
+      throw new Error(`${model} -> ${res.status} ${t.slice(0, 200)} (if 401/402/403/429: check key + balance at https://openrouter.ai/credits)`);
     }
     const data = await res.json();
     const content = data.choices?.[0]?.message?.content || '';

--- a/products/rnd-research-fleet/twin-search.js
+++ b/products/rnd-research-fleet/twin-search.js
@@ -130,7 +130,7 @@ function countOf(v) {
  * runA/runB: { answer, citations, latency_ms, cost_usd }
  * adjudication: parsed adjudicator object (may be null -> fallback merge).
  */
-function buildTwinResult({ queryId, models, runA, runB, adjudication, adjudicatorLatencyMs = 0, adjudicatorCostUsd = null }) {
+function buildTwinResult({ queryId, models, runA, runB, adjudication, adjudicatorLatencyMs = 0, adjudicatorCostUsd = null, error = false }) {
   const adj = adjudication || {};
   const sourcesA = runA.citations || [];
   const sourcesB = runB.citations || [];
@@ -147,7 +147,10 @@ function buildTwinResult({ queryId, models, runA, runB, adjudication, adjudicato
     query_id: queryId,
     answer,
     citations,
-    error: false,
+    // A twin run is only error-free when BOTH arms returned; a failed arm is
+    // surfaced so eval/search-eval.js can quantify error-rate instead of the
+    // whole run vanishing.
+    error: Boolean(error),
     latency_ms,
     cost_usd,
     twin: {
@@ -230,17 +233,37 @@ if (require.main === module) {
     const userMsg = [{ role: 'system', content: SEARCH_SYSTEM }, { role: 'user', content: query }];
 
     console.error(`[twin] A=${models.modelA}  B=${models.modelB}  adj=${models.adjudicator}`);
-    // Two independent runs IN PARALLEL — the whole point of twin.
-    const [a, b] = await Promise.all([callModel(models.modelA, userMsg), callModel(models.modelB, userMsg)]);
+    // Two independent runs IN PARALLEL — allSettled so a single arm failing
+    // still yields an eval-compatible (error-flagged) report instead of losing
+    // the whole run.
+    const settled = await Promise.allSettled([callModel(models.modelA, userMsg), callModel(models.modelB, userMsg)]);
+    const okA = settled[0].status === 'fulfilled';
+    const okB = settled[1].status === 'fulfilled';
+    if (!okA) console.error(`[twin] model A (${models.modelA}) failed: ${settled[0].reason?.message}`);
+    if (!okB) console.error(`[twin] model B (${models.modelB}) failed: ${settled[1].reason?.message}`);
+    const a = okA ? settled[0].value : { content: '', latency_ms: 0, cost_usd: null };
+    const b = okB ? settled[1].value : { content: '', latency_ms: 0, cost_usd: null };
     const runA = { answer: a.content, citations: extractCitations(a.content), latency_ms: a.latency_ms, cost_usd: a.cost_usd };
     const runB = { answer: b.content, citations: extractCitations(b.content), latency_ms: b.latency_ms, cost_usd: b.cost_usd };
 
-    const adjMsg = [
-      { role: 'system', content: ADJUDICATOR_SYSTEM },
-      { role: 'user', content: `Question:\n${query}\n\n--- Answer A (${models.modelA}) ---\n${runA.answer}\n\n--- Answer B (${models.modelB}) ---\n${runB.answer}` },
-    ];
-    const adj = await callModel(models.adjudicator, adjMsg);
-    const adjudication = parseAdjudication(adj.content);
+    // Adjudicate only if at least one arm produced content.
+    let adjudication = null;
+    let adjLatency = 0;
+    let adjCost = null;
+    if (okA || okB) {
+      const adjMsg = [
+        { role: 'system', content: ADJUDICATOR_SYSTEM },
+        { role: 'user', content: `Question:\n${query}\n\n--- Answer A (${models.modelA}) ---\n${runA.answer}\n\n--- Answer B (${models.modelB}) ---\n${runB.answer}` },
+      ];
+      try {
+        const adj = await callModel(models.adjudicator, adjMsg);
+        adjudication = parseAdjudication(adj.content);
+        adjLatency = adj.latency_ms;
+        adjCost = adj.cost_usd;
+      } catch (e) {
+        console.error(`[twin] adjudicator (${models.adjudicator}) failed: ${e.message}`);
+      }
+    }
 
     const result = buildTwinResult({
       queryId: 'cli-query',
@@ -248,12 +271,14 @@ if (require.main === module) {
       runA,
       runB,
       adjudication,
-      adjudicatorLatencyMs: adj.latency_ms,
-      adjudicatorCostUsd: adj.cost_usd,
+      adjudicatorLatencyMs: adjLatency,
+      adjudicatorCostUsd: adjCost,
+      error: !okA || !okB, // a twin needs both arms; a failed arm is a degraded (error) run
     });
     // Emit the eval-compatible report on stdout (pipe to a fixture, then run
     // `npm run eval:strategies ... --twin-adjudicated <file>`).
     console.log(JSON.stringify(buildTwinReport([result], models), null, 2));
+    if (!okA || !okB) process.exitCode = 1; // signal a degraded run without discarding the report
   })().catch((e) => {
     console.error('twin-search error:', e.message);
     process.exit(1);

--- a/products/rnd-research-fleet/twin-search.js
+++ b/products/rnd-research-fleet/twin-search.js
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Twin-LLM live search runner (twin_llm_adjudicated).
+ *
+ * Implements the strategy specced in standards/SEARCH_EVALUATION.md as a LIVE
+ * path (the existing deep-search-router.js only does sequential failover):
+ *
+ *   1. Send the SAME query to TWO independent models in PARALLEL (model_a, model_b)
+ *      — ideally different providers, so failure modes are uncorrelated.
+ *   2. An adjudicator model merges them: keep agreed + source-backed claims,
+ *      resolve disagreements toward the better-cited side, DROP unsupported claims.
+ *   3. Emit a result object matching the twin JSON schema so it plugs straight
+ *      into eval/search-eval.js (--twin-adjudicated) for the keep/tune/rollback
+ *      decision. Green CI never proves twin is better — the eval does.
+ *
+ * Uses OPENROUTER_API_KEY (this is the rnd-research-fleet product's paid search
+ * lane, not the credit-free BIOME crew). Pure helpers are exported for tests;
+ * the network orchestration lives under `if (require.main === module)`.
+ */
+
+const DEFAULTS = {
+  modelA: process.env.TWIN_MODEL_A || 'openai/gpt-4o-search-preview',
+  modelB: process.env.TWIN_MODEL_B || 'anthropic/claude-3.5-sonnet',
+  adjudicator: process.env.TWIN_ADJUDICATOR || 'openai/gpt-4o',
+};
+
+const URL_RE = /\bhttps?:\/\/[^\s)\]"'<>]+/g;
+
+function extractCitations(text) {
+  if (!text) return [];
+  const out = [];
+  const seen = new Set();
+  for (const m of String(text).matchAll(URL_RE)) {
+    // strip trailing punctuation that commonly clings to URLs in prose
+    const url = m[0].replace(/[.,;:)\]}>"']+$/, '');
+    if (!seen.has(url)) {
+      seen.add(url);
+      out.push(url);
+    }
+  }
+  return out;
+}
+
+function domainOf(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '').toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+function domainSet(urls) {
+  return new Set((urls || []).map(domainOf).filter(Boolean));
+}
+
+// Jaccard overlap of source domains — used as a fallback agreement signal when
+// the adjudicator doesn't return its own agreement_score.
+function sourceOverlapScore(a, b) {
+  const sa = domainSet(a);
+  const sb = domainSet(b);
+  if (sa.size === 0 && sb.size === 0) return 0;
+  let inter = 0;
+  for (const d of sa) if (sb.has(d)) inter += 1;
+  const union = new Set([...sa, ...sb]).size;
+  return union ? round(inter / union) : 0;
+}
+
+function round(n, p = 2) {
+  const f = 10 ** p;
+  return Math.round(n * f) / f;
+}
+
+function unionCitations(a, b) {
+  const out = [];
+  const seen = new Set();
+  for (const u of [...(a || []), ...(b || [])]) {
+    if (!seen.has(u)) {
+      seen.add(u);
+      out.push(u);
+    }
+  }
+  return out;
+}
+
+// Parse the adjudicator's structured verdict. Tolerates ```json fences and
+// surrounding prose; returns null if no JSON object can be recovered.
+function parseAdjudication(content) {
+  if (!content) return null;
+  let text = String(content).trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) text = fence[1].trim();
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1 || end < start) return null;
+  try {
+    const obj = JSON.parse(text.slice(start, end + 1));
+    return obj && typeof obj === 'object' ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+function clamp01(n, fallback) {
+  if (typeof n !== 'number' || Number.isNaN(n)) return fallback;
+  return Math.max(0, Math.min(1, n));
+}
+
+function countOf(v) {
+  if (Array.isArray(v)) return v.length;
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  return 0;
+}
+
+/**
+ * Assemble one twin result row matching the SEARCH_EVALUATION twin schema.
+ * runA/runB: { answer, citations, latency_ms, cost_usd }
+ * adjudication: parsed adjudicator object (may be null -> fallback merge).
+ */
+function buildTwinResult({ queryId, models, runA, runB, adjudication, adjudicatorLatencyMs = 0, adjudicatorCostUsd = null }) {
+  const adj = adjudication || {};
+  const sourcesA = runA.citations || [];
+  const sourcesB = runB.citations || [];
+
+  const answer = typeof adj.answer === 'string' && adj.answer.trim() ? adj.answer.trim() : runA.answer || runB.answer || '';
+  const citations =
+    Array.isArray(adj.citations) && adj.citations.length ? adj.citations.slice() : unionCitations(sourcesA, sourcesB);
+
+  const latency_ms = Math.max(runA.latency_ms || 0, runB.latency_ms || 0) + (adjudicatorLatencyMs || 0);
+  const costs = [runA.cost_usd, runB.cost_usd, adjudicatorCostUsd].filter((c) => typeof c === 'number');
+  const cost_usd = costs.length ? round(costs.reduce((s, c) => s + c, 0), 6) : null;
+
+  return {
+    query_id: queryId,
+    answer,
+    citations,
+    error: false,
+    latency_ms,
+    cost_usd,
+    twin: {
+      model_a: models.modelA,
+      model_b: models.modelB,
+      adjudicator: models.adjudicator,
+      agreement_score: clamp01(adj.agreement_score, sourceOverlapScore(sourcesA, sourcesB)),
+      disagreements: countOf(adj.disagreements),
+      adjudication_quality: clamp01(adj.adjudication_quality, 0.5),
+      sources_a: sourcesA,
+      sources_b: sourcesB,
+      unsupported_claims: countOf(adj.unsupported_claims),
+    },
+  };
+}
+
+function buildTwinReport(results, models) {
+  return {
+    label: 'twin_llm_adjudicated',
+    strategy: 'twin_llm_adjudicated',
+    search_prompt_version: 'twin-llm-adjudicated-v1',
+    router_profile: 'twin_dual_model_adjudicated',
+    models,
+    results,
+  };
+}
+
+module.exports = {
+  DEFAULTS,
+  extractCitations,
+  domainOf,
+  sourceOverlapScore,
+  unionCitations,
+  parseAdjudication,
+  buildTwinResult,
+  buildTwinReport,
+};
+
+// --- CLI / live orchestration ---------------------------------------------
+if (require.main === module) {
+  const SEARCH_SYSTEM = `You are a research assistant. Answer the question accurately and concisely. Cite every nontrivial claim with a full source URL inline. Prefer primary/authoritative sources. If unsure, say so rather than guessing.`;
+
+  const ADJUDICATOR_SYSTEM = `You are an adjudicator merging two independent research answers (A and B) to the same question. Keep only claims that at least one answer supports with a cited source; resolve disagreements toward the better-cited side; DROP any claim with no supporting source. Return STRICT JSON only, no prose, with this exact shape:
+{"answer": "<merged source-backed answer>", "citations": ["<url>", ...], "agreement_score": <0..1>, "disagreements": <int>, "adjudication_quality": <0..1>, "unsupported_claims": <int>}`;
+
+  async function callModel(model, messages) {
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    if (!apiKey) throw new Error('OPENROUTER_API_KEY required');
+    const started = Date.now();
+    const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': 'https://rnd-research-fleet',
+        'X-Title': 'R&D Research Fleet — Twin Search',
+      },
+      body: JSON.stringify({ model, messages, max_tokens: 4000, temperature: 0.3, usage: { include: true } }),
+    });
+    const latency_ms = Date.now() - started;
+    if (!res.ok) {
+      const t = await res.text().catch(() => '');
+      throw new Error(`${model} -> ${res.status} ${t.slice(0, 200)}`);
+    }
+    const data = await res.json();
+    const content = data.choices?.[0]?.message?.content || '';
+    const cost_usd = typeof data.usage?.cost === 'number' ? data.usage.cost : null;
+    return { content, latency_ms, cost_usd };
+  }
+
+  (async () => {
+    const query = process.argv.slice(2).join(' ').trim();
+    if (!query) {
+      console.log('Usage: node twin-search.js "your research question"');
+      console.log('Env: TWIN_MODEL_A, TWIN_MODEL_B, TWIN_ADJUDICATOR (optional overrides)');
+      process.exit(0);
+    }
+    const models = { ...DEFAULTS };
+    const userMsg = [{ role: 'system', content: SEARCH_SYSTEM }, { role: 'user', content: query }];
+
+    console.error(`[twin] A=${models.modelA}  B=${models.modelB}  adj=${models.adjudicator}`);
+    // Two independent runs IN PARALLEL — the whole point of twin.
+    const [a, b] = await Promise.all([callModel(models.modelA, userMsg), callModel(models.modelB, userMsg)]);
+    const runA = { answer: a.content, citations: extractCitations(a.content), latency_ms: a.latency_ms, cost_usd: a.cost_usd };
+    const runB = { answer: b.content, citations: extractCitations(b.content), latency_ms: b.latency_ms, cost_usd: b.cost_usd };
+
+    const adjMsg = [
+      { role: 'system', content: ADJUDICATOR_SYSTEM },
+      { role: 'user', content: `Question:\n${query}\n\n--- Answer A (${models.modelA}) ---\n${runA.answer}\n\n--- Answer B (${models.modelB}) ---\n${runB.answer}` },
+    ];
+    const adj = await callModel(models.adjudicator, adjMsg);
+    const adjudication = parseAdjudication(adj.content);
+
+    const result = buildTwinResult({
+      queryId: 'cli-query',
+      models,
+      runA,
+      runB,
+      adjudication,
+      adjudicatorLatencyMs: adj.latency_ms,
+      adjudicatorCostUsd: adj.cost_usd,
+    });
+    // Emit the eval-compatible report on stdout (pipe to a fixture, then run
+    // `npm run eval:strategies ... --twin-adjudicated <file>`).
+    console.log(JSON.stringify(buildTwinReport([result], models), null, 2));
+  })().catch((e) => {
+    console.error('twin-search error:', e.message);
+    process.exit(1);
+  });
+}

--- a/products/rnd-research-fleet/twin-search.js
+++ b/products/rnd-research-fleet/twin-search.js
@@ -20,11 +20,23 @@
  * the network orchestration lives under `if (require.main === module)`.
  */
 
+const { MASTER_PROMPT } = require('./deep-search-router');
+
 const DEFAULTS = {
   modelA: process.env.TWIN_MODEL_A || 'openai/gpt-4o-search-preview',
   modelB: process.env.TWIN_MODEL_B || 'anthropic/claude-3.5-sonnet',
   adjudicator: process.env.TWIN_ADJUDICATOR || 'openai/gpt-4o',
 };
+
+// The twin's two arms apply the SAME R&D frameworks as the deep-search lane —
+// DOE Screening, TRIZ, MEErP, LCA, and BNAT (Best Not Yet Available Technology) —
+// so it stays a true deep-research twin, not a generic Q&A. Citations are added
+// on top because the evaluator scores source coverage.
+function buildSearchSystemPrompt() {
+  return `${MASTER_PROMPT}
+
+Additionally, for this search: cite every nontrivial claim with a full source URL inline. Prefer primary/authoritative sources. If unsure, say so rather than guessing.`;
+}
 
 const URL_RE = /\bhttps?:\/\/[^\s)\]"'<>]+/g;
 
@@ -165,6 +177,7 @@ function buildTwinReport(results, models) {
 
 module.exports = {
   DEFAULTS,
+  buildSearchSystemPrompt,
   extractCitations,
   domainOf,
   sourceOverlapScore,
@@ -176,7 +189,7 @@ module.exports = {
 
 // --- CLI / live orchestration ---------------------------------------------
 if (require.main === module) {
-  const SEARCH_SYSTEM = `You are a research assistant. Answer the question accurately and concisely. Cite every nontrivial claim with a full source URL inline. Prefer primary/authoritative sources. If unsure, say so rather than guessing.`;
+  const SEARCH_SYSTEM = buildSearchSystemPrompt();
 
   const ADJUDICATOR_SYSTEM = `You are an adjudicator merging two independent research answers (A and B) to the same question. Keep only claims that at least one answer supports with a cited source; resolve disagreements toward the better-cited side; DROP any claim with no supporting source. Return STRICT JSON only, no prose, with this exact shape:
 {"answer": "<merged source-backed answer>", "citations": ["<url>", ...], "agreement_score": <0..1>, "disagreements": <int>, "adjudication_quality": <0..1>, "unsupported_claims": <int>}`;

--- a/tests/twin-search.test.js
+++ b/tests/twin-search.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  extractCitations,
+  domainOf,
+  sourceOverlapScore,
+  unionCitations,
+  parseAdjudication,
+  buildTwinResult,
+  buildTwinReport,
+} = require('../products/rnd-research-fleet/twin-search');
+
+test('extractCitations pulls + dedupes URLs and strips trailing punctuation', () => {
+  const text = 'See https://a.com/x. Also (https://b.com/y) and https://a.com/x again.';
+  assert.deepEqual(extractCitations(text), ['https://a.com/x', 'https://b.com/y']);
+});
+
+test('extractCitations handles empty/none', () => {
+  assert.deepEqual(extractCitations(''), []);
+  assert.deepEqual(extractCitations('no links here'), []);
+});
+
+test('domainOf normalizes host and drops www', () => {
+  assert.equal(domainOf('https://www.Example.com/a?b=1'), 'example.com');
+  assert.equal(domainOf('not a url'), '');
+});
+
+test('sourceOverlapScore is Jaccard over domains', () => {
+  assert.equal(sourceOverlapScore(['https://a.com/1'], ['https://a.com/2']), 1); // same domain
+  assert.equal(sourceOverlapScore(['https://a.com'], ['https://b.com']), 0);
+  assert.equal(sourceOverlapScore([], []), 0);
+  // {a,b} vs {b,c} -> intersect {b}=1, union {a,b,c}=3 -> 0.33
+  assert.equal(sourceOverlapScore(['https://a.com', 'https://b.com'], ['https://b.com', 'https://c.com']), 0.33);
+});
+
+test('unionCitations dedupes preserving order', () => {
+  assert.deepEqual(unionCitations(['x', 'y'], ['y', 'z']), ['x', 'y', 'z']);
+});
+
+test('parseAdjudication recovers JSON from fenced/prose output', () => {
+  const fenced = 'Here:\n```json\n{"answer":"ok","agreement_score":0.8}\n```\nthanks';
+  assert.deepEqual(parseAdjudication(fenced), { answer: 'ok', agreement_score: 0.8 });
+  assert.equal(parseAdjudication('no json'), null);
+  assert.equal(parseAdjudication(''), null);
+});
+
+test('buildTwinResult uses adjudicator fields and emits the twin schema', () => {
+  const runA = { answer: 'A says https://a.com', citations: ['https://a.com'], latency_ms: 1000, cost_usd: 0.001 };
+  const runB = { answer: 'B says https://b.com', citations: ['https://b.com'], latency_ms: 1500, cost_usd: 0.002 };
+  const adjudication = {
+    answer: 'merged',
+    citations: ['https://a.com', 'https://b.com'],
+    agreement_score: 0.7,
+    disagreements: 1,
+    adjudication_quality: 0.9,
+    unsupported_claims: 0,
+  };
+  const r = buildTwinResult({
+    queryId: 'q1',
+    models: { modelA: 'm-a', modelB: 'm-b', adjudicator: 'm-adj' },
+    runA,
+    runB,
+    adjudication,
+    adjudicatorLatencyMs: 500,
+    adjudicatorCostUsd: 0.0005,
+  });
+  assert.equal(r.query_id, 'q1');
+  assert.equal(r.answer, 'merged');
+  assert.deepEqual(r.citations, ['https://a.com', 'https://b.com']);
+  assert.equal(r.latency_ms, 1500 + 500); // slowest arm + adjudicator
+  assert.equal(r.cost_usd, 0.0035); // 0.001 + 0.002 + 0.0005
+  assert.equal(r.twin.model_a, 'm-a');
+  assert.equal(r.twin.adjudicator, 'm-adj');
+  assert.equal(r.twin.agreement_score, 0.7);
+  assert.equal(r.twin.disagreements, 1);
+  assert.deepEqual(r.twin.sources_a, ['https://a.com']);
+});
+
+test('buildTwinResult falls back when adjudication is null (overlap + union)', () => {
+  const runA = { answer: 'a', citations: ['https://a.com'], latency_ms: 1000, cost_usd: null };
+  const runB = { answer: 'b', citations: ['https://b.com'], latency_ms: 1200, cost_usd: null };
+  const r = buildTwinResult({ queryId: 'q', models: { modelA: 'a', modelB: 'b', adjudicator: 'c' }, runA, runB, adjudication: null });
+  assert.deepEqual(r.citations, ['https://a.com', 'https://b.com']); // union fallback
+  assert.equal(r.twin.agreement_score, 0); // disjoint domains
+  assert.equal(r.twin.adjudication_quality, 0.5); // fallback floor
+  assert.equal(r.cost_usd, null); // no costs known
+});
+
+test('buildTwinReport wraps results with the adjudicated strategy labels', () => {
+  const rep = buildTwinReport([{ query_id: 'q' }], { modelA: 'a', modelB: 'b', adjudicator: 'c' });
+  assert.equal(rep.strategy, 'twin_llm_adjudicated');
+  assert.equal(rep.router_profile, 'twin_dual_model_adjudicated');
+  assert.equal(rep.results.length, 1);
+});

--- a/tests/twin-search.test.js
+++ b/tests/twin-search.test.js
@@ -3,6 +3,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
 const {
+  buildSearchSystemPrompt,
   extractCitations,
   domainOf,
   sourceOverlapScore,
@@ -11,6 +12,15 @@ const {
   buildTwinResult,
   buildTwinReport,
 } = require('../products/rnd-research-fleet/twin-search');
+
+test('twin arms apply the R&D frameworks incl. BNAT (not a generic prompt)', () => {
+  const p = buildSearchSystemPrompt();
+  for (const fw of ['DOE', 'TRIZ', 'MEErP', 'LCA', 'BNAT']) {
+    assert.ok(p.includes(fw), `search prompt missing framework: ${fw}`);
+  }
+  assert.match(p, /Best Not Yet Available Technology/);
+  assert.match(p, /cite every nontrivial claim/i); // citations still required for the evaluator
+});
 
 test('extractCitations pulls + dedupes URLs and strips trailing punctuation', () => {
   const text = 'See https://a.com/x. Also (https://b.com/y) and https://a.com/x again.';

--- a/tests/twin-search.test.js
+++ b/tests/twin-search.test.js
@@ -88,6 +88,19 @@ test('buildTwinResult uses adjudicator fields and emits the twin schema', () => 
   assert.deepEqual(r.twin.sources_a, ['https://a.com']);
 });
 
+test('buildTwinResult surfaces error state (so eval can measure error-rate)', () => {
+  const ok = { answer: 'a', citations: ['https://a.com'], latency_ms: 100, cost_usd: null };
+  const empty = { answer: '', citations: [], latency_ms: 0, cost_usd: null };
+  const models = { modelA: 'a', modelB: 'b', adjudicator: 'c' };
+  // default: error-free
+  assert.equal(buildTwinResult({ queryId: 'q', models, runA: ok, runB: ok, adjudication: null }).error, false);
+  // a failed arm -> error true, but a report is still produced
+  const degraded = buildTwinResult({ queryId: 'q', models, runA: ok, runB: empty, adjudication: null, error: true });
+  assert.equal(degraded.error, true);
+  assert.equal(degraded.query_id, 'q');
+  assert.deepEqual(degraded.citations, ['https://a.com']); // surviving arm's sources still surface
+});
+
 test('buildTwinResult falls back when adjudication is null (overlap + union)', () => {
   const runA = { answer: 'a', citations: ['https://a.com'], latency_ms: 1000, cost_usd: null };
   const runB = { answer: 'b', citations: ['https://b.com'], latency_ms: 1200, cost_usd: null };


### PR DESCRIPTION
## Summary

You asked whether the "OpenRouter twin" already existed — it did, but **only as a spec + offline evaluator** (`SEARCH_EVALUATION.md` + `eval/search-eval.js` + fixtures). Nothing actually *ran* a twin: the live router (`deep-search-router.js`) does sequential model failover, not a parallel twin.

This PR adds the missing **live runner**, `twin-search.js`, implementing the repo's specced `twin_llm_adjudicated` strategy:
1. Sends the query to **two independent models in parallel** (`TWIN_MODEL_A`, `TWIN_MODEL_B`).
2. Runs an **adjudicator** that keeps agreed, source-backed claims, resolves disagreements toward the better-cited side, and **drops unsupported claims**.
3. Prints a report in the **exact twin JSON schema** the comparator consumes — so a live run feeds straight into `search-eval.js --twin-adjudicated` for the `keep_twin` / `tune_twin` / `rollback_twin` decision.

Uses `OPENROUTER_API_KEY` (this product's paid search lane — **not** the credit-free BIOME crew).

> **Note (matches the standard):** the repo's twin is two *independent* models synthesized for **quality** (~2× cost/latency), not "the same model twice for speed." It must still **earn `keep_twin`** on the comparator before becoming the default.

No associated issue.

## Changes

- `products/rnd-research-fleet/twin-search.js` — pure helpers (`extractCitations`, `sourceOverlapScore`, `parseAdjudication`, `buildTwinResult`/`buildTwinReport`) + live OpenRouter orchestration (parallel A+B → adjudicator) under `require.main`. Models overridable via `TWIN_MODEL_A/B/ADJUDICATOR`.
- `tests/twin-search.test.js` — 9 unit tests for the pure logic (citation extraction, Jaccard domain overlap, adjudication JSON parsing incl. fenced/prose, schema assembly, null-adjudication fallback).
- `package.json` — add `twin:search` script.
- `SEARCH_EVALUATION.md` — document the live runner and how to score its output against Fable/baseline.

## Validation

- `npm test` → **300 pass / 0 fail** (adds 9 twin tests; nothing else regressed).
- `markdownlint-cli2` on the changed doc → **0 errors**; `package.json` valid JSON; module loads clean.
- Output shape verified against the `twin` schema in `SEARCH_EVALUATION.md` and the `twin-llm-adjudicated.example.json` fixture (so live output is comparator-compatible).
- Live API path is not exercised in CI (needs `OPENROUTER_API_KEY`); the network orchestration is isolated under `require.main` and the scored logic is unit-tested.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — N/A, no associated issue
- [x] No hardcoded secrets or credentials (key read from `OPENROUTER_API_KEY` env)
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtW5jiCNuzxDCW4tjSkZ66)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a **live twin-LLM search runner** (`twin-search.js`) that implements the previously spec-only `twin_llm_adjudicated` strategy. The implementation sends research queries to two independent models in parallel, adjudicates their responses by keeping source-backed claims and resolving disagreements, then outputs results in the standard twin JSON schema that can be fed directly into the existing offline evaluator (`search-eval.js`). This bridges the gap between the documented twin strategy and actual execution, enabling quality comparison against baseline and Fable search strategies. The runner uses the `OPENROUTER_API_KEY` for paid API access, includes 9 unit tests covering the pure logic (citation extraction, domain overlap scoring, adjudication parsing), and adds documentation on how to run and evaluate live twin searches.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `products/rnd-research-fleet/standards/SEARCH_EVALUATION.md` |
| 2 | `tests/twin-search.test.js` |
| 3 | `products/rnd-research-fleet/twin-search.js` |
| 4 | `products/rnd-research-fleet/package.json` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live twin-LLM search runner that queries two models in parallel, adjudicates their answers, and outputs eval-compatible twin JSON. Now resilient to partial failures and clearer about funded `OPENROUTER_API_KEY` requirements so runs remain comparable for scoring.

- New Features
  - `twin-search.js`: parallel A+B → adjudicator; prints twin-schema JSON consumable by `eval/search-eval.js --twin-adjudicated`.
  - Uses `OPENROUTER_API_KEY`; models overridable via `TWIN_MODEL_A`, `TWIN_MODEL_B`, `TWIN_ADJUDICATOR`; adds `npm run twin:search`; collects cost from OpenRouter `usage.cost` when available; freezes `DEFAULTS`.
  - Updates `SEARCH_EVALUATION.md` with live run steps and scoring; 11 unit tests for citations, overlap, adjudication parsing, schema assembly, and fallbacks.

- Bug Fixes
  - Twin arms now use the canonical `MASTER_PROMPT` (DOE/TRIZ/MEErP/LCA/BNAT) with a citation requirement.
  - Resilience: `Promise.allSettled` prevents full-run failures; emits a report with `error: true` (and exit code 1) if an arm fails; adjudicator failures degrade gracefully.
  - `deep-search-router.js` exports `MASTER_PROMPT` and guards its CLI under `require.main`; clearer OpenRouter error messages note funded key/rate-limit checks.

<sup>Written for commit 30bda4eb692b5a94ee6d144dc5c602ca73676b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/14864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

