### PR TITLE
fix(auto-approve): approve owner PRs as a non-author identity (unblocks hands-off merge)

### DIFF
--- a/.github/workflows/auto-approve-clean-prs.yml
+++ b/.github/workflows/auto-approve-clean-prs.yml
@@ -61,7 +61,9 @@ jobs:
             // the PAT silently fails. Approve from a DIFFERENT identity than the
             // author: github-actions[bot] (free github.token) for owner-authored PRs,
             // the admin PAT for everyone else (and for bot-authored PRs).
-            const { getOctokit } = require('@actions/github');
+            // NOTE: github-script already provides `getOctokit` in scope — do NOT
+            // redeclare it (const { getOctokit } = require(...) throws "already
+            // been declared"). Use the ambient one.
             const adminToken = process.env.ADMIN_TOKEN || '';
             const botToken = process.env.BOT_TOKEN || '';
             const adminClient = adminToken ? getOctokit(adminToken) : github;

--- a/.github/workflows/auto-approve-clean-prs.yml
+++ b/.github/workflows/auto-approve-clean-prs.yml
@@ -8,6 +8,12 @@
 #      label AND Bito review labels — too narrow, caused PRs to sit in limbo.
 # What: Triggers on check_suite completion, verifies all required checks pass,
 #       then auto-approves if the PR author is trusted.
+# Fix (2026-06-30): the approval is submitted from an identity DIFFERENT from the
+#       PR author. The org owner (midnghtsapphire) is a trusted author, and the
+#       ADMIN_GITHUB_TOKEN PAT is that same account — so approving owner-authored
+#       PRs with the PAT silently failed ("Can not approve your own pull request")
+#       and the job went green without ever approving. Owner PRs are now approved
+#       as github-actions[bot] (the free github.token); other authors keep the PAT.
 # ═══════════════════════════════════════════════════════════════════════════════
 
 name: Auto-Approve Clean PRs
@@ -42,10 +48,31 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/github-script@v9.0.0
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          BOT_TOKEN: ${{ github.token }}
         with:
           github-token: ${{ secrets.ADMIN_GITHUB_TOKEN || github.token }}
           script: |
             const { owner, repo } = context.repo;
+
+            // GitHub forbids approving your OWN PR. The org owner (midnghtsapphire)
+            // is a trusted author AND owns the ADMIN PAT, so approving owner PRs with
+            // the PAT silently fails. Approve from a DIFFERENT identity than the
+            // author: github-actions[bot] (free github.token) for owner-authored PRs,
+            // the admin PAT for everyone else (and for bot-authored PRs).
+            const { getOctokit } = require('@actions/github');
+            const adminToken = process.env.ADMIN_TOKEN || '';
+            const botToken = process.env.BOT_TOKEN || '';
+            const adminClient = adminToken ? getOctokit(adminToken) : github;
+            const botClient = botToken ? getOctokit(botToken) : github;
+            const ADMIN_OWNER = 'midnghtsapphire'; // the account the ADMIN PAT belongs to
+            function approverFor(author) {
+              const a = (author || '').toLowerCase();
+              if (a === 'github-actions[bot]') return { client: adminClient, who: 'admin-pat' };
+              if (a === ADMIN_OWNER.toLowerCase() || !adminToken) return { client: botClient, who: 'github-actions[bot]' };
+              return { client: adminClient, who: 'admin-pat' };
+            }
 
             // Trusted authors: bots and org owner
             const TRUSTED_AUTHORS = [
@@ -157,14 +184,16 @@ jobs:
                   continue;
                 }
 
-                // All checks pass, author is trusted — submit APPROVE
-                await github.rest.pulls.createReview({
+                // All checks pass, author is trusted — submit APPROVE from a
+                // non-author identity so GitHub accepts it (not a silent self-approve).
+                const { client: approver, who } = approverFor(author);
+                await approver.rest.pulls.createReview({
                   owner, repo, pull_number: prNumber,
                   event: 'APPROVE',
-                  body: `🤖 **Auto-Approved** — All CI checks pass and author (${author}) is trusted. Lifecycle automation will handle merge progression.`,
+                  body: `🤖 **Auto-Approved** (by ${who}) — All CI checks pass and author (${author}) is trusted. Lifecycle automation will handle merge progression.`,
                 });
 
-                core.info(`✅ Submitted APPROVE review on PR #${prNumber} (author: ${author})`);
+                core.info(`✅ Submitted APPROVE review on PR #${prNumber} (author: ${author}, approver: ${who})`);
 
                 // Remove stuck/waiting labels if present
                 const CLEANUP_LABELS = ['scaffolding-detected', 'needs-completion', 'lifecycle:stuck', 'status:waiting-for-review', 'awaiting-review'];


### PR DESCRIPTION
## Summary

Fixes why clean PRs sit at **"awaiting-review"** forever and never auto-merge. `auto-approve-clean-prs.yml` submits its APPROVE using `ADMIN_GITHUB_TOKEN` — which is the org owner's (`midnghtsapphire`) PAT. But `midnghtsapphire` is *also* a trusted **author**, and GitHub forbids approving your own PR. So for every owner-authored PR the approve call threw *"Can not approve your own pull request"*, the `catch` logged it as a `core.warning`, and the job still reported **success** — a green "Auto-approve" check with **no actual approval**. With no approving review, branch protection stays blocked and auto-merge can't fire.

Verified on #14868: every review is `COMMENTED`, none `APPROVED`.

No associated issue.

## Changes

- `.github/workflows/auto-approve-clean-prs.yml` — submit the APPROVE from an identity **different from the PR author**: `github-actions[bot]` (the free `github.token`) for owner-authored PRs, the admin PAT for everyone else (and for bot-authored PRs, which the PAT can legitimately approve). Adds an `approverFor(author)` selector and `BOT_TOKEN` / `ADMIN_TOKEN` step env. Everything else (trusted-author gate, CI-pass check, label cleanup) is unchanged.

## Validation

Workflow YAML parses (`yaml.safe_load`); the embedded github-script body passes `node --check` when wrapped in its async harness. This is a logic fix to a workflow (no unit tests apply).

**Bootstrap note:** this PR is itself authored by `midnghtsapphire`, so it hits the very bug it fixes — it needs a one-time manual merge (admin-merge). Once merged, the next `check_suite` completion (or a `workflow_dispatch` with a PR number) will auto-approve clean owner PRs as `github-actions[bot]`, and the rest flow hands-off.

**Branch-protection dependency:** a `github-actions[bot]` approving review counts toward a *numeric* required-approvals rule. If "Require review from Code Owners" is enabled, a codeowner/human approval is still required — in that case lower the requirement or add the bot as an allowed reviewer for true hands-off merge.

docs-freshness: bugfix to an existing workflow's approval identity — no new tool or behavior to document.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — N/A, no associated issue
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`fix:`)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)