### PR TITLE
feat(vine-marketplace): CSV + ASIN product links via vine-parser

### DIFF
--- a/reesereviews/vine-marketplace/README.md
+++ b/reesereviews/vine-marketplace/README.md
@@ -1,18 +1,25 @@
 # Vine → Marketplace
 
-Automated pipeline that reads **Amazon Vine** and paid order emails from `angelreporters@gmail.com`, extracts product data, and posts listings to **Facebook Marketplace** (via Meta Graph API) at **20% below your cost basis**.
+Automated pipeline that reads **Amazon Vine** and paid order emails (or **order history CSV**), extracts product data using **`lib/amazon-parser.js`**, builds **Amazon product links from ASIN** (no personal photos required), and prepares listing packs / optional Facebook Marketplace posts at **20% below your cost basis**.
+
+**Spine:** vine parse shape — every item is `{ orderId, asin, productTitle, imageUrl, productUrl, … }` whether it came from email or CSV.
 
 ## Features
 
 | Feature | Detail |
 |---|---|
 | 📬 Email ingestion | IMAP reader pulls Amazon shipped/delivered/Vine emails |
+| 📄 CSV import | Amazon order history CSV → same product records as email parse |
+| 🔗 Product links | ASIN → `https://www.amazon.com/dp/{ASIN}` (owner does not upload photos) |
+| 🖼 Image enrich | Prefer email CDN image; optional fetch of product-page gallery |
+| ▶ One-at-a-time | `GET /api/queue/next` for sequential review |
+| 📋 Listing pack | Title, description, 3–5 images, price — human posts to Marketplace |
 | 🔍 Smart parsing | Extracts product name, ASIN, price paid, Vine FMV, images |
 | 💲 Auto-pricing | 20% off cost basis; Vine items use 1099 FMV as cost |
-| 🚀 FB Marketplace | Posts via Meta Graph API (Page Post or Commerce Catalog) |
+| 🚀 FB Marketplace | Optional Meta Graph API (Page Post or Commerce Catalog) |
 | 📦 Inventory tracking | JSON file tracks all products, listing status, sold status |
 | 🔄 Repost scheduler | Auto-refreshes stale listings after N days |
-| 📊 Dashboard UI | Glassmorphism dark UI — date range, queue review, mark sold |
+| 📊 Dashboard UI | Glassmorphism dark UI — CSV upload, queue, date range, mark sold |
 | ⏰ Cron automation | Runs silently 3× daily; repost check every Monday |
 
 ---
@@ -48,6 +55,9 @@ npm start
 # Fetch and ingest Amazon emails
 node index.js fetch
 
+# Import Amazon order history CSV (Account → order reports — human download)
+node index.js import-csv ./orders.csv
+
 # Post all unlisted products to Facebook (add --dry-run to preview)
 node index.js post
 node index.js post --dry-run
