### PR TITLE
fix: fail closed on fleet WR lookup errors

### DIFF
--- a/SYSTEM_STATE.md
+++ b/SYSTEM_STATE.md
@@ -51,6 +51,7 @@
 | BUG-015 | Affiliate Hub regressed below patched Next.js/PostCSS dependency floor (`next` 15.5.15, `eslint-config-next` 14.2.3, nested PostCSS 8.4.x) | high | resolved | 2026-05-16 |
 | BUG-016 | BASIC WR / issue-type intake could miss required WR labels, causing `wr-pr-creation.yml` to skip instead of creating a PR | high | resolved | 2026-05-17 |
 | BUG-017 | Root workflow validation failed on malformed `ship-status-audit.yml` markdown template literal indentation and duplicate `script` keys in `ship-to-market.yml` | medium | resolved | 2026-05-19 |
+| BUG-018 | Fleet maintenance treated failed open-WR lookup as no open WR, risking duplicate `[WR]` issues | high | resolved | 2026-07-09 |
 
 ---
 
@@ -107,6 +108,7 @@
 | Creator Payout Tracker product | 2026-05-21 | ✅ `npm run test`, `npm run lint`, `npm run build`, and `npm audit --audit-level=high` pass in `products/creator-payout-tracker` | Verifies payout recommendation engine, Markdown/CSV report export, `/api/report`, TypeScript, and production build. npm audit still reports a moderate nested Next/PostCSS advisory with no stable non-breaking fix. |
 | WR issue template / BASIC WR regression test | 2026-05-17 | ✅ `node tests/work-request-form-sync.test.js` verifies template label sync, portable template sync, and BASIC WR workflow detection | — |
 | Perplexity no-key integration | 2026-05-17 | ✅ `node tests/perplexity-research-issue.test.js`, `npm run workflows:validate`, and `npm test` pass after `npm ci` | Verifies the fork-backed research script, no required `PERPLEXITY_API_KEY`, workflow install path, Credential Gatekeeper omission, and MCP registration |
+| Fleet Maintenance WR dedupe | 2026-07-09 | ✅ `node tests/fleet-maintenance.test.js` and `npm test` pass | Verifies open-WR lookup success, empty results, `gh` failure, malformed JSON, and no issue creation after failed lookup |
 | PromptForge app validation | 2026-05-17 | ✅ `node tests/prompt-generation-app.test.js`; `npm run lint`; `npm run build` in `products/prompt-generation-app` | — |
 | Research Engine unit test | 2026-05-17 | ✅ `node tests/research-engine.test.js` verified lane coverage, OpenRouter triangulation, missing-key packets, and offline mocked execution | — |
 | Workflow YAML validation | 2026-05-17 | ✅ `node tests/workflow-yaml-validation.test.js` compiles key WR github-script blocks; `npm run workflows:validate` reports 120 valid workflows, 0 invalid, 0 missing timeouts | — |
