### PR TITLE
fix: post-merge review findings from #15497 (static require + 3 Copilot comments)

### DIFF
--- a/.github/workflows/weekly-research.yml
+++ b/.github/workflows/weekly-research.yml
@@ -55,9 +55,9 @@ jobs:
             const rawIssueType = issue.type || context.payload.issue?.type;
             const issueType = typeof rawIssueType === 'string' ? rawIssueType : (rawIssueType?.name || '');
             const normalizedIssueType = issueType.trim().toLowerCase();
-            const hasRouteTags =
-              title.toLowerCase().includes('#app') ||
-              title.toLowerCase().includes('#tools');
+            // Word-boundary match (Copilot post-merge finding on #15497):
+            // bare includes('#app') false-positived on #application/#tooling.
+            const hasRouteTags = /(?:^|[^a-z0-9])#(?:app|apps|tool|tools)\b/i.test(title);
             const hasSourceUrl =
               body.includes('https://') ||
               body.includes('http://');

--- a/agent-creator.html
+++ b/agent-creator.html
@@ -759,10 +759,15 @@ function copyText(text) {
 function copyTextFallback(text) {
   const ta = document.createElement("textarea");
   ta.value = text;
+  // readonly + focus before select: Safari/iOS won't copy from an
+  // unfocused (or keyboard-summoning) element (Copilot review finding).
+  ta.setAttribute("readonly", "");
   ta.style.position = "fixed";
   ta.style.opacity = "0";
   document.body.appendChild(ta);
+  ta.focus();
   ta.select();
+  ta.setSelectionRange(0, ta.value.length);
   let ok = false;
   try { ok = document.execCommand("copy"); } catch (_) { ok = false; }
   ta.remove();

--- a/agent-creator.html
+++ b/agent-creator.html
@@ -747,12 +747,34 @@ $("reset").addEventListener("click", () => {
   for (const id of ["need", "raw", "aname"]) $(id).value = "";
   for (const id of ["qcard", "matchcard", "fleetcard", "gapcard", "outcard"]) $(id).style.display = "none";
 });
+// Clipboard API is unavailable/denied in non-secure contexts (notably
+// file://, which this page explicitly supports) — fall back to a hidden
+// textarea + execCommand, and never leave a rejection unhandled.
+function copyText(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    return navigator.clipboard.writeText(text).then(() => true).catch(() => copyTextFallback(text));
+  }
+  return Promise.resolve(copyTextFallback(text));
+}
+function copyTextFallback(text) {
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
+  document.body.appendChild(ta);
+  ta.select();
+  let ok = false;
+  try { ok = document.execCommand("copy"); } catch (_) { ok = false; }
+  ta.remove();
+  return ok;
+}
 document.querySelectorAll("[data-copy]").forEach((btn) => {
   btn.addEventListener("click", () => {
     const map = { prompt: "out-prompt", skill: "out-skill", wr: "out-wr", fleet: "out-fleet" };
-    navigator.clipboard.writeText($(map[btn.dataset.copy]).textContent).then(() => {
-      const t = btn.textContent; btn.textContent = "Copied ✓";
-      setTimeout(() => { btn.textContent = t; }, 1200);
+    copyText($(map[btn.dataset.copy]).textContent).then((ok) => {
+      const t = btn.textContent;
+      btn.textContent = ok ? "Copied ✓" : "Select & copy manually";
+      setTimeout(() => { btn.textContent = t; }, 1600);
     });
   });
 });

--- a/scripts/build-agent-creator-data.js
+++ b/scripts/build-agent-creator-data.js
@@ -62,7 +62,9 @@ function buildData() {
   const promptTemplates = Object.keys(promptsDoc.prompts || {});
   const labelTriggers = promptsDoc.label_triggers || {};
 
-  const { PERSONA_REGISTRY } = require(path.join(ROOT, SOURCES.personas));
+  // Static require (reviewer-fleet finding: no dynamic require paths);
+  // SOURCES.personas stays the documented source-of-truth pointer.
+  const { PERSONA_REGISTRY } = require("./openrouter-personas.js");
   const personas = Object.values(PERSONA_REGISTRY).map((p) => ({
     handle: p.handle,
     name: p.name,

--- a/scripts/openrouter-personas.js
+++ b/scripts/openrouter-personas.js
@@ -550,7 +550,11 @@ try {
       instructions: [
         `You are ${member.name} (@${member.handle}), the fleet's ${member.pattern} expert.`,
         `Your ONE job: ${member.job}`,
-        `Scope: ${fleetDef.initial_scope}. Refuse work outside your pattern \u2014 hand it to @conductor for re-delegation.`,
+        // The conductor IS the delegation point — telling it to hand off to
+        // itself would undermine the one-job guardrail (Copilot finding).
+        member.handle === "conductor"
+          ? `Scope: ${fleetDef.initial_scope}. You are the fleet's entry point: decompose incoming work and delegate each piece to the right pattern expert; never do their jobs yourself.`
+          : `Scope: ${fleetDef.initial_scope}. Refuse work outside your pattern \u2014 hand it to @conductor for re-delegation.`,
         `Operating rules: ${charterRules.join("; ")}.`,
       ].join(" "),
       readinessPrompt: `Report online as ${member.name}. In two sentences, confirm you are ready and name the one ${member.pattern} job you do.`,


### PR DESCRIPTION
## Summary

Follow-up to the merged #15497, addressing the review findings that landed after (or seconds before) the merge: the reviewer-fleet's dynamic-require flag plus the three Copilot inline comments the owner surfaced post-merge.

## Changes

- `scripts/build-agent-creator-data.js` — dynamic `require(path.join(...))` → static `require("./openrouter-personas.js")` (reviewer-fleet checklist finding).
- `.github/workflows/weekly-research.yml` — `hasRouteTags` used bare `includes('#app')`/`includes('#tools')`, which false-positived on `#application`/`#tooling` and could route non-WR issues with a URL body into the WR pipeline; now a word-boundary regex (Copilot, Medium).
- `scripts/openrouter-personas.js` — the derived `@conductor` persona was told to hand out-of-scope work to `@conductor` (itself); the conductor now gets entry-point instructions (decompose and delegate, never do member jobs) while other fleet members still defer to `@conductor` (Copilot, Low).
- `agent-creator.html` — copy buttons called `navigator.clipboard.writeText` with no fallback or `.catch`; clipboard is unavailable in non-secure contexts (notably `file://`, which the page explicitly supports). Added secure-context check, textarea/`execCommand` fallback, and honest "Select & copy manually" feedback (Copilot, Medium).
- `agent-creator-data.{json,js}` — regenerated (conductor instruction change flows into the catalog).

## Validation

Full suite 403 pass / 0 fail; `yaml.safe_load` on the touched workflow; conductor/member instructions verified via `getPersona()` (conductor no longer self-references, members still defer); clipboard flow driven on `file://` in headless Chromium — "Copied ✓", zero console errors.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge *(no issue — post-merge review follow-up)*
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKq3TswuUcHPnD3gPfF3jc