@@ -58,6 +68,27 @@ node index.js repost
 # Print inventory summary
 node index.js summary
 ```
+
+### 5. CSV / queue API (no personal photos)
+
+```bash
+# Import CSV (JSON body)
+curl -s -X POST http://localhost:3030/api/import/csv \
+  -H "Content-Type: application/json" \
+  -d "{\"csv\": \"$(cat orders.csv | sed 's/\"/\\\"/g')\"}"
+
+# Next unlisted item + try to pull product images from Amazon page
+curl -s "http://localhost:3030/api/queue/next?enrich=1" | jq .
+
+# Listing pack for copy-paste to Marketplace
+curl -s "http://localhost:3030/api/products/ORDER-ID/listing-pack" | jq .
+```
+
+### 6. Vercel
+
+Root directory for deploy: `reesereviews/vine-marketplace`  
+Entry: `api/index.js` + `vercel.json`. Inventory on serverless uses `/tmp` (ephemeral unless you add a DB later).
+
 
 ---
 

--- a/reesereviews/vine-marketplace/api/index.js
+++ b/reesereviews/vine-marketplace/api/index.js
@@ -1,0 +1,16 @@
+/**
+ * Vercel serverless entry — reuses the Express app from index.js
+ * without starting cron/listen (CLI server mode only when run as main).
+ */
+'use strict';
+
+// Load env if present (no-op on Vercel when vars are set in project settings)
+try {
+  require('dotenv').config();
+} catch {
+  // optional
+}
+
+const { app } = require('../index.js');
+
+module.exports = app;

--- a/reesereviews/vine-marketplace/index.js
+++ b/reesereviews/vine-marketplace/index.js
@@ -18,9 +18,11 @@ const cron = require('node-cron');
 const path = require('path');
 
 const { fetchEmails, filterAmazonEmails } = require('./lib/gmail-reader');
-const { parseAmazonEmail } = require('./lib/amazon-parser');
+const { parseAmazonEmail, attachProductLink } = require('./lib/amazon-parser');
 const { calculateListingPrice, formatUSD } = require('./lib/price-calculator');
 const { postProduct, repostProduct } = require('./lib/facebook-poster');
+const { importOrderCsv } = require('./lib/csv-import');
+const { enrichProduct, buildListingPack } = require('./lib/product-link');
 const inventory = require('./lib/inventory');
 const rfy = require('./lib/rfy-tracker');
 
@@ -137,7 +139,8 @@ async function repostStale({ dryRun = false } = {}) {
 // ─────────────────────────────────────────────
 
 const app = express();
-app.use(express.json());
+app.use(express.json({ limit: '8mb' }));
+app.use(express.text({ type: ['text/csv', 'text/plain'], limit: '8mb' }));
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Health check
@@ -190,6 +193,93 @@ app.post('/api/fetch', async (req, res) => {
       before: before ? new Date(before) : null,
     });
     res.json({ ingested: products.length, products });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ── CSV import (Amazon order history) → same product shape as vine parse ──
+// Body: raw CSV text (Content-Type: text/csv) OR JSON { csv: "..." }
+app.post('/api/import/csv', (req, res) => {
+  try {
+    const csvText =
+      typeof req.body === 'string'
+        ? req.body
+        : req.body && req.body.csv != null
+          ? req.body.csv
+          : '';
+    if (!csvText || !String(csvText).trim()) {
+      return res.status(400).json({ error: 'Provide CSV as text body or JSON { csv: "..." }' });
+    }
+    const result = importOrderCsv(csvText);
+    const stored = [];
+    for (const p of result.products) {
+      inventory.upsert(p);
+      stored.push(p);
+    }
+    res.json({
+      ingested: stored.length,
+      skipped: result.skipped,
+      errors: result.errors,
+      headers: result.headers,
+      products: stored,
+      note: 'ASIN → productUrl attached. Run enrich for product-page images. No personal photos required.',
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// One-at-a-time queue: next unlisted product (optional enrich)
+app.get('/api/queue/next', async (req, res) => {
+  try {
+    const doEnrich = req.query.enrich === '1' || req.query.enrich === 'true';
+    const unlisted = inventory.getUnlisted();
+    if (unlisted.length === 0) {
+      return res.json({ product: null, remaining: 0 });
+    }
+    let product = attachProductLink(unlisted[0]);
+    let enrichMeta = null;
+    if (doEnrich) {
+      const r = await enrichProduct(product, { fetchImages: true });
+      product = r.product;
+      inventory.upsert(product);
+      enrichMeta = { reason: r.reason, fetchError: r.fetchError || null, imageCount: (r.imageUrls || []).length };
+    }
+    res.json({
+      product,
+      remaining: unlisted.length,
+      enrich: enrichMeta,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Enrich one product: productUrl + images from Amazon product page (when fetchable)
+app.post('/api/products/:orderId/enrich', async (req, res) => {
+  try {
+    const existing = inventory.getByOrderId(req.params.orderId);
+    if (!existing) return res.status(404).json({ error: 'Not found' });
+    const r = await enrichProduct(existing, {
+      fetchImages: req.body?.fetchImages !== false,
+    });
+    inventory.upsert(r.product);
+    res.json(r);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Listing pack for marketplace copy-paste (human posts)
+app.get('/api/products/:orderId/listing-pack', (req, res) => {
+  try {
+    const existing = inventory.getByOrderId(req.params.orderId);
+    if (!existing) return res.status(404).json({ error: 'Not found' });
+    const product = attachProductLink(existing);
+    const pricing = calculateListingPrice(product);
+    const pack = buildListingPack(product, pricing);
+    res.json(pack);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -362,36 +452,70 @@ function startScheduler() {
 }
 
 // ─────────────────────────────────────────────
-//  CLI entry point
+//  CLI / local server entry (not when required by Vercel)
 // ─────────────────────────────────────────────
 
-const CLI_COMMAND = process.argv[2];
+function main() {
+  const CLI_COMMAND = process.argv[2];
 
-if (CLI_COMMAND === 'fetch') {
-  fetchAndIngest()
-    .then((p) => { console.log(`Ingested ${p.length} products.`); process.exit(0); })
-    .catch((err) => { console.error(err.message); process.exit(1); });
-} else if (CLI_COMMAND === 'post') {
-  postUnlisted({ dryRun: process.argv[3] === '--dry-run' })
-    .then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(0); })
-    .catch((err) => { console.error(err.message); process.exit(1); });
-} else if (CLI_COMMAND === 'repost') {
-  repostStale({ dryRun: process.argv[3] === '--dry-run' })
-    .then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(0); })
-    .catch((err) => { console.error(err.message); process.exit(1); });
-} else if (CLI_COMMAND === 'summary') {
-  console.log(JSON.stringify(inventory.getSummary(), null, 2));
-  process.exit(0);
-} else if (CLI_COMMAND === 'rfy') {
-  console.log(JSON.stringify(rfy.getSummary(), null, 2));
-  process.exit(0);
-} else {
-  // Server mode
+  if (CLI_COMMAND === 'fetch') {
+    return fetchAndIngest()
+      .then((p) => { console.log(`Ingested ${p.length} products.`); process.exit(0); })
+      .catch((err) => { console.error(err.message); process.exit(1); });
+  }
+  if (CLI_COMMAND === 'post') {
+    return postUnlisted({ dryRun: process.argv[3] === '--dry-run' })
+      .then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(0); })
+      .catch((err) => { console.error(err.message); process.exit(1); });
+  }
+  if (CLI_COMMAND === 'repost') {
+    return repostStale({ dryRun: process.argv[3] === '--dry-run' })
+      .then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(0); })
+      .catch((err) => { console.error(err.message); process.exit(1); });
+  }
+  if (CLI_COMMAND === 'summary') {
+    console.log(JSON.stringify(inventory.getSummary(), null, 2));
+    process.exit(0);
+    return;
+  }
+  if (CLI_COMMAND === 'rfy') {
+    console.log(JSON.stringify(rfy.getSummary(), null, 2));
+    process.exit(0);
+    return;
+  }
+  if (CLI_COMMAND === 'import-csv') {
+    const fs = require('fs');
+    const file = process.argv[3];
+    if (!file) {
+      console.error('Usage: node index.js import-csv <path-to-orders.csv>');
+      process.exit(1);
+      return;
+    }
+    const { importOrderCsv: imp } = require('./lib/csv-import');
+    const result = imp(fs.readFileSync(file, 'utf8'));
+    result.products.forEach((p) => inventory.upsert(p));
+    console.log(JSON.stringify({ ingested: result.products.length, skipped: result.skipped, errors: result.errors }, null, 2));
+    process.exit(0);
+    return;
+  }
+
+  // Local server mode
   app.listen(PORT, () => {
     console.log(`\n🛒  Vine → Marketplace Dashboard`);
-    console.log(`   http://localhost:${PORT}\n`);
+    console.log(`   http://localhost:${PORT}`);
+    console.log(`   CSV: POST /api/import/csv  |  Next: GET /api/queue/next?enrich=1\n`);
     startScheduler();
   });
 }
 