@@ -169,6 +171,10 @@ Until populated, the workflows fail loudly on every new issue (intentional — s
 ## Last Updated
 
 ```
+Last updated: 2026-07-09 03:03 UTC
+Updated by: Cursor
+Session summary: Fixed fleet maintenance WR dedupe to fail closed on `gh issue list` and JSON parse errors, with regression tests proving duplicate WR creation is blocked.
+
 Last updated: 2026-05-19 05:34 UTC
 Updated by: Cursor
 Session summary: Added green website reporting workflow/template/standard with README carbon marker support, fixed workflow YAML blockers in ship-status/ship-to-market, and verified focused green tests, workflow validation, Automation Doctor, and full root npm test pass.

--- a/learnings.md
+++ b/learnings.md
@@ -34,6 +34,20 @@ This file tracks autonomous executions, failures, root causes, and locked-in sol
 
 ---
 
+**Date/Time:** 2026-07-09T03:03:00Z
+
+**Task Attempted:** Fix fleet maintenance duplicate Work Request risk when open-issue lookup fails
+
+**Outcome:** Success - `hasOpenWorkRequest` now fails closed on `gh issue list` errors, auth/rate-limit failures, malformed JSON, and non-array payloads; regression tests verify `fileWorkRequest` does not create a new `[WR]` after lookup failure.
+
+**Root Cause of Failure (If any):** The open-WR preflight caught every `gh` or JSON parsing error and returned `false`, making an untrusted lookup indistinguishable from a confirmed empty result.
+
+**Self-Healing Fix / Learned Lesson:** Deduplication preflights must fail closed. If the script cannot prove the target repo has no open marker issue, it must throw a contextual error and skip creation instead of opening another automation issue.
+
+**Next Action:** None - Work complete.
+
+---
+
 **Date/Time:** 2026-05-01T19:37:00Z
 
 **Task Attempted:** Fix recurring `oAudrey retro` issues reporting HTTP 000 for `oaudrey.com` and `fieldwork.oaudrey.com`

--- a/scripts/fleet-maintenance.js
+++ b/scripts/fleet-maintenance.js
@@ -83,20 +83,28 @@ function marker(owner, repo) {
   return `fleet-maintenance:${owner}/${repo}`;
 }
 
-function hasOpenWorkRequest(centralRepo, owner, repo) {
+function hasOpenWorkRequest(centralRepo, owner, repo, ghRunner = gh) {
+  const searchMarker = marker(owner, repo);
   try {
-    const raw = gh([
+    const raw = ghRunner([
       "issue", "list", "--repo", centralRepo,
-      "--state", "open", "--search", marker(owner, repo), "--json", "number",
+      "--state", "open", "--search", searchMarker, "--json", "number",
     ]);
-    return JSON.parse(raw || "[]").length > 0;
-  } catch {
-    return false;
+    const issues = JSON.parse(raw || "[]");
+    if (!Array.isArray(issues)) {
+      throw new Error(`expected an array, got ${typeof issues}`);
+    }
+    return issues.length > 0;
+  } catch (err) {
+    throw new Error(
+      `Unable to verify open fleet Work Requests for ${owner}/${repo} in ${centralRepo} ` +
+      `(${searchMarker}); refusing to file a duplicate. ${err.message}`
+    );
   }
 }
 
-function fileWorkRequest(centralRepo, owner, repo, dryRun) {
-  if (hasOpenWorkRequest(centralRepo, owner, repo)) {
+function fileWorkRequest(centralRepo, owner, repo, dryRun, ghRunner = gh) {
+  if (hasOpenWorkRequest(centralRepo, owner, repo, ghRunner)) {
     console.log(`• ${repo}: open fleet Work Request already exists — skipping.`);
     return false;
   }
@@ -129,7 +137,7 @@ function fileWorkRequest(centralRepo, owner, repo, dryRun) {
 
   const tmp = `/tmp/fleet-wr-${repo}.md`;
   fs.writeFileSync(tmp, body);
-  const out = gh([
+  const out = ghRunner([
     "issue", "create", "--repo", centralRepo,
     "--title", title, "--body-file", tmp,
     "--label", "work-request", "--label", "openrouter",
@@ -180,4 +188,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { selectRepos, isoWeek };
+module.exports = { selectRepos, isoWeek, hasOpenWorkRequest, fileWorkRequest, marker };

--- a/tests/fleet-maintenance.test.js
+++ b/tests/fleet-maintenance.test.js
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 "use strict";
 
-/** Unit tests for scripts/fleet-maintenance.js — pure selection/rotation logic. */
+/** Unit tests for scripts/fleet-maintenance.js. */
 
 const assert = require("assert");
-const { selectRepos, isoWeek } = require("../scripts/fleet-maintenance");
+const {
+  fileWorkRequest,
+  hasOpenWorkRequest,
+  isoWeek,
+  selectRepos,
+} = require("../scripts/fleet-maintenance");
 
 let passed = 0;
 let failed = 0;
@@ -39,6 +44,52 @@ test("rotates across weeks to cover the fleet", () => {
 test("isoWeek returns a sane week number", () => {
   const w = isoWeek(new Date("2026-05-23T00:00:00Z"));
   assert.ok(w >= 1 && w <= 53, `got ${w}`);
+});
+
+test("hasOpenWorkRequest returns true when a matching open WR exists", () => {
+  const found = hasOpenWorkRequest("midnghtsapphire/revvel-standards", "midnghtsapphire", "target", () => (
+    JSON.stringify([{ number: 123 }])
+  ));
+
+  assert.strictEqual(found, true);
+});
+
+test("hasOpenWorkRequest returns false when no matching open WR exists", () => {
+  const found = hasOpenWorkRequest("midnghtsapphire/revvel-standards", "midnghtsapphire", "target", () => "[]");
+
+  assert.strictEqual(found, false);
+});
+
+test("hasOpenWorkRequest fails closed when gh issue list fails", () => {
+  assert.throws(
+    () => hasOpenWorkRequest("midnghtsapphire/revvel-standards", "midnghtsapphire", "target", () => {
+      throw new Error("gh auth failed");
+    }),
+    /refusing to file a duplicate.*gh auth failed/
+  );
+});
+
+test("hasOpenWorkRequest fails closed when gh returns malformed JSON", () => {
+  assert.throws(
+    () => hasOpenWorkRequest("midnghtsapphire/revvel-standards", "midnghtsapphire", "target", () => "{"),
+    /refusing to file a duplicate/
+  );
+});
+
+test("fileWorkRequest does not create an issue when open-WR lookup fails", () => {
+  const calls = [];
+
+  assert.throws(
+    () => fileWorkRequest("midnghtsapphire/revvel-standards", "midnghtsapphire", "target", false, (args) => {
+      calls.push(args);
+      if (args[1] === "list") throw new Error("rate limit exceeded");
+      if (args[1] === "create") return "https://github.com/example/issues/1\n";
+      throw new Error(`unexpected gh call: ${args.join(" ")}`);
+    }),
+    /refusing to file a duplicate.*rate limit exceeded/
+  );
+
+  assert.strictEqual(calls.some((args) => args[1] === "create"), false);
 });
 
 console.log(`\nTest Summary: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the fleet maintenance WR dedupe preflight so GitHub CLI/list/parse failures do not look like an empty open-WR result.
Closes #

## Changes

- Make `hasOpenWorkRequest` throw a contextual fail-closed error when `gh issue list` fails, returns malformed JSON, or returns a non-array payload.
- Pass an injectable `ghRunner` through the lookup and issue-create path so regression tests can prove failed preflight does not create another WR.
- Add focused regression coverage for open WR detection, empty results, command failures, malformed JSON, and no-create-on-lookup-failure behavior.
- Record the resolved bug and validation evidence in `SYSTEM_STATE.md` and `learnings.md`.

## Validation

- `node tests/fleet-maintenance.test.js` passed with 10 focused checks.
- `npm test` passed with 403 root tests and the shell formatter test.
- `npx markdownlint-cli2 SYSTEM_STATE.md learnings.md` passed with 0 Markdown errors.
- Repo-level code-review MCP was checked but no `code-review` tool is exposed in this Cursor Cloud environment.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cd9e66d-271a-460b-badf-9438147cd9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cd9e66d-271a-460b-badf-9438147cd9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves error handling in the fleet maintenance work request deduplication logic by implementing a **fail-closed** approach. Previously, when GitHub CLI commands failed or returned malformed data during the open work request lookup, the system would silently treat it as "no open work requests exist" and potentially create duplicates. Now, the `hasOpenWorkRequest` function throws a descriptive error instead, preventing duplicate work request creation when the lookup fails. The change includes making the GitHub CLI runner injectable for testing purposes and adds comprehensive test coverage for various failure scenarios including command failures, malformed JSON, and non-array responses.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tests/fleet-maintenance.test.js` |
| 2 | `scripts/fleet-maintenance.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed on fleet maintenance Work Request lookup errors to prevent duplicate WR creation. Adds an injectable `ghRunner` and tests to ensure no issue is created when lookup fails.

- **Bug Fixes**
  - `hasOpenWorkRequest` now throws a clear error when `gh issue list` fails, returns malformed JSON, or a non-array payload.
  - `fileWorkRequest` accepts an injected `ghRunner` and does not create issues when lookup fails.
  - Added focused tests for open-WR detection, empty results, command failures, malformed JSON, and no-create-on-failure; exported `hasOpenWorkRequest`, `fileWorkRequest`, and `marker`.

<sup>Written for commit 4107ecbfeceb5191c41a254415e5f2fcf15007a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