-module.exports = { fetchAndIngest, listProduct, postUnlisted, repostStale };
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  app,
+  fetchAndIngest,
+  listProduct,
+  postUnlisted,
+  repostStale,
+};

--- a/reesereviews/vine-marketplace/lib/amazon-parser.js
+++ b/reesereviews/vine-marketplace/lib/amazon-parser.js
@@ -9,9 +9,42 @@
  *   2. "Your order has been delivered" — marks item as received
  *   3. "Amazon Vine — Your product has arrived" — marks as Vine + captures FMV if present
  *   4. "Amazon Vine — Product Received" — alternate Vine confirmation template
+ *
+ * Shared product identity (also used by CSV import):
+ *   ASIN → productUrl = https://www.amazon.com/dp/{ASIN}
+ *   imageUrl from email/Amazon CDN when present (owner does not supply photos)
  */
 
 'use strict';
+
+/** Build the canonical Amazon product page URL from an ASIN. */
+function productUrlFromAsin(asin, marketplace = 'www.amazon.com') {
+  if (!asin || typeof asin !== 'string') return null;
+  const clean = asin.trim().toUpperCase();
+  if (!/^[A-Z0-9]{10}$/.test(clean)) return null;
+  const host = marketplace.replace(/^https?:\/\//, '').replace(/\/$/, '') || 'www.amazon.com';
+  return `https://${host}/dp/${clean}`;
+}
+
+/** True when value looks like a 10-char ASIN. */
+function isValidAsin(asin) {
+  return typeof asin === 'string' && /^[A-Z0-9]{10}$/i.test(asin.trim());
+}
+
+/**
+ * Fill productUrl (and keep imageUrl) on any product-shaped record.
+ * Safe to call repeatedly — does not overwrite a non-empty productUrl.
+ */
+function attachProductLink(product, marketplace = 'www.amazon.com') {
+  if (!product || typeof product !== 'object') return product;
+  const asin = product.asin ? String(product.asin).trim().toUpperCase() : null;
+  const url = productUrlFromAsin(asin, marketplace);
+  return {
+    ...product,
+    asin: asin || product.asin || null,
+    productUrl: product.productUrl || url,
+  };
+}
 
 // Regex patterns for extracting data from Amazon email bodies
 const PATTERNS = {
@@ -111,18 +144,22 @@ function parseAmazonEmail(mail) {
   const deliveryDate = deliveryDateStr ? new Date(deliveryDateStr).toISOString() : null;
 
   const isVine = emailType === 'vine';
+  const asinClean = asin ? asin.toUpperCase() : null;
 
-  return {
+  return attachProductLink({
     orderId: orderId || `UNKNOWN-${Date.now()}`,
-    asin: asin || null,
+    asin: asinClean,
     productTitle: productTitle.substring(0, 200),
     paidPrice,
     vineTaxValue,
     isVine,
     imageUrl: imageUrl || null,
+    productUrl: productUrlFromAsin(asinClean),
+    imageUrls: imageUrl ? [imageUrl] : [],
     trackingNumber: tracking || null,
     deliveryDate: deliveryDate || (emailType === 'delivered' ? new Date().toISOString() : null),
     emailType,
+    source: 'email',
     receivedAt: new Date().toISOString(),
     subject,
     // Listing fields populated later
@@ -133,7 +170,14 @@ function parseAmazonEmail(mail) {
     listedAt: null,
     soldAt: null,
     soldPrice: null,
-  };
+  });
 }
 
-module.exports = { parseAmazonEmail, detectEmailType };
+module.exports = {
+  parseAmazonEmail,
+  detectEmailType,
+  productUrlFromAsin,
+  isValidAsin,
+  attachProductLink,
+  PATTERNS,
+};

--- a/reesereviews/vine-marketplace/lib/csv-import.js
+++ b/reesereviews/vine-marketplace/lib/csv-import.js
@@ -1,0 +1,235 @@
+/**
+ * vine-marketplace — Amazon Order History CSV → product records
+ *
+ * Uses the SAME shape as amazon-parser.js so inventory / queue / listing packs
+ * work whether the item came from email or CSV.
+ *
+ * Owner downloads CSV via Amazon Account → Request Your Information / Order History
+ * reports (human step). No Amazon account scraping.
+ *
+ * Product images: not in most CSV exports. After import, use productUrl (ASIN →
+ * /dp/{ASIN}) and enrich for gallery URLs. Owner does not upload personal photos.
+ */
+
+'use strict';
+
+const { productUrlFromAsin, isValidAsin, attachProductLink } = require('./amazon-parser');
+
+/** Normalize header keys: "Order ID" → "order id", "ASIN/ISBN" → "asin/isbn" */
+function normalizeHeader(h) {
+  return String(h || '')
+    .replace(/^\uFEFF/, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[_]+/g, ' ')
+    .replace(/\s+/g, ' ');
+}
+
+/**
+ * Minimal CSV line parser supporting quoted fields.
+ * @returns {string[]}
+ */
+function parseCsvLine(line) {
+  const out = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cur += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      out.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+/**
+ * Parse full CSV text into rows of objects keyed by normalized headers.
+ */
+function parseCsvText(csvText) {
+  const text = String(csvText || '').replace(/^\uFEFF/, '').trim();
+  if (!text) return { headers: [], rows: [] };
+
+  const lines = text.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return { headers: [], rows: [] };
+
+  const headers = parseCsvLine(lines[0]).map(normalizeHeader);
+  const rows = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cells = parseCsvLine(lines[i]);
+    const row = {};
+    headers.forEach((h, idx) => {
+      row[h] = cells[idx] != null ? cells[idx].trim() : '';
+    });
+    rows.push(row);
+  }
+  return { headers, rows };
+}
+
+/** Pick first non-empty value among candidate header names. */
+function pick(row, names) {
+  for (const n of names) {
+    const key = normalizeHeader(n);
+    if (row[key] != null && String(row[key]).trim() !== '') {
+      return String(row[key]).trim();
+    }
+  }
+  // partial contains match
+  for (const n of names) {
+    const want = normalizeHeader(n);
+    for (const [k, v] of Object.entries(row)) {
+      if (k.includes(want) && v != null && String(v).trim() !== '') {
+        return String(v).trim();
+      }
+    }
+  }
+  return '';
+}
+
+function parseMoney(raw) {
+  if (raw == null || raw === '') return 0;
+  const n = parseFloat(String(raw).replace(/[^0-9.-]/g, ''));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function extractAsin(raw) {
+  if (!raw) return null;
+  const s = String(raw).trim();
+  // Full URL → ASIN
+  const fromUrl = s.match(/\/(?:dp|gp\/product|product)\/([A-Z0-9]{10})/i);
+  if (fromUrl) return fromUrl[1].toUpperCase();
+  if (isValidAsin(s)) return s.toUpperCase();
+  // Sometimes "B0XXXXXXX " with trailing junk
+  const m = s.match(/\b([A-Z0-9]{10})\b/i);
+  return m ? m[1].toUpperCase() : null;
+}
+
+/**
+ * Convert one CSV row into a vine-marketplace product record (parser shape).
+ */
+function rowToProduct(row, index = 0) {
+  const orderId =
+    pick(row, ['order id', 'orderid', 'order number', 'order #']) ||
+    `CSV-${Date.now()}-${index}`;
+
+  const asin = extractAsin(
+    pick(row, ['asin', 'asin/isbn', 'asin isbn', 'product asin', 'isbn'])
+  );
+
+  const productTitle =
+    pick(row, ['title', 'product name', 'product title', 'item name', 'description']) ||
+    (asin ? `Amazon product ${asin}` : `CSV item ${index + 1}`);
+
+  const paidPrice = parseMoney(
+    pick(row, [
+      'item total',
+      'total owed',
+      'unit price',
+      'purchase price',
+      'item subtotal',
+      'shipment item subtotal',
+      'price',
+    ])
+  );
+
+  const website = pick(row, ['website', 'site', 'marketplace']) || 'www.amazon.com';
+  const host = website.includes('amazon.')
+    ? website.replace(/^https?:\/\//, '').split('/')[0]
+    : 'www.amazon.com';
+
+  const productUrl =
+    pick(row, ['product url', 'url', 'link', 'product link']) ||
+    productUrlFromAsin(asin, host);
+
+  // CSV rarely includes image URLs; leave empty and enrich from product page later
+  const imageRaw = pick(row, ['image', 'image url', 'imageurl', 'photo']);
+  const imageUrl = imageRaw && /^https?:\/\//i.test(imageRaw) ? imageRaw : null;
+
+  const qty = parseInt(pick(row, ['quantity', 'qty']) || '1', 10) || 1;
+  const orderDate = pick(row, ['order date', 'date', 'purchase date']) || null;
+
+  return attachProductLink({
+    orderId: `${orderId}${qty > 1 && asin ? `-${asin}` : ''}`,
+    asin,
+    productTitle: productTitle.substring(0, 200),
+    paidPrice,
+    vineTaxValue: 0,
+    isVine: false,
+    imageUrl,
+    productUrl: productUrl || productUrlFromAsin(asin, host),
+    imageUrls: imageUrl ? [imageUrl] : [],
+    trackingNumber: pick(row, ['carrier name & tracking number', 'tracking number', 'tracking']) || null,
+    deliveryDate: null,
+    emailType: 'csv',
+    source: 'csv',
+    orderDate,
+    quantity: qty,
+    receivedAt: new Date().toISOString(),
+    subject: `CSV import: ${productTitle.substring(0, 80)}`,
+    listed: false,
+    sold: false,
+    listingId: null,
+    listingPrice: null,
+    listedAt: null,
+    soldAt: null,
+    soldPrice: null,
+  }, host);
+}
+
+/**
+ * Parse Amazon order history CSV text → product records ready for inventory.upsert.
+ *
+ * @param {string} csvText
+ * @returns {{ products: object[], skipped: number, headers: string[], errors: string[] }}
+ */
+function importOrderCsv(csvText) {
+  const { headers, rows } = parseCsvText(csvText);
+  const products = [];
+  const errors = [];
+  let skipped = 0;
+
+  if (rows.length === 0) {
+    return { products: [], skipped: 0, headers, errors: ['CSV has no data rows'] };
+  }
+
+  rows.forEach((row, i) => {
+    try {
+      const product = rowToProduct(row, i);
+      // Skip empty junk rows with no ASIN and generic title
+      if (!product.asin && (!product.productTitle || product.productTitle.startsWith('CSV item'))) {
+        skipped++;
+        return;
+      }
+      products.push(product);
+    } catch (err) {
+      errors.push(`Row ${i + 2}: ${err.message}`);
+      skipped++;
+    }
+  });
+
+  return { products, skipped, headers, errors };
+}
+
+module.exports = {
+  importOrderCsv,
+  parseCsvText,
+  rowToProduct,
+  extractAsin,
+  normalizeHeader,
+};

--- a/reesereviews/vine-marketplace/lib/inventory.js
+++ b/reesereviews/vine-marketplace/lib/inventory.js
@@ -41,7 +41,12 @@ try {
   // rfy-tracker unavailable — RFY stats will be omitted from summary
 }
 
-const DATA_DIR = path.join(__dirname, '..', 'data');
+// On Vercel/serverless, the app filesystem is read-only except /tmp.
+const DATA_DIR =
+  process.env.DATA_DIR ||
+  (process.env.VERCEL || process.env.AWS_LAMBDA_FUNCTION_NAME
+    ? path.join('/tmp', 'vine-marketplace-data')
+    : path.join(__dirname, '..', 'data'));
 const INVENTORY_FILE = path.join(DATA_DIR, 'inventory.json');
 
 // Ensure data directory exists

--- a/reesereviews/vine-marketplace/lib/product-link.js
+++ b/reesereviews/vine-marketplace/lib/product-link.js
@@ -1,0 +1,183 @@
+/**
+ * vine-marketplace — Product link + image enrichment from ASIN
+ *
+ * Owner does not take photos. We always have:
+ *   productUrl = https://www.amazon.com/dp/{ASIN}
+ *
+ * imageUrl may already exist from vine email parse (Amazon CDN in the message).
+ * Optional network enrich tries Open Graph / product page image tags.
+ * If Amazon blocks bots, we still return productUrl so the human can open the page.
+ */
+
+'use strict';
+
+// Prefer global fetch (Node 18+ / Vercel); fall back to node-fetch if present.
+const fetchFn =
+  typeof globalThis.fetch === 'function'
+    ? globalThis.fetch.bind(globalThis)
+    : (...args) => require('node-fetch')(...args);
+const { productUrlFromAsin, isValidAsin, attachProductLink } = require('./amazon-parser');
+
+/**
+ * Collect candidate image URLs from HTML (og:image, product media).
+ * Deterministic, no AI.
+ */
+function extractImageUrlsFromHtml(html, limit = 8) {
+  if (!html || typeof html !== 'string') return [];
+  const found = [];
+  const push = (u) => {
+    if (!u || typeof u !== 'string') return;
+    let url = u.trim().replace(/&amp;/g, '&');
+    if (url.startsWith('//')) url = `https:${url}`;
+    if (!/^https?:\/\//i.test(url)) return;
+    // Prefer Amazon media / product images
+    if (!found.includes(url)) found.push(url);
+  };
+
+  // og:image
+  const ogRe = /property=["']og:image["'][^>]*content=["']([^"']+)["']/gi;
+  const ogRe2 = /content=["']([^"']+)["'][^>]*property=["']og:image["']/gi;
+  let m;
+  while ((m = ogRe.exec(html)) !== null) push(m[1]);
+  while ((m = ogRe2.exec(html)) !== null) push(m[1]);
+
+  // Amazon image CDN patterns in page
+  const cdnRe = /https?:\/\/[^"'\\s]*media-amazon\.com\/images\/I\/[A-Za-z0-9._%-]+\.(?:jpg|jpeg|png|webp)/gi;
+  while ((m = cdnRe.exec(html)) !== null) push(m[0]);
+
+  const sslRe = /https?:\/\/[^"'\\s]*ssl-images-amazon\.com\/images\/I\/[A-Za-z0-9._%-]+\.(?:jpg|jpeg|png|webp)/gi;
+  while ((m = sslRe.exec(html)) !== null) push(m[0]);
+
+  return found.slice(0, limit);
+}
+
+/**
+ * Enrich a product: ensure productUrl; optionally fetch gallery images.
+ *
+ * @param {object} product
+ * @param {{ fetchImages?: boolean, timeoutMs?: number }} opts
+ */
+async function enrichProduct(product, opts = {}) {
+  const fetchImages = opts.fetchImages !== false;
+  const timeoutMs = opts.timeoutMs || 12000;
+
+  let next = attachProductLink({ ...product });
+  if (!next.asin || !isValidAsin(next.asin)) {
+    return {
+      product: next,
+      enriched: false,
+      reason: 'missing_or_invalid_asin',
+      imageUrls: next.imageUrls || (next.imageUrl ? [next.imageUrl] : []),
+    };
+  }
+
+  next.productUrl = next.productUrl || productUrlFromAsin(next.asin);
+  const existing = [];
+  if (next.imageUrl) existing.push(next.imageUrl);
+  if (Array.isArray(next.imageUrls)) {
+    next.imageUrls.forEach((u) => {
+      if (u && !existing.includes(u)) existing.push(u);
+    });
+  }
+
+  if (!fetchImages) {
+    next.imageUrls = existing;
+    return { product: next, enriched: true, reason: 'link_only', imageUrls: existing };
+  }
+
+  let fetched = [];
+  let fetchError = null;
+  try {
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+    const res = await fetchFn(next.productUrl, {
+      redirect: 'follow',
+      signal: controller ? controller.signal : undefined,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept-Language': 'en-US,en;q=0.9',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+    });
+    if (timer) clearTimeout(timer);
+    if (!res.ok) {
+      fetchError = `HTTP ${res.status}`;
+    } else {
+      const html = await res.text();
+      fetched = extractImageUrlsFromHtml(html, 8);
+    }
+  } catch (err) {
+    fetchError = err.message || String(err);
+  }
+
+  const merged = [...existing];
+  fetched.forEach((u) => {
+    if (!merged.includes(u)) merged.push(u);
+  });
+
+  next.imageUrls = merged.slice(0, 8);
+  if (!next.imageUrl && merged[0]) next.imageUrl = merged[0];
+
+  return {
+    product: next,
+    enriched: true,
+    reason: fetchError ? `partial:${fetchError}` : 'ok',
+    imageUrls: next.imageUrls,
+    fetchError,
+  };
+}
+
+/**
+ * Build a marketplace listing pack for one product (human posts; no auto-FB required).
+ */
+function buildListingPack(product, pricing = null) {
+  const p = attachProductLink({ ...product });
+  const images = p.imageUrls && p.imageUrls.length
+    ? p.imageUrls
+    : p.imageUrl
+      ? [p.imageUrl]
+      : [];
+
+  const title = (p.productTitle || 'Item for sale').substring(0, 100);
+  const price = pricing && pricing.listingPrice != null
+    ? pricing.listingPrice
+    : p.listingPrice;
+
+  const description = [
+    p.productTitle || title,
+    '',
+    p.isVine ? 'Source: Amazon Vine (see condition notes).' : 'From my Amazon orders.',
+    p.asin ? `Product reference ASIN: ${p.asin}` : null,
+    p.productUrl ? `Product page: ${p.productUrl}` : null,
+    '',
+    'Condition: See photos / notes. Local pickup or shipping as agreed.',
+    'Message me with questions — thanks for looking!',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return {
+    orderId: p.orderId,
+    asin: p.asin,
+    productUrl: p.productUrl,
+    title,
+    description,
+    suggestedPrice: price,
+    images,
+    imageCount: images.length,
+    // Pick up to 5 for marketplace UIs that want a small set
+    selectedImages: images.slice(0, 5),
+    product: p,
+    builtAt: new Date().toISOString(),
+    note: images.length
+      ? 'Images from Amazon product/email — owner did not upload personal photos.'
+      : 'No images yet — open productUrl and copy images, or re-run enrich.',
+  };
+}
+
+module.exports = {
+  enrichProduct,
+  extractImageUrlsFromHtml,
+  buildListingPack,
+};

--- a/reesereviews/vine-marketplace/public/index.html
+++ b/reesereviews/vine-marketplace/public/index.html
@@ -257,6 +257,39 @@
     <button class="btn btn-primary" onclick="postSelected()" id="btn-post">🚀 Post to Marketplace</button>
   </div>
 
+  <!-- CSV import + one-at-a-time queue (no personal photos — ASIN → Amazon product link/images) -->
+  <div class="card" style="margin-bottom:20px;">
+    <div class="card-header">
+      <div class="card-title">Orders CSV → product links (vine-parser shape)</div>
+      <div style="font-size:12px;color:var(--mist);">No photos from you — ASIN builds amazon.com/dp/… then we pull product images</div>
+    </div>
+    <div style="padding:16px 18px;display:flex;flex-wrap:wrap;gap:14px;align-items:flex-end;">
+      <div class="field" style="flex:1;min-width:220px;">
+        <label>Amazon order history CSV</label>
+        <input type="file" id="csv-file" accept=".csv,text/csv" style="color:var(--mist);font-size:12px;">
+      </div>
+      <button class="btn btn-primary" onclick="importCsv()" id="btn-csv">⬆ Import CSV</button>
+      <button class="btn btn-ghost" onclick="queueNext(true)" id="btn-next">▶ Next item (enrich images)</button>
+      <button class="btn btn-ghost" onclick="queueNext(false)">▶ Next (link only)</button>
+    </div>
+    <div id="queue-panel" style="display:none;padding:0 18px 18px;">
+      <div style="display:flex;gap:16px;flex-wrap:wrap;align-items:flex-start;background:rgba(0,0,0,.25);border-radius:12px;padding:14px;border:1px solid var(--border);">
+        <img id="queue-img" class="thumb" style="width:96px;height:96px;object-fit:contain;background:#fff;border-radius:10px;" alt="">
+        <div style="flex:1;min-width:200px;">
+          <div id="queue-title" style="font-weight:600;margin-bottom:6px;"></div>
+          <div id="queue-meta" style="font-size:12px;color:var(--mist);margin-bottom:8px;"></div>
+          <div id="queue-images" style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px;"></div>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;">
+            <a id="queue-link" class="btn btn-sm btn-ghost" target="_blank" rel="noopener">Open product page</a>
+            <button class="btn btn-sm btn-primary" onclick="showListingPack()">Listing pack (copy)</button>
+            <button class="btn btn-sm btn-success" onclick="enrichCurrent()">Re-fetch images</button>
+          </div>
+          <pre id="queue-pack" style="display:none;margin-top:12px;font-size:11px;white-space:pre-wrap;color:var(--mist);max-height:220px;overflow:auto;"></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Log pane -->
   <div id="log-pane"></div>
 
@@ -508,6 +541,147 @@ async function fetchEmails() {
     toast('Fetch failed: ' + e.message);
   } finally {
     btn.disabled = false;
+  }
+}
+
+// ── CSV import + one-at-a-time queue ───────────────────────────────────────
+let currentQueueProduct = null;
+
+async function importCsv() {
+  const input = document.getElementById('csv-file');
+  const btn = document.getElementById('btn-csv');
+  if (!input.files || !input.files[0]) {
+    toast('Choose an Amazon orders CSV file first');
+    return;
+  }
+  btn.disabled = true;
+  log('Importing order CSV…', 'log-info');
+  try {
+    const text = await input.files[0].text();
+    const r = await fetch(`${API}/import/csv`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ csv: text }),
+    });
+    const data = await r.json();
+    if (data.error) throw new Error(data.error);
+    log(`✅ CSV ingested ${data.ingested} (skipped ${data.skipped})`, 'log-ok');
+    toast(`Imported ${data.ingested} products from CSV`);
+    await loadSummary();
+    await loadProducts();
+  } catch (e) {
+    log('❌ CSV: ' + e.message, 'log-err');
+    toast('CSV import failed: ' + e.message);
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+function renderQueueProduct(product, remaining, enrichMeta) {
+  currentQueueProduct = product;
+  const panel = document.getElementById('queue-panel');
+  panel.style.display = 'block';
+  document.getElementById('queue-title').textContent = product.productTitle || '(no title)';
+  const bits = [
+    product.asin ? `ASIN ${product.asin}` : 'no ASIN',
+    product.productUrl || '',
+    remaining != null ? `${remaining} left in queue` : '',
+    enrichMeta && enrichMeta.reason ? `enrich: ${enrichMeta.reason}` : '',
+  ].filter(Boolean);
+  document.getElementById('queue-meta').textContent = bits.join(' · ');
+  const img = document.getElementById('queue-img');
+  const imgs = product.imageUrls && product.imageUrls.length
+    ? product.imageUrls
+    : product.imageUrl
+      ? [product.imageUrl]
+      : [];
+  if (imgs[0]) {
+    img.src = imgs[0];
+    img.style.display = 'block';
+  } else {
+    img.removeAttribute('src');
+    img.style.display = 'none';
+  }
+  const strip = document.getElementById('queue-images');
+  strip.innerHTML = imgs.slice(0, 5).map((u) =>
+    `<img src="${escHtml(u)}" class="thumb" style="width:56px;height:56px;object-fit:contain;background:#fff;" alt="">`
+  ).join('') || '<span style="color:var(--mist);font-size:12px;">No images yet — open product page or re-fetch</span>';
+  const link = document.getElementById('queue-link');
+  if (product.productUrl) {
+    link.href = product.productUrl;
+    link.style.display = 'inline-flex';
+  } else {
+    link.removeAttribute('href');
+    link.style.display = 'none';
+  }
+  document.getElementById('queue-pack').style.display = 'none';
+}
+
+async function queueNext(enrich) {
+  log(enrich ? 'Next item + enrich images…' : 'Next item (link only)…', 'log-info');
+  try {
+    const r = await fetch(`${API}/queue/next?enrich=${enrich ? '1' : '0'}`);
+    const data = await r.json();
+    if (data.error) throw new Error(data.error);
+    if (!data.product) {
+      toast('Queue empty — import CSV or fetch emails');
+      document.getElementById('queue-panel').style.display = 'none';
+      currentQueueProduct = null;
+      return;
+    }
+    renderQueueProduct(data.product, data.remaining, data.enrich);
+    log(`▶ ${data.product.productTitle?.substring(0, 60)} (${data.remaining} in queue)`, 'log-ok');
+    toast(`Queue: ${data.remaining} remaining`);
+  } catch (e) {
+    log('❌ Queue: ' + e.message, 'log-err');
+    toast(e.message);
+  }
+}
+
+async function enrichCurrent() {
+  if (!currentQueueProduct) return toast('Load next item first');
+  try {
+    const r = await fetch(`${API}/products/${encodeURIComponent(currentQueueProduct.orderId)}/enrich`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fetchImages: true }),
+    });
+    const data = await r.json();
+    if (data.error) throw new Error(data.error);
+    renderQueueProduct(data.product, null, { reason: data.reason });
+    toast(data.fetchError ? `Partial: ${data.fetchError}` : `Images: ${(data.imageUrls || []).length}`);
+  } catch (e) {
+    toast(e.message);
+  }
+}
+
+async function showListingPack() {
+  if (!currentQueueProduct) return toast('Load next item first');
+  try {
+    const r = await fetch(`${API}/products/${encodeURIComponent(currentQueueProduct.orderId)}/listing-pack`);
+    const pack = await r.json();
+    if (pack.error) throw new Error(pack.error);
+    const el = document.getElementById('queue-pack');
+    el.style.display = 'block';
+    el.textContent = [
+      pack.title,
+      '',
+      `Price: $${pack.suggestedPrice ?? '?'}`,
+      pack.productUrl || '',
+      '',
+      pack.description,
+      '',
+      `Images (${pack.imageCount}):`,
+      ...(pack.selectedImages || []),
+    ].join('\n');
+    try {
+      await navigator.clipboard.writeText(el.textContent);
+      toast('Listing pack copied to clipboard');
+    } catch {
+      toast('Listing pack ready (copy manually)');
+    }
+  } catch (e) {
+    toast(e.message);
   }
 }
 

--- a/reesereviews/vine-marketplace/tests/vine-marketplace.test.js
+++ b/reesereviews/vine-marketplace/tests/vine-marketplace.test.js
@@ -79,7 +79,12 @@ test('rounding to 2 decimal places', () => {
 
 console.log('\n📧  Amazon Parser');
 
-const { parseAmazonEmail, detectEmailType } = require('../lib/amazon-parser');
+const {
+  parseAmazonEmail,
+  detectEmailType,
+  productUrlFromAsin,
+  attachProductLink,
+} = require('../lib/amazon-parser');
 
 test('detectEmailType: vine email', () => {
   assert.strictEqual(detectEmailType('Amazon Vine — Your product has arrived'), 'vine');
@@ -157,6 +162,90 @@ test('parseAmazonEmail: unknown email type returns null', () => {
     text: 'Check out these deals',
   };
   assert.strictEqual(parseAmazonEmail(mail), null);
+});
+
+test('productUrlFromAsin builds /dp/ URL', () => {
+  assert.strictEqual(
+    productUrlFromAsin('B08C4KWM9T'),
+    'https://www.amazon.com/dp/B08C4KWM9T'
+  );
+  assert.strictEqual(productUrlFromAsin('bad'), null);
+});
+
+test('parseAmazonEmail attaches productUrl from ASIN', () => {
+  const mail = {
+    subject: 'Your package has been delivered',
+    from: { text: 'ship-confirm@amazon.com' },
+    text: `
+      Order Total: $10.00
+      You ordered: Widget
+      ASIN: B08C4KWM9T
+      Your Order: 112-3456789-0123456
+    `,
+  };
+  const result = parseAmazonEmail(mail);
+  assert.strictEqual(result.productUrl, 'https://www.amazon.com/dp/B08C4KWM9T');
+  assert.strictEqual(result.source, 'email');
+});
+
+// ── CSV import ─────────────────────────────────────────────────────────────
+
+console.log('\n📄  CSV Import');
+
+const { importOrderCsv, extractAsin } = require('../lib/csv-import');
+const { buildListingPack, extractImageUrlsFromHtml } = require('../lib/product-link');
+
+test('extractAsin from bare ASIN and URL', () => {
+  assert.strictEqual(extractAsin('B08C4KWM9T'), 'B08C4KWM9T');
+  assert.strictEqual(extractAsin('https://www.amazon.com/dp/B08C4KWM9T/ref=xx'), 'B08C4KWM9T');
+});
+
+test('importOrderCsv maps rows to vine-parser product shape', () => {
+  const csv = [
+    'Order ID,Order Date,Title,ASIN,Unit Price,Quantity',
+    '112-1111111-2222222,2026-01-15,Test Blender,B08C4KWM9T,29.99,1',
+    '112-3333333-4444444,2026-01-16,Another Item,B09ABCDEFG,5.00,1',
+  ].join('\n');
+  const { products, skipped } = importOrderCsv(csv);
+  assert.strictEqual(products.length, 2);
+  assert.strictEqual(skipped, 0);
+  assert.strictEqual(products[0].asin, 'B08C4KWM9T');
+  assert.strictEqual(products[0].productUrl, 'https://www.amazon.com/dp/B08C4KWM9T');
+  assert.strictEqual(products[0].source, 'csv');
+  assert.strictEqual(products[0].emailType, 'csv');
+  assert.strictEqual(products[0].paidPrice, 29.99);
+  assert.strictEqual(products[0].listed, false);
+});
+
+test('buildListingPack includes productUrl and selectedImages', () => {
+  const pack = buildListingPack({
+    orderId: 'X',
+    asin: 'B08C4KWM9T',
+    productTitle: 'Test Blender',
+    productUrl: 'https://www.amazon.com/dp/B08C4KWM9T',
+    imageUrl: 'https://m.media-amazon.com/images/I/example.jpg',
+    imageUrls: [
+      'https://m.media-amazon.com/images/I/example.jpg',
+      'https://m.media-amazon.com/images/I/example2.jpg',
+    ],
+  }, { listingPrice: 24 });
+  assert.strictEqual(pack.productUrl, 'https://www.amazon.com/dp/B08C4KWM9T');
+  assert.strictEqual(pack.suggestedPrice, 24);
+  assert.ok(pack.selectedImages.length >= 1);
+  assert.ok(pack.selectedImages.length <= 5);
+});
+
+test('extractImageUrlsFromHtml finds og:image', () => {
+  const html = '<html><meta property="og:image" content="https://m.media-amazon.com/images/I/abc.jpg"/></html>';
+  const urls = extractImageUrlsFromHtml(html);
+  assert.ok(urls.some((u) => u.includes('abc.jpg')));
+});
+
+test('attachProductLink is idempotent', () => {
+  const p = attachProductLink({ asin: 'B08C4KWM9T', productTitle: 'x' });
+  assert.strictEqual(p.productUrl, 'https://www.amazon.com/dp/B08C4KWM9T');
+  const p2 = attachProductLink(p);
+  assert.strictEqual(p2.productUrl, p.productUrl);
 });
 
 // ── Inventory ──────────────────────────────────────────────────────────────

--- a/reesereviews/vine-marketplace/vercel.json
+++ b/reesereviews/vine-marketplace/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/index.js", "use": "@vercel/node" },
+    { "src": "public/**", "use": "@vercel/static" }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "api/index.js" },
+    { "src": "/(.*)", "dest": "public/$1" }
+  ]
+}


### PR DESCRIPTION
Extends vine-marketplace so order CSV uses the same product shape as amazon-parser (vine email parse). No personal photos: ASIN builds amazon.com/dp/ASIN; optional product-page image enrich; one-at-a-time queue and listing pack for human Marketplace post. Dashboard CSV UI + Vercel entry. Tests 55 passed. Related #15520.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extends the vine-marketplace pipeline to accept Amazon order history CSV files in addition to email parsing, building a unified product data shape. Both CSV imports and email parses now generate Amazon product links from ASIN (no personal photo uploads required), with optional image enrichment from product pages. It introduces a one-at-a-time queue API for sequential human review, listing pack generation for manual Marketplace posting, dashboard CSV upload UI, and Vercel serverless deployment support. All products share the same `{ orderId, asin, productTitle, imageUrl, productUrl, … }` shape whether sourced from email or CSV.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `reesereviews/vine-marketplace/lib/amazon-parser.js` |
| 2 | `reesereviews/vine-marketplace/lib/csv-import.js` |
| 3 | `reesereviews/vine-marketplace/lib/product-link.js` |
| 4 | `reesereviews/vine-marketplace/index.js` |
| 5 | `reesereviews/vine-marketplace/api/index.js` |
| 6 | `reesereviews/vine-marketplace/vercel.json` |
| 7 | `reesereviews/vine-marketplace/lib/inventory.js` |
| 8 | `reesereviews/vine-marketplace/public/index.html` |
| 9 | `reesereviews/vine-marketplace/tests/vine-marketplace.test.js` |
| 10 | `reesereviews/vine-marketplace/README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Amazon order CSV import and unifies product records with the vine email parser so every item has ASIN-based product links. Enables photo-less listing packs via ASIN → product page images, plus a one-at-a-time queue and Vercel serverless entry. Related to #15520.

- New Features
  - CSV import produces the same shape as email parse: `{ orderId, asin, productTitle, imageUrl, productUrl, … }`.
  - ASIN → `https://www.amazon.com/dp/{ASIN}` via `attachProductLink`; optional product-page image enrichment (`enrichProduct`).
  - Queue API/UI for one-at-a-time review: `POST /api/import/csv`, `GET /api/queue/next?enrich=1`, `POST /api/products/:orderId/enrich`, `GET /api/products/:orderId/listing-pack`.
  - Dashboard adds CSV upload and listing pack view; CLI adds `node index.js import-csv ./orders.csv`.

- Deployment
  - Vercel serverless entry via `api/index.js` and `vercel.json`; inventory persists under `/tmp` in serverless.

<sup>Written for commit 6beef8f8cc6d16392c1b3217411f8617315ca347. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

