### PR TITLE
fix(vine-orders): make START and Open Amazon buttons obvious

### DIFF
--- a/docs/vine-orders/README.md
+++ b/docs/vine-orders/README.md
@@ -1,24 +1,17 @@
-# Amazon Orders → Listing Pack (live upload page)
+# Amazon Orders upload page
 
-**This is the page that accepts your CSV upload.**
-
-## Live URL (after deploy)
+## Open this URL only
 
 https://revvel-standards.vercel.app/docs/vine-orders/
 
-## What it is
+## What to click (in order)
 
-- Browser-only tool (your CSV stays on your machine)
-- Parses Amazon order history CSV
-- Builds `https://www.amazon.com/dp/{ASIN}` from product IDs
-- One-at-a-time listing pack for Marketplace copy-paste
-- **You do not upload personal product photos**
+1. **Green button** — "START — load 3 sample products" (no file needed)
+2. **Orange button** — "OPEN THIS PRODUCT ON AMAZON" (this is the product link)
+3. **Next product** — go through the list
+4. Later: **Choose my orders CSV** for your real Amazon export
 
-## What it is not
+## What NOT to expect
 
-- Not the main hub homepage (folders / oAudrey / artifacts)
-- Not the full Node `reesereviews/vine-marketplace` server (email + FB API)
-
-## Local open
-
-Open `index.html` in a browser, or after `bash scripts/build-static.sh` visit `/docs/vine-orders/`.
+- The dashed "Choose CSV" box is a **file picker on your computer**, not a product website.
+- The main hub https://revvel-standards.vercel.app/ does not upload orders.

--- a/docs/vine-orders/index.html
+++ b/docs/vine-orders/index.html
@@ -3,208 +3,214 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Amazon Orders → Marketplace Pack | Vine parse</title>
-  <meta name="description" content="Upload Amazon order CSV. Get product links from ASIN. One at a time. No personal photos required." />
+  <title>START HERE · Amazon Orders → Marketplace</title>
   <style>
     :root {
-      --bg: #0a0a0f;
-      --card: rgba(255,255,255,0.05);
-      --border: rgba(255,255,255,0.1);
-      --accent: #7c6af7;
-      --accent2: #a89cff;
-      --ok: #22c55e;
-      --warn: #f59e0b;
-      --mist: rgba(255,255,255,0.55);
-      --white: #f5f5ff;
-      --radius: 14px;
+      --bg: #0b0b12;
+      --card: #14141f;
+      --border: #2a2a3d;
+      --purple: #8b7cf7;
+      --green: #3dd68c;
+      --amber: #f5c542;
+      --mist: #a0a0b8;
+      --white: #f4f4ff;
+      --danger: #ff6b7a;
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
-      font-family: Inter, system-ui, sans-serif;
+      font-family: system-ui, Segoe UI, sans-serif;
       background: var(--bg);
       color: var(--white);
+      line-height: 1.5;
       min-height: 100vh;
-      line-height: 1.45;
+      padding: 20px 16px 80px;
     }
-    body::before {
-      content: "";
-      position: fixed; inset: 0;
-      background:
-        radial-gradient(ellipse 70% 50% at 15% 10%, rgba(124,106,247,.2), transparent 60%),
-        radial-gradient(ellipse 50% 40% at 90% 80%, rgba(34,197,94,.08), transparent 55%);
-      pointer-events: none; z-index: 0;
-    }
-    .wrap { position: relative; z-index: 1; max-width: 920px; margin: 0 auto; padding: 28px 18px 64px; }
-    h1 { font-size: 1.55rem; letter-spacing: -0.03em; margin-bottom: 6px; }
-    h1 span { color: var(--accent2); }
-    .sub { color: var(--mist); font-size: 0.95rem; margin-bottom: 22px; max-width: 40rem; }
-    .banner {
-      background: rgba(124,106,247,.12);
-      border: 1px solid rgba(124,106,247,.35);
-      border-radius: var(--radius);
-      padding: 12px 16px;
+    .wrap { max-width: 720px; margin: 0 auto; }
+    h1 { font-size: 1.45rem; margin-bottom: 8px; }
+    .lead { color: var(--mist); margin-bottom: 20px; font-size: 1rem; }
+    .callout {
+      background: #1a1530;
+      border: 2px solid var(--purple);
+      border-radius: 14px;
+      padding: 16px;
       margin-bottom: 18px;
-      font-size: 0.9rem;
+      font-size: 0.95rem;
     }
-    .banner strong { color: var(--accent2); }
-    .card {
+    .callout b { color: #c4b5ff; }
+    .step {
       background: var(--card);
       border: 1px solid var(--border);
-      border-radius: var(--radius);
+      border-radius: 14px;
       padding: 18px;
-      margin-bottom: 16px;
-      backdrop-filter: blur(12px);
+      margin-bottom: 14px;
     }
-    .card h2 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: .08em; color: var(--mist); margin-bottom: 12px; }
-    .drop {
-      border: 2px dashed rgba(168,156,255,.45);
-      border-radius: 12px;
-      padding: 28px 16px;
-      text-align: center;
-      cursor: pointer;
-      transition: background .15s, border-color .15s;
+    .step-num {
+      display: inline-block;
+      background: var(--purple);
+      color: #fff;
+      font-weight: 800;
+      font-size: 0.75rem;
+      padding: 4px 10px;
+      border-radius: 999px;
+      margin-bottom: 10px;
+      letter-spacing: 0.04em;
     }
-    .drop:hover, .drop.drag { background: rgba(124,106,247,.12); border-color: var(--accent2); }
-    .drop input { display: none; }
-    .drop p { color: var(--mist); font-size: 0.9rem; margin-top: 6px; }
+    .step h2 { font-size: 1.1rem; margin-bottom: 8px; }
+    .step p { color: var(--mist); font-size: 0.95rem; margin-bottom: 12px; }
     .btn {
-      display: inline-flex; align-items: center; gap: 8px;
-      border: none; border-radius: 10px;
-      padding: 10px 16px; font-weight: 600; font-size: 0.9rem;
-      cursor: pointer; color: #fff; background: var(--accent);
+      display: block;
+      width: 100%;
+      text-align: center;
+      border: none;
+      border-radius: 12px;
+      padding: 16px 18px;
+      font-size: 1.05rem;
+      font-weight: 700;
+      cursor: pointer;
+      margin-bottom: 10px;
+      text-decoration: none;
+      color: #fff;
     }
-    .btn:disabled { opacity: .4; cursor: not-allowed; }
-    .btn-ghost { background: rgba(255,255,255,.08); border: 1px solid var(--border); }
-    .btn-ok { background: var(--ok); color: #041; }
-    .row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-top: 12px; }
-    .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 10px; margin-bottom: 16px; }
-    .stat { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 12px; }
-    .stat b { display: block; font-size: 1.4rem; }
-    .stat span { font-size: 0.7rem; text-transform: uppercase; letter-spacing: .06em; color: var(--mist); }
-    .product {
-      display: grid; grid-template-columns: 88px 1fr; gap: 14px;
-      padding: 14px; border-radius: 12px; border: 1px solid var(--border);
-      background: rgba(0,0,0,.25); margin-bottom: 10px;
+    .btn:disabled { opacity: 0.35; cursor: not-allowed; }
+    .btn-start { background: var(--green); color: #042; font-size: 1.15rem; padding: 18px; }
+    .btn-amazon { background: #ff9900; color: #111; font-size: 1.1rem; }
+    .btn-next { background: var(--purple); }
+    .btn-copy { background: #2a2a40; border: 1px solid var(--border); }
+    .btn-file {
+      background: transparent;
+      border: 2px dashed #555;
+      color: var(--mist);
+      font-weight: 600;
+      font-size: 0.95rem;
     }
-    .product img {
-      width: 88px; height: 88px; object-fit: contain; background: #fff; border-radius: 10px;
+    .btn-file:hover { border-color: var(--purple); color: var(--white); }
+    .status {
+      background: #0f1a14;
+      border: 1px solid #1f3d2e;
+      border-radius: 12px;
+      padding: 12px 14px;
+      margin-bottom: 14px;
+      font-size: 0.95rem;
     }
-    .product .ph {
-      width: 88px; height: 88px; border-radius: 10px; background: rgba(255,255,255,.06);
-      display: flex; align-items: center; justify-content: center; color: var(--mist); font-size: 0.75rem; text-align: center; padding: 6px;
+    .status.empty { background: #1a1510; border-color: #4a3a10; }
+    .status strong { color: var(--green); }
+    .status.empty strong { color: var(--amber); }
+    .product-box {
+      background: #0d0d16;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px;
+      margin: 12px 0;
     }
-    .product h3 { font-size: 1rem; margin-bottom: 4px; }
-    .meta { font-size: 0.8rem; color: var(--mist); margin-bottom: 8px; word-break: break-all; }
-    a.link { color: var(--accent2); }
-    textarea, pre.pack {
-      width: 100%; min-height: 160px; margin-top: 10px;
-      background: rgba(0,0,0,.35); border: 1px solid var(--border);
-      border-radius: 10px; color: var(--white); padding: 12px; font-size: 0.8rem;
-      font-family: ui-monospace, Consolas, monospace; white-space: pre-wrap;
+    .product-box h3 { font-size: 1.05rem; margin-bottom: 6px; }
+    .meta { color: var(--mist); font-size: 0.88rem; margin-bottom: 8px; }
+    textarea {
+      width: 100%;
+      min-height: 140px;
+      background: #0a0a10;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      color: var(--white);
+      padding: 12px;
+      font-family: ui-monospace, Consolas, monospace;
+      font-size: 0.82rem;
+      margin-top: 8px;
     }
-    table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
-    th, td { text-align: left; padding: 8px 6px; border-bottom: 1px solid rgba(255,255,255,.06); vertical-align: top; }
-    th { color: var(--mist); font-size: 0.7rem; text-transform: uppercase; letter-spacing: .06em; }
-    tr.active { background: rgba(124,106,247,.12); }
-    tr { cursor: pointer; }
+    .hidden { display: none !important; }
     .toast {
-      position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-      background: #1a1a28; border: 1px solid var(--border); padding: 10px 16px;
-      border-radius: 10px; font-size: 0.85rem; opacity: 0; transition: opacity .2s; z-index: 9;
+      position: fixed; bottom: 18px; left: 50%; transform: translateX(-50%);
+      background: #222; border: 1px solid #444; padding: 10px 16px;
+      border-radius: 10px; font-size: 0.9rem; opacity: 0; transition: .2s; z-index: 20;
+      max-width: 90%;
     }
     .toast.show { opacity: 1; }
-    .steps { font-size: 0.85rem; color: var(--mist); margin-bottom: 14px; }
-    .steps ol { margin-left: 1.2rem; }
-    .hidden { display: none !important; }
+    .warn { color: var(--amber); }
+    .tiny { font-size: 0.8rem; color: var(--mist); margin-top: 8px; }
+    ol.howto { margin: 8px 0 0 1.2rem; color: var(--mist); font-size: 0.9rem; }
+    ol.howto li { margin-bottom: 4px; }
+    #file { display: none; }
   </style>
 </head>
 <body>
   <div class="wrap">
-    <h1>Amazon Orders → <span>Listing Pack</span></h1>
-    <p class="sub">
-      Upload your Amazon order history CSV. We build product links from ASIN
-      (<code>amazon.com/dp/…</code>). No personal photos. One item at a time for Marketplace copy-paste.
+    <h1>Amazon orders → Marketplace listing</h1>
+    <p class="lead">
+      This page does <b>one job</b>: turn your order list into product links and listing text.
+      It does <b>not</b> open products until you load a list first.
     </p>
 
-    <div class="banner">
-      <strong>This is the upload page.</strong>
-      Not the main hub (folders / artifacts). Bookmark this URL only for orders:
-      <div style="margin-top:6px;word-break:break-all;">
-        <code id="self-url"></code>
-      </div>
+    <div class="callout">
+      <b>Why “click here” did nothing on Amazon:</b><br />
+      That box only opens your computer’s <b>file chooser</b> (to pick a CSV).
+      It is <b>not</b> a link to a product. Product links appear <b>after</b> Step 1 or Step 2.
     </div>
 
-    <div class="card">
-      <h2>1 · How to get the CSV (Amazon)</h2>
-      <div class="steps">
-        <ol>
-          <li>Amazon → Account → <strong>Your Orders</strong> or <strong>Request Your Information / Order history reports</strong></li>
-          <li>Download the <strong>Items</strong> / order history report as <strong>CSV</strong></li>
-          <li>Upload that file below (stays in your browser — not sent to our server)</li>
-        </ol>
-      </div>
+    <div class="status empty" id="status">
+      <strong>Right now:</strong> <span id="status-text">No list loaded yet. Press the green button first.</span>
     </div>
 
-    <div class="card">
-      <h2>2 · Upload CSV</h2>
-      <label class="drop" id="drop" for="file">
-        <div style="font-size:1.6rem;">⬆</div>
-        <div style="font-weight:600;margin-top:8px;">Click or drop orders CSV here</div>
-        <p>Accepts .csv from Amazon order history</p>
-        <input type="file" id="file" accept=".csv,text/csv,text/plain" />
-      </label>
-      <div class="row">
-        <button type="button" class="btn" id="btn-demo">Load sample (3 items)</button>
-        <span id="file-name" style="color:var(--mist);font-size:0.85rem;"></span>
-      </div>
+    <!-- STEP 1 -->
+    <div class="step" id="step1">
+      <div class="step-num">STEP 1 · START HERE</div>
+      <h2>Try it with sample products (no file needed)</h2>
+      <p>
+        Press the green button. Three fake orders load. Then you will see a big
+        orange button to open the real Amazon product page.
+      </p>
+      <button type="button" class="btn btn-start" id="btn-start">
+        ▶ START — load 3 sample products
+      </button>
+      <p class="tiny">Use this first so you understand the flow. Your real CSV is Step 2.</p>
     </div>
 
-    <div id="after" class="hidden">
-      <div class="stats">
-        <div class="stat"><span>Imported</span><b id="n-total">0</b></div>
-        <div class="stat"><span>With ASIN</span><b id="n-asin">0</b></div>
-        <div class="stat"><span>Queue left</span><b id="n-left">0</b></div>
-        <div class="stat"><span>Current #</span><b id="n-idx">—</b></div>
-      </div>
-
-      <div class="card">
-        <h2>3 · One at a time</h2>
-        <div class="row" style="margin-top:0;">
-          <button type="button" class="btn" id="btn-prev">← Prev</button>
-          <button type="button" class="btn btn-ok" id="btn-next">Next →</button>
-          <button type="button" class="btn btn-ghost" id="btn-copy">Copy listing pack</button>
-          <button type="button" class="btn btn-ghost" id="btn-open">Open Amazon product</button>
-        </div>
-        <div id="current" style="margin-top:14px;"></div>
-        <label style="display:block;margin-top:12px;font-size:0.75rem;color:var(--mist);text-transform:uppercase;letter-spacing:.06em;">Listing pack (edit then copy)</label>
-        <textarea id="pack" spellcheck="false"></textarea>
-      </div>
-
-      <div class="card">
-        <h2>4 · All imported items</h2>
-        <div style="overflow-x:auto;">
-          <table>
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Title</th>
-                <th>ASIN</th>
-                <th>Paid</th>
-                <th>Link</th>
-              </tr>
-            </thead>
-            <tbody id="tbody"></tbody>
-          </table>
-        </div>
-      </div>
+    <!-- STEP 2 -->
+    <div class="step">
+      <div class="step-num">STEP 2 · YOUR REAL ORDERS (optional)</div>
+      <h2>Upload Amazon order CSV</h2>
+      <p>Only after you have a CSV from Amazon on your computer:</p>
+      <ol class="howto">
+        <li>Amazon.com → Account → Your Orders (or “Download order reports”)</li>
+        <li>Get the <b>CSV</b> file onto this computer</li>
+        <li>Press the button below and choose that file</li>
+      </ol>
+      <button type="button" class="btn btn-file" id="btn-pick">
+        Choose my orders CSV file…
+      </button>
+      <input type="file" id="file" accept=".csv,text/csv,text/plain" />
+      <p class="tiny" id="file-label"></p>
     </div>
 
-    <div class="card" style="margin-top:8px;">
-      <h2>Not this page?</h2>
-      <p style="color:var(--mist);font-size:0.9rem;">
-        <a class="link" href="https://revvel-standards.vercel.app/">revvel-standards.vercel.app</a>
-        is the public hub (folders / oAudrey / docs). It does <strong>not</strong> upload orders.
-        Full Node app (email + FB): <code>reesereviews/vine-marketplace</code> on GitHub — run locally or deploy that folder separately.
+    <!-- STEP 3 — only after load -->
+    <div class="step hidden" id="step3">
+      <div class="step-num">STEP 3 · THIS PRODUCT</div>
+      <h2>Open on Amazon · copy listing</h2>
+      <p class="warn" id="hint">
+        The orange button opens Amazon in a new tab for THIS product’s photos and page.
+      </p>
+
+      <div class="product-box" id="product-box"></div>
+
+      <a class="btn btn-amazon hidden" id="btn-amazon" href="#" target="_blank" rel="noopener">
+        🛒 OPEN THIS PRODUCT ON AMAZON
+      </a>
+      <p class="tiny hidden" id="no-asin">
+        This row has no ASIN, so there is no Amazon product link. Use Next or fix the CSV.
+      </p>
+
+      <button type="button" class="btn btn-next" id="btn-next">Next product →</button>
+      <button type="button" class="btn btn-copy" id="btn-prev">← Previous product</button>
+      <button type="button" class="btn btn-copy" id="btn-copy">Copy listing text for Marketplace</button>
+
+      <label class="tiny" style="display:block;margin-top:12px;">Listing text (you can edit, then copy)</label>
+      <textarea id="pack" spellcheck="false"></textarea>
+    </div>
+
+    <div class="step">
+      <div class="step-num">REMEMBER</div>
+      <p style="margin:0;">
+        <b>Green button</b> = load list.<br />
+        <b>Orange button</b> = go to Amazon for that product.<br />
+        <b>Dashed “Choose CSV”</b> = pick a file on your PC (not a website link).
       </p>
     </div>
   </div>
@@ -212,15 +218,19 @@
 
   <script>
 (function () {
-  document.getElementById('self-url').textContent = location.href.split('#')[0];
-
   const state = { products: [], index: 0 };
 
   function toast(msg) {
     const el = document.getElementById('toast');
     el.textContent = msg;
     el.classList.add('show');
-    setTimeout(() => el.classList.remove('show'), 2200);
+    setTimeout(() => el.classList.remove('show'), 2800);
+  }
+
+  function setStatus(html, empty) {
+    const box = document.getElementById('status');
+    document.getElementById('status-text').innerHTML = html;
+    box.classList.toggle('empty', !!empty);
   }
 
   function normHeader(h) {
@@ -289,115 +299,81 @@
   }
 
   function rowToProduct(row, i) {
-    const orderId = pick(row, ['order id', 'order number', 'order #']) || `CSV-${i + 1}`;
+    const orderId = pick(row, ['order id', 'order number', 'order #']) || `ROW-${i + 1}`;
     const asin = extractAsin(pick(row, ['asin', 'asin/isbn', 'asin isbn', 'isbn']));
     const title = pick(row, ['title', 'product name', 'product title', 'item name', 'description'])
       || (asin ? `Amazon product ${asin}` : `Item ${i + 1}`);
     const paid = money(pick(row, ['item total', 'total owed', 'unit price', 'purchase price', 'price', 'shipment item subtotal']));
-    const productUrl = asin ? `https://www.amazon.com/dp/${asin}` : (pick(row, ['product url', 'url', 'link']) || null);
-    const suggest = Math.max(1, Math.round(paid * 0.8 * 100) / 100);
-    return {
-      orderId,
-      asin,
-      productTitle: title.slice(0, 200),
-      paidPrice: paid,
-      suggestedPrice: paid ? suggest : null,
-      productUrl,
-      orderDate: pick(row, ['order date', 'date', 'purchase date']) || '',
-    };
-  }
-
-  function importText(text, label) {
-    const rows = parseCsv(text);
-    const products = rows.map(rowToProduct).filter((p) => p.asin || (p.productTitle && !p.productTitle.startsWith('Item ')));
-    state.products = products;
-    state.index = 0;
-    document.getElementById('file-name').textContent = label || `${products.length} products`;
-    document.getElementById('after').classList.toggle('hidden', products.length === 0);
-    if (!products.length) {
-      toast('No products found — need Title and/or ASIN columns');
-      return;
-    }
-    renderAll();
-    toast(`Loaded ${products.length} products`);
+    const productUrl = asin ? `https://www.amazon.com/dp/${asin}` : null;
+    const suggestedPrice = paid ? Math.max(1, Math.round(paid * 0.8 * 100) / 100) : null;
+    return { orderId, asin, productTitle: title.slice(0, 200), paidPrice: paid, suggestedPrice, productUrl };
   }
 
   function listingPack(p) {
-    const price = p.suggestedPrice != null ? `$${p.suggestedPrice.toFixed(2)}` : '(set price)';
+    const price = p.suggestedPrice != null ? `$${p.suggestedPrice.toFixed(2)}` : '(set your price)';
     return [
       p.productTitle,
       '',
       `Asking: ${price}`,
-      p.paidPrice ? `(I paid about $${p.paidPrice.toFixed(2)})` : '',
+      p.paidPrice ? `(About what I paid: $${p.paidPrice.toFixed(2)})` : '',
       '',
       p.asin ? `ASIN: ${p.asin}` : '',
       p.productUrl || '',
       '',
-      'From my Amazon orders. Condition: as noted — ask questions before buying.',
-      'Local pickup / shipping as agreed. Thanks for looking!',
-    ].filter((line, idx, arr) => !(line === '' && arr[idx - 1] === '')).join('\n');
+      'From my orders. Message me with questions. Local pickup / shipping as agreed.',
+    ].filter((line, i, a) => !(line === '' && a[i - 1] === '')).join('\n');
   }
 
-  function renderAll() {
-    const n = state.products.length;
-    const withAsin = state.products.filter((p) => p.asin).length;
-    document.getElementById('n-total').textContent = n;
-    document.getElementById('n-asin').textContent = withAsin;
-    document.getElementById('n-left').textContent = Math.max(0, n - state.index - 1);
-    document.getElementById('n-idx').textContent = n ? `${state.index + 1}/${n}` : '—';
-
-    const tbody = document.getElementById('tbody');
-    tbody.innerHTML = state.products.map((p, i) => `
-      <tr class="${i === state.index ? 'active' : ''}" data-i="${i}">
-        <td>${i + 1}</td>
-        <td>${esc(p.productTitle)}</td>
-        <td>${esc(p.asin || '—')}</td>
-        <td>${p.paidPrice ? '$' + p.paidPrice.toFixed(2) : '—'}</td>
-        <td>${p.productUrl ? `<a class="link" href="${esc(p.productUrl)}" target="_blank" rel="noopener">dp/${esc(p.asin)}</a>` : '—'}</td>
-      </tr>`).join('');
-
-    tbody.querySelectorAll('tr').forEach((tr) => {
-      tr.addEventListener('click', (e) => {
-        if (e.target.tagName === 'A') return;
-        state.index = Number(tr.dataset.i);
-        renderCurrent();
-        renderAll();
-      });
-    });
-
-    renderCurrent();
+  function loadProducts(products, label) {
+    state.products = products;
+    state.index = 0;
+    document.getElementById('step3').classList.remove('hidden');
+    document.getElementById('file-label').textContent = label || '';
+    render();
+    toast('List loaded. Use the orange button to open Amazon.');
+    // Scroll to product section
+    document.getElementById('step3').scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
-  function renderCurrent() {
+  function render() {
     const p = state.products[state.index];
-    const box = document.getElementById('current');
+    const n = state.products.length;
     if (!p) {
-      box.innerHTML = '';
-      document.getElementById('pack').value = '';
+      setStatus('No list loaded yet. Press the green button first.', true);
       return;
     }
-    document.getElementById('n-left').textContent = Math.max(0, state.products.length - state.index - 1);
-    document.getElementById('n-idx').textContent = `${state.index + 1}/${state.products.length}`;
-    box.innerHTML = `
-      <div class="product">
-        <div class="ph">Open Amazon<br>for photos</div>
-        <div>
-          <h3>${esc(p.productTitle)}</h3>
-          <div class="meta">
-            Order ${esc(p.orderId)}
-            ${p.asin ? ' · ASIN ' + esc(p.asin) : ''}
-            ${p.orderDate ? ' · ' + esc(p.orderDate) : ''}
-            ${p.paidPrice ? ' · paid $' + p.paidPrice.toFixed(2) : ''}
-            ${p.suggestedPrice != null ? ' · suggest $' + p.suggestedPrice.toFixed(2) : ''}
-          </div>
-          ${p.productUrl ? `<a class="link" href="${esc(p.productUrl)}" target="_blank" rel="noopener">${esc(p.productUrl)}</a>` : '<span style="color:var(--warn)">No ASIN — add product link manually</span>'}
-          <p style="margin-top:8px;font-size:0.8rem;color:var(--mist);">
-            Photos: open the product page (link above) and save 3–5 Amazon images for your Marketplace listing.
-            This page does not store your CSV on a server.
-          </p>
-        </div>
-      </div>`;
+
+    setStatus(
+      `Viewing product <strong>${state.index + 1} of ${n}</strong>. ` +
+      (p.productUrl
+        ? 'Press the <strong>orange</strong> button to open it on Amazon.'
+        : 'This row has no ASIN — cannot open Amazon for this one.'),
+      false
+    );
+
+    document.getElementById('product-box').innerHTML =
+      '<h3>' + esc(p.productTitle) + '</h3>' +
+      '<div class="meta">Order ' + esc(p.orderId) +
+      (p.asin ? ' · ASIN ' + esc(p.asin) : ' · <span class="warn">no ASIN</span>') +
+      (p.paidPrice ? ' · paid $' + p.paidPrice.toFixed(2) : '') +
+      (p.suggestedPrice != null ? ' · suggest $' + p.suggestedPrice.toFixed(2) : '') +
+      '</div>';
+
+    const a = document.getElementById('btn-amazon');
+    const no = document.getElementById('no-asin');
+    if (p.productUrl) {
+      a.href = p.productUrl;
+      a.classList.remove('hidden');
+      no.classList.add('hidden');
+    } else {
+      a.removeAttribute('href');
+      a.classList.add('hidden');
+      no.classList.remove('hidden');
+    }
+
     document.getElementById('pack').value = listingPack(p);
+    document.getElementById('btn-prev').disabled = state.index <= 0;
+    document.getElementById('btn-next').disabled = state.index >= n - 1;
   }
 
   function esc(s) {
@@ -405,67 +381,73 @@
       .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 
-  const drop = document.getElementById('drop');
-  const fileInput = document.getElementById('file');
-
-  ['dragenter', 'dragover'].forEach((ev) => {
-    drop.addEventListener(ev, (e) => { e.preventDefault(); drop.classList.add('drag'); });
-  });
-  ['dragleave', 'drop'].forEach((ev) => {
-    drop.addEventListener(ev, (e) => { e.preventDefault(); drop.classList.remove('drag'); });
-  });
-  drop.addEventListener('drop', (e) => {
-    const f = e.dataTransfer.files && e.dataTransfer.files[0];
-    if (f) readFile(f);
-  });
-  fileInput.addEventListener('change', () => {
-    if (fileInput.files[0]) readFile(fileInput.files[0]);
-  });
-
-  function readFile(f) {
-    const reader = new FileReader();
-    reader.onload = () => importText(String(reader.result || ''), f.name);
-    reader.onerror = () => toast('Could not read file');
-    reader.readAsText(f);
-  }
-
-  document.getElementById('btn-demo').onclick = () => {
+  // STEP 1 — sample
+  document.getElementById('btn-start').onclick = function () {
     const sample = [
       'Order ID,Order Date,Title,ASIN,Unit Price,Quantity',
-      '112-1111111-2222222,2026-01-10,Example Kitchen Blender,B08C4KWM9T,39.99,1',
-      '112-3333333-4444444,2026-01-12,Example LED Desk Lamp,B09ABCDEF1,18.50,1',
-      '112-5555555-6666666,2026-01-14,Example Yoga Mat,B07XYZ1234,22.00,1',
+      // Real-looking ASIN pattern; may or may not still be live on Amazon — still teaches the button
+      '112-1111111-2222222,2026-01-10,Kitchen Blender (sample row),B08N5WRWNW,39.99,1',
+      '112-3333333-4444444,2026-01-12,LED Desk Lamp (sample row),B07GZD2LTB,18.50,1',
+      '112-5555555-6666666,2026-01-14,Yoga Mat (sample row),B01LP0U5X0,22.00,1',
     ].join('\n');
-    importText(sample, 'sample.csv');
+    const rows = parseCsv(sample);
+    loadProducts(rows.map(rowToProduct), 'sample (3 products)');
   };
 
-  document.getElementById('btn-next').onclick = () => {
+  // STEP 2 — file
+  document.getElementById('btn-pick').onclick = function () {
+    document.getElementById('file').click();
+  };
+  document.getElementById('file').onchange = function () {
+    const f = this.files && this.files[0];
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = function () {
+      const rows = parseCsv(String(reader.result || ''));
+      const products = rows.map(rowToProduct).filter(function (p) {
+        return p.asin || (p.productTitle && !/^Item \d+$/.test(p.productTitle));
+      });
+      if (!products.length) {
+        toast('No products found. CSV needs Title and/or ASIN columns.');
+        setStatus('CSV opened but no products found. Check it has ASIN or Title columns.', true);
+        return;
+      }
+      loadProducts(products, f.name + ' · ' + products.length + ' products');
+    };
+    reader.onerror = function () { toast('Could not read that file'); };
+    reader.readAsText(f);
+  };
+
+  document.getElementById('btn-next').onclick = function () {
     if (state.index < state.products.length - 1) {
       state.index++;
-      renderAll();
-    } else toast('End of list');
+      render();
+    } else toast('That was the last product.');
   };
-  document.getElementById('btn-prev').onclick = () => {
+  document.getElementById('btn-prev').onclick = function () {
     if (state.index > 0) {
       state.index--;
-      renderAll();
+      render();
     }
   };
-  document.getElementById('btn-open').onclick = () => {
-    const p = state.products[state.index];
-    if (p && p.productUrl) window.open(p.productUrl, '_blank', 'noopener');
-    else toast('No product URL');
-  };
-  document.getElementById('btn-copy').onclick = async () => {
+  document.getElementById('btn-copy').onclick = async function () {
     const text = document.getElementById('pack').value;
     try {
       await navigator.clipboard.writeText(text);
-      toast('Listing pack copied');
-    } catch {
+      toast('Listing text copied — paste into Marketplace.');
+    } catch (e) {
       document.getElementById('pack').select();
-      toast('Select text and copy (Ctrl+C)');
+      toast('Press Ctrl+C to copy the selected text.');
     }
   };
+
+  // Amazon button: if someone clicks when hidden/no href, explain
+  document.getElementById('btn-amazon').addEventListener('click', function (e) {
+    if (!this.getAttribute('href')) {
+      e.preventDefault();
+      toast('Load products first (green button), then orange opens Amazon.');
+    }
+  });
 })();
   </script>
 </body>

--- a/vine-orders.html
+++ b/vine-orders.html
@@ -3,208 +3,214 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Amazon Orders → Marketplace Pack | Vine parse</title>
-  <meta name="description" content="Upload Amazon order CSV. Get product links from ASIN. One at a time. No personal photos required." />
+  <title>START HERE · Amazon Orders → Marketplace</title>
   <style>
     :root {
-      --bg: #0a0a0f;
-      --card: rgba(255,255,255,0.05);
-      --border: rgba(255,255,255,0.1);
-      --accent: #7c6af7;
-      --accent2: #a89cff;
-      --ok: #22c55e;
-      --warn: #f59e0b;
-      --mist: rgba(255,255,255,0.55);
-      --white: #f5f5ff;
-      --radius: 14px;
+      --bg: #0b0b12;
+      --card: #14141f;
+      --border: #2a2a3d;
+      --purple: #8b7cf7;
+      --green: #3dd68c;
+      --amber: #f5c542;
+      --mist: #a0a0b8;
+      --white: #f4f4ff;
+      --danger: #ff6b7a;
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
-      font-family: Inter, system-ui, sans-serif;
+      font-family: system-ui, Segoe UI, sans-serif;
       background: var(--bg);
       color: var(--white);
+      line-height: 1.5;
       min-height: 100vh;
-      line-height: 1.45;
+      padding: 20px 16px 80px;
     }
-    body::before {
-      content: "";
-      position: fixed; inset: 0;
-      background:
-        radial-gradient(ellipse 70% 50% at 15% 10%, rgba(124,106,247,.2), transparent 60%),
-        radial-gradient(ellipse 50% 40% at 90% 80%, rgba(34,197,94,.08), transparent 55%);
-      pointer-events: none; z-index: 0;
-    }
-    .wrap { position: relative; z-index: 1; max-width: 920px; margin: 0 auto; padding: 28px 18px 64px; }
-    h1 { font-size: 1.55rem; letter-spacing: -0.03em; margin-bottom: 6px; }
-    h1 span { color: var(--accent2); }
-    .sub { color: var(--mist); font-size: 0.95rem; margin-bottom: 22px; max-width: 40rem; }
-    .banner {
-      background: rgba(124,106,247,.12);
-      border: 1px solid rgba(124,106,247,.35);
-      border-radius: var(--radius);
-      padding: 12px 16px;
+    .wrap { max-width: 720px; margin: 0 auto; }
+    h1 { font-size: 1.45rem; margin-bottom: 8px; }
+    .lead { color: var(--mist); margin-bottom: 20px; font-size: 1rem; }
+    .callout {
+      background: #1a1530;
+      border: 2px solid var(--purple);
+      border-radius: 14px;
+      padding: 16px;
       margin-bottom: 18px;
-      font-size: 0.9rem;
+      font-size: 0.95rem;
     }
-    .banner strong { color: var(--accent2); }
-    .card {
+    .callout b { color: #c4b5ff; }
+    .step {
       background: var(--card);
       border: 1px solid var(--border);
-      border-radius: var(--radius);
+      border-radius: 14px;
       padding: 18px;
-      margin-bottom: 16px;
-      backdrop-filter: blur(12px);
+      margin-bottom: 14px;
     }
-    .card h2 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: .08em; color: var(--mist); margin-bottom: 12px; }
-    .drop {
-      border: 2px dashed rgba(168,156,255,.45);
-      border-radius: 12px;
-      padding: 28px 16px;
-      text-align: center;
-      cursor: pointer;
-      transition: background .15s, border-color .15s;
+    .step-num {
+      display: inline-block;
+      background: var(--purple);
+      color: #fff;
+      font-weight: 800;
+      font-size: 0.75rem;
+      padding: 4px 10px;
+      border-radius: 999px;
+      margin-bottom: 10px;
+      letter-spacing: 0.04em;
     }
-    .drop:hover, .drop.drag { background: rgba(124,106,247,.12); border-color: var(--accent2); }
-    .drop input { display: none; }
-    .drop p { color: var(--mist); font-size: 0.9rem; margin-top: 6px; }
+    .step h2 { font-size: 1.1rem; margin-bottom: 8px; }
+    .step p { color: var(--mist); font-size: 0.95rem; margin-bottom: 12px; }
     .btn {
-      display: inline-flex; align-items: center; gap: 8px;
-      border: none; border-radius: 10px;
-      padding: 10px 16px; font-weight: 600; font-size: 0.9rem;
-      cursor: pointer; color: #fff; background: var(--accent);
+      display: block;
+      width: 100%;
+      text-align: center;
+      border: none;
+      border-radius: 12px;
+      padding: 16px 18px;
+      font-size: 1.05rem;
+      font-weight: 700;
+      cursor: pointer;
+      margin-bottom: 10px;
+      text-decoration: none;
+      color: #fff;
     }
-    .btn:disabled { opacity: .4; cursor: not-allowed; }
-    .btn-ghost { background: rgba(255,255,255,.08); border: 1px solid var(--border); }
-    .btn-ok { background: var(--ok); color: #041; }
-    .row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-top: 12px; }
-    .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 10px; margin-bottom: 16px; }
-    .stat { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 12px; }
-    .stat b { display: block; font-size: 1.4rem; }
-    .stat span { font-size: 0.7rem; text-transform: uppercase; letter-spacing: .06em; color: var(--mist); }
-    .product {
-      display: grid; grid-template-columns: 88px 1fr; gap: 14px;
-      padding: 14px; border-radius: 12px; border: 1px solid var(--border);
-      background: rgba(0,0,0,.25); margin-bottom: 10px;
+    .btn:disabled { opacity: 0.35; cursor: not-allowed; }
+    .btn-start { background: var(--green); color: #042; font-size: 1.15rem; padding: 18px; }
+    .btn-amazon { background: #ff9900; color: #111; font-size: 1.1rem; }
+    .btn-next { background: var(--purple); }
+    .btn-copy { background: #2a2a40; border: 1px solid var(--border); }
+    .btn-file {
+      background: transparent;
+      border: 2px dashed #555;
+      color: var(--mist);
+      font-weight: 600;
+      font-size: 0.95rem;
     }
-    .product img {
-      width: 88px; height: 88px; object-fit: contain; background: #fff; border-radius: 10px;
+    .btn-file:hover { border-color: var(--purple); color: var(--white); }
+    .status {
+      background: #0f1a14;
+      border: 1px solid #1f3d2e;
+      border-radius: 12px;
+      padding: 12px 14px;
+      margin-bottom: 14px;
+      font-size: 0.95rem;
     }
-    .product .ph {
-      width: 88px; height: 88px; border-radius: 10px; background: rgba(255,255,255,.06);
-      display: flex; align-items: center; justify-content: center; color: var(--mist); font-size: 0.75rem; text-align: center; padding: 6px;
+    .status.empty { background: #1a1510; border-color: #4a3a10; }
+    .status strong { color: var(--green); }
+    .status.empty strong { color: var(--amber); }
+    .product-box {
+      background: #0d0d16;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px;
+      margin: 12px 0;
     }
-    .product h3 { font-size: 1rem; margin-bottom: 4px; }
-    .meta { font-size: 0.8rem; color: var(--mist); margin-bottom: 8px; word-break: break-all; }
-    a.link { color: var(--accent2); }
-    textarea, pre.pack {
-      width: 100%; min-height: 160px; margin-top: 10px;
-      background: rgba(0,0,0,.35); border: 1px solid var(--border);
-      border-radius: 10px; color: var(--white); padding: 12px; font-size: 0.8rem;
-      font-family: ui-monospace, Consolas, monospace; white-space: pre-wrap;
+    .product-box h3 { font-size: 1.05rem; margin-bottom: 6px; }
+    .meta { color: var(--mist); font-size: 0.88rem; margin-bottom: 8px; }
+    textarea {
+      width: 100%;
+      min-height: 140px;
+      background: #0a0a10;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      color: var(--white);
+      padding: 12px;
+      font-family: ui-monospace, Consolas, monospace;
+      font-size: 0.82rem;
+      margin-top: 8px;
     }
-    table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
-    th, td { text-align: left; padding: 8px 6px; border-bottom: 1px solid rgba(255,255,255,.06); vertical-align: top; }
-    th { color: var(--mist); font-size: 0.7rem; text-transform: uppercase; letter-spacing: .06em; }
-    tr.active { background: rgba(124,106,247,.12); }
-    tr { cursor: pointer; }
+    .hidden { display: none !important; }
     .toast {
-      position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-      background: #1a1a28; border: 1px solid var(--border); padding: 10px 16px;
-      border-radius: 10px; font-size: 0.85rem; opacity: 0; transition: opacity .2s; z-index: 9;
+      position: fixed; bottom: 18px; left: 50%; transform: translateX(-50%);
+      background: #222; border: 1px solid #444; padding: 10px 16px;
+      border-radius: 10px; font-size: 0.9rem; opacity: 0; transition: .2s; z-index: 20;
+      max-width: 90%;
     }
     .toast.show { opacity: 1; }
-    .steps { font-size: 0.85rem; color: var(--mist); margin-bottom: 14px; }
-    .steps ol { margin-left: 1.2rem; }
-    .hidden { display: none !important; }
+    .warn { color: var(--amber); }
+    .tiny { font-size: 0.8rem; color: var(--mist); margin-top: 8px; }
+    ol.howto { margin: 8px 0 0 1.2rem; color: var(--mist); font-size: 0.9rem; }
+    ol.howto li { margin-bottom: 4px; }
+    #file { display: none; }
   </style>
 </head>
 <body>
   <div class="wrap">
-    <h1>Amazon Orders → <span>Listing Pack</span></h1>
-    <p class="sub">
-      Upload your Amazon order history CSV. We build product links from ASIN
-      (<code>amazon.com/dp/…</code>). No personal photos. One item at a time for Marketplace copy-paste.
+    <h1>Amazon orders → Marketplace listing</h1>
+    <p class="lead">
+      This page does <b>one job</b>: turn your order list into product links and listing text.
+      It does <b>not</b> open products until you load a list first.
     </p>
 
-    <div class="banner">
-      <strong>This is the upload page.</strong>
-      Not the main hub (folders / artifacts). Bookmark this URL only for orders:
-      <div style="margin-top:6px;word-break:break-all;">
-        <code id="self-url"></code>
-      </div>
+    <div class="callout">
+      <b>Why “click here” did nothing on Amazon:</b><br />
+      That box only opens your computer’s <b>file chooser</b> (to pick a CSV).
+      It is <b>not</b> a link to a product. Product links appear <b>after</b> Step 1 or Step 2.
     </div>
 
-    <div class="card">
-      <h2>1 · How to get the CSV (Amazon)</h2>
-      <div class="steps">
-        <ol>
-          <li>Amazon → Account → <strong>Your Orders</strong> or <strong>Request Your Information / Order history reports</strong></li>
-          <li>Download the <strong>Items</strong> / order history report as <strong>CSV</strong></li>
-          <li>Upload that file below (stays in your browser — not sent to our server)</li>
-        </ol>
-      </div>
+    <div class="status empty" id="status">
+      <strong>Right now:</strong> <span id="status-text">No list loaded yet. Press the green button first.</span>
     </div>
 
-    <div class="card">
-      <h2>2 · Upload CSV</h2>
-      <label class="drop" id="drop" for="file">
-        <div style="font-size:1.6rem;">⬆</div>
-        <div style="font-weight:600;margin-top:8px;">Click or drop orders CSV here</div>
-        <p>Accepts .csv from Amazon order history</p>
-        <input type="file" id="file" accept=".csv,text/csv,text/plain" />
-      </label>
-      <div class="row">
-        <button type="button" class="btn" id="btn-demo">Load sample (3 items)</button>
-        <span id="file-name" style="color:var(--mist);font-size:0.85rem;"></span>
-      </div>
+    <!-- STEP 1 -->
+    <div class="step" id="step1">
+      <div class="step-num">STEP 1 · START HERE</div>
+      <h2>Try it with sample products (no file needed)</h2>
+      <p>
+        Press the green button. Three fake orders load. Then you will see a big
+        orange button to open the real Amazon product page.
+      </p>
+      <button type="button" class="btn btn-start" id="btn-start">
+        ▶ START — load 3 sample products
+      </button>
+      <p class="tiny">Use this first so you understand the flow. Your real CSV is Step 2.</p>
     </div>
 
-    <div id="after" class="hidden">
-      <div class="stats">
-        <div class="stat"><span>Imported</span><b id="n-total">0</b></div>
-        <div class="stat"><span>With ASIN</span><b id="n-asin">0</b></div>
-        <div class="stat"><span>Queue left</span><b id="n-left">0</b></div>
-        <div class="stat"><span>Current #</span><b id="n-idx">—</b></div>
-      </div>
-
-      <div class="card">
-        <h2>3 · One at a time</h2>
-        <div class="row" style="margin-top:0;">
-          <button type="button" class="btn" id="btn-prev">← Prev</button>
-          <button type="button" class="btn btn-ok" id="btn-next">Next →</button>
-          <button type="button" class="btn btn-ghost" id="btn-copy">Copy listing pack</button>
-          <button type="button" class="btn btn-ghost" id="btn-open">Open Amazon product</button>
-        </div>
-        <div id="current" style="margin-top:14px;"></div>
-        <label style="display:block;margin-top:12px;font-size:0.75rem;color:var(--mist);text-transform:uppercase;letter-spacing:.06em;">Listing pack (edit then copy)</label>
-        <textarea id="pack" spellcheck="false"></textarea>
-      </div>
-
-      <div class="card">
-        <h2>4 · All imported items</h2>
-        <div style="overflow-x:auto;">
-          <table>
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Title</th>
-                <th>ASIN</th>
-                <th>Paid</th>
-                <th>Link</th>
-              </tr>
-            </thead>
-            <tbody id="tbody"></tbody>
-          </table>
-        </div>
-      </div>
+    <!-- STEP 2 -->
+    <div class="step">
+      <div class="step-num">STEP 2 · YOUR REAL ORDERS (optional)</div>
+      <h2>Upload Amazon order CSV</h2>
+      <p>Only after you have a CSV from Amazon on your computer:</p>
+      <ol class="howto">
+        <li>Amazon.com → Account → Your Orders (or “Download order reports”)</li>
+        <li>Get the <b>CSV</b> file onto this computer</li>
+        <li>Press the button below and choose that file</li>
+      </ol>
+      <button type="button" class="btn btn-file" id="btn-pick">
+        Choose my orders CSV file…
+      </button>
+      <input type="file" id="file" accept=".csv,text/csv,text/plain" />
+      <p class="tiny" id="file-label"></p>
     </div>
 
-    <div class="card" style="margin-top:8px;">
-      <h2>Not this page?</h2>
-      <p style="color:var(--mist);font-size:0.9rem;">
-        <a class="link" href="https://revvel-standards.vercel.app/">revvel-standards.vercel.app</a>
-        is the public hub (folders / oAudrey / docs). It does <strong>not</strong> upload orders.
-        Full Node app (email + FB): <code>reesereviews/vine-marketplace</code> on GitHub — run locally or deploy that folder separately.
+    <!-- STEP 3 — only after load -->
+    <div class="step hidden" id="step3">
+      <div class="step-num">STEP 3 · THIS PRODUCT</div>
+      <h2>Open on Amazon · copy listing</h2>
+      <p class="warn" id="hint">
+        The orange button opens Amazon in a new tab for THIS product’s photos and page.
+      </p>
+
+      <div class="product-box" id="product-box"></div>
+
+      <a class="btn btn-amazon hidden" id="btn-amazon" href="#" target="_blank" rel="noopener">
+        🛒 OPEN THIS PRODUCT ON AMAZON
+      </a>
+      <p class="tiny hidden" id="no-asin">
+        This row has no ASIN, so there is no Amazon product link. Use Next or fix the CSV.
+      </p>
+
+      <button type="button" class="btn btn-next" id="btn-next">Next product →</button>
+      <button type="button" class="btn btn-copy" id="btn-prev">← Previous product</button>
+      <button type="button" class="btn btn-copy" id="btn-copy">Copy listing text for Marketplace</button>
+
+      <label class="tiny" style="display:block;margin-top:12px;">Listing text (you can edit, then copy)</label>
+      <textarea id="pack" spellcheck="false"></textarea>
+    </div>
+
+    <div class="step">
+      <div class="step-num">REMEMBER</div>
+      <p style="margin:0;">
+        <b>Green button</b> = load list.<br />
+        <b>Orange button</b> = go to Amazon for that product.<br />
+        <b>Dashed “Choose CSV”</b> = pick a file on your PC (not a website link).
       </p>
     </div>
   </div>
@@ -212,15 +218,19 @@
 
   <script>
 (function () {
-  document.getElementById('self-url').textContent = location.href.split('#')[0];
-
   const state = { products: [], index: 0 };
 
   function toast(msg) {
     const el = document.getElementById('toast');
     el.textContent = msg;
     el.classList.add('show');
-    setTimeout(() => el.classList.remove('show'), 2200);
+    setTimeout(() => el.classList.remove('show'), 2800);
+  }
+
+  function setStatus(html, empty) {
+    const box = document.getElementById('status');
+    document.getElementById('status-text').innerHTML = html;
+    box.classList.toggle('empty', !!empty);
   }
 
   function normHeader(h) {
@@ -289,115 +299,81 @@
   }
 
   function rowToProduct(row, i) {
-    const orderId = pick(row, ['order id', 'order number', 'order #']) || `CSV-${i + 1}`;
+    const orderId = pick(row, ['order id', 'order number', 'order #']) || `ROW-${i + 1}`;
     const asin = extractAsin(pick(row, ['asin', 'asin/isbn', 'asin isbn', 'isbn']));
     const title = pick(row, ['title', 'product name', 'product title', 'item name', 'description'])
       || (asin ? `Amazon product ${asin}` : `Item ${i + 1}`);
     const paid = money(pick(row, ['item total', 'total owed', 'unit price', 'purchase price', 'price', 'shipment item subtotal']));
-    const productUrl = asin ? `https://www.amazon.com/dp/${asin}` : (pick(row, ['product url', 'url', 'link']) || null);
-    const suggest = Math.max(1, Math.round(paid * 0.8 * 100) / 100);
-    return {
-      orderId,
-      asin,
-      productTitle: title.slice(0, 200),
-      paidPrice: paid,
-      suggestedPrice: paid ? suggest : null,
-      productUrl,
-      orderDate: pick(row, ['order date', 'date', 'purchase date']) || '',
-    };
-  }
-
-  function importText(text, label) {
-    const rows = parseCsv(text);
-    const products = rows.map(rowToProduct).filter((p) => p.asin || (p.productTitle && !p.productTitle.startsWith('Item ')));
-    state.products = products;
-    state.index = 0;
-    document.getElementById('file-name').textContent = label || `${products.length} products`;
-    document.getElementById('after').classList.toggle('hidden', products.length === 0);
-    if (!products.length) {
-      toast('No products found — need Title and/or ASIN columns');
-      return;
-    }
-    renderAll();
-    toast(`Loaded ${products.length} products`);
+    const productUrl = asin ? `https://www.amazon.com/dp/${asin}` : null;
+    const suggestedPrice = paid ? Math.max(1, Math.round(paid * 0.8 * 100) / 100) : null;
+    return { orderId, asin, productTitle: title.slice(0, 200), paidPrice: paid, suggestedPrice, productUrl };
   }
 
   function listingPack(p) {
-    const price = p.suggestedPrice != null ? `$${p.suggestedPrice.toFixed(2)}` : '(set price)';
+    const price = p.suggestedPrice != null ? `$${p.suggestedPrice.toFixed(2)}` : '(set your price)';
     return [
       p.productTitle,
       '',
       `Asking: ${price}`,
-      p.paidPrice ? `(I paid about $${p.paidPrice.toFixed(2)})` : '',
+      p.paidPrice ? `(About what I paid: $${p.paidPrice.toFixed(2)})` : '',
       '',
       p.asin ? `ASIN: ${p.asin}` : '',
       p.productUrl || '',
       '',
-      'From my Amazon orders. Condition: as noted — ask questions before buying.',
-      'Local pickup / shipping as agreed. Thanks for looking!',
-    ].filter((line, idx, arr) => !(line === '' && arr[idx - 1] === '')).join('\n');
+      'From my orders. Message me with questions. Local pickup / shipping as agreed.',
+    ].filter((line, i, a) => !(line === '' && a[i - 1] === '')).join('\n');
   }
 
-  function renderAll() {
-    const n = state.products.length;
-    const withAsin = state.products.filter((p) => p.asin).length;
-    document.getElementById('n-total').textContent = n;
-    document.getElementById('n-asin').textContent = withAsin;
-    document.getElementById('n-left').textContent = Math.max(0, n - state.index - 1);
-    document.getElementById('n-idx').textContent = n ? `${state.index + 1}/${n}` : '—';
-
-    const tbody = document.getElementById('tbody');
-    tbody.innerHTML = state.products.map((p, i) => `
-      <tr class="${i === state.index ? 'active' : ''}" data-i="${i}">
-        <td>${i + 1}</td>
-        <td>${esc(p.productTitle)}</td>
-        <td>${esc(p.asin || '—')}</td>
-        <td>${p.paidPrice ? '$' + p.paidPrice.toFixed(2) : '—'}</td>
-        <td>${p.productUrl ? `<a class="link" href="${esc(p.productUrl)}" target="_blank" rel="noopener">dp/${esc(p.asin)}</a>` : '—'}</td>
-      </tr>`).join('');
-
-    tbody.querySelectorAll('tr').forEach((tr) => {
-      tr.addEventListener('click', (e) => {
-        if (e.target.tagName === 'A') return;
-        state.index = Number(tr.dataset.i);
-        renderCurrent();
-        renderAll();
-      });
-    });
-
-    renderCurrent();
+  function loadProducts(products, label) {
+    state.products = products;
+    state.index = 0;
+    document.getElementById('step3').classList.remove('hidden');
+    document.getElementById('file-label').textContent = label || '';
+    render();
+    toast('List loaded. Use the orange button to open Amazon.');
+    // Scroll to product section
+    document.getElementById('step3').scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
-  function renderCurrent() {
+  function render() {
     const p = state.products[state.index];
-    const box = document.getElementById('current');
+    const n = state.products.length;
     if (!p) {
-      box.innerHTML = '';
-      document.getElementById('pack').value = '';
+      setStatus('No list loaded yet. Press the green button first.', true);
       return;
     }
-    document.getElementById('n-left').textContent = Math.max(0, state.products.length - state.index - 1);
-    document.getElementById('n-idx').textContent = `${state.index + 1}/${state.products.length}`;
-    box.innerHTML = `
-      <div class="product">
-        <div class="ph">Open Amazon<br>for photos</div>
-        <div>
-          <h3>${esc(p.productTitle)}</h3>
-          <div class="meta">
-            Order ${esc(p.orderId)}
-            ${p.asin ? ' · ASIN ' + esc(p.asin) : ''}
-            ${p.orderDate ? ' · ' + esc(p.orderDate) : ''}
-            ${p.paidPrice ? ' · paid $' + p.paidPrice.toFixed(2) : ''}
-            ${p.suggestedPrice != null ? ' · suggest $' + p.suggestedPrice.toFixed(2) : ''}
-          </div>
-          ${p.productUrl ? `<a class="link" href="${esc(p.productUrl)}" target="_blank" rel="noopener">${esc(p.productUrl)}</a>` : '<span style="color:var(--warn)">No ASIN — add product link manually</span>'}
-          <p style="margin-top:8px;font-size:0.8rem;color:var(--mist);">
-            Photos: open the product page (link above) and save 3–5 Amazon images for your Marketplace listing.
-            This page does not store your CSV on a server.
-          </p>
-        </div>
-      </div>`;
+
+    setStatus(
+      `Viewing product <strong>${state.index + 1} of ${n}</strong>. ` +
+      (p.productUrl
+        ? 'Press the <strong>orange</strong> button to open it on Amazon.'
+        : 'This row has no ASIN — cannot open Amazon for this one.'),
+      false
+    );
+
+    document.getElementById('product-box').innerHTML =
+      '<h3>' + esc(p.productTitle) + '</h3>' +
+      '<div class="meta">Order ' + esc(p.orderId) +
+      (p.asin ? ' · ASIN ' + esc(p.asin) : ' · <span class="warn">no ASIN</span>') +
+      (p.paidPrice ? ' · paid $' + p.paidPrice.toFixed(2) : '') +
+      (p.suggestedPrice != null ? ' · suggest $' + p.suggestedPrice.toFixed(2) : '') +
+      '</div>';
+
+    const a = document.getElementById('btn-amazon');
+    const no = document.getElementById('no-asin');
+    if (p.productUrl) {
+      a.href = p.productUrl;
+      a.classList.remove('hidden');
+      no.classList.add('hidden');
+    } else {
+      a.removeAttribute('href');
+      a.classList.add('hidden');
+      no.classList.remove('hidden');
+    }
+
     document.getElementById('pack').value = listingPack(p);
+    document.getElementById('btn-prev').disabled = state.index <= 0;
+    document.getElementById('btn-next').disabled = state.index >= n - 1;
   }
 
   function esc(s) {
@@ -405,67 +381,73 @@
       .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 
-  const drop = document.getElementById('drop');
-  const fileInput = document.getElementById('file');
-
-  ['dragenter', 'dragover'].forEach((ev) => {
-    drop.addEventListener(ev, (e) => { e.preventDefault(); drop.classList.add('drag'); });
-  });
-  ['dragleave', 'drop'].forEach((ev) => {
-    drop.addEventListener(ev, (e) => { e.preventDefault(); drop.classList.remove('drag'); });
-  });
-  drop.addEventListener('drop', (e) => {
-    const f = e.dataTransfer.files && e.dataTransfer.files[0];
-    if (f) readFile(f);
-  });
-  fileInput.addEventListener('change', () => {
-    if (fileInput.files[0]) readFile(fileInput.files[0]);
-  });
-
-  function readFile(f) {
-    const reader = new FileReader();
-    reader.onload = () => importText(String(reader.result || ''), f.name);
-    reader.onerror = () => toast('Could not read file');
-    reader.readAsText(f);
-  }
-
-  document.getElementById('btn-demo').onclick = () => {
+  // STEP 1 — sample
+  document.getElementById('btn-start').onclick = function () {
     const sample = [
       'Order ID,Order Date,Title,ASIN,Unit Price,Quantity',
-      '112-1111111-2222222,2026-01-10,Example Kitchen Blender,B08C4KWM9T,39.99,1',
-      '112-3333333-4444444,2026-01-12,Example LED Desk Lamp,B09ABCDEF1,18.50,1',
-      '112-5555555-6666666,2026-01-14,Example Yoga Mat,B07XYZ1234,22.00,1',
+      // Real-looking ASIN pattern; may or may not still be live on Amazon — still teaches the button
+      '112-1111111-2222222,2026-01-10,Kitchen Blender (sample row),B08N5WRWNW,39.99,1',
+      '112-3333333-4444444,2026-01-12,LED Desk Lamp (sample row),B07GZD2LTB,18.50,1',
+      '112-5555555-6666666,2026-01-14,Yoga Mat (sample row),B01LP0U5X0,22.00,1',
     ].join('\n');
-    importText(sample, 'sample.csv');
+    const rows = parseCsv(sample);
+    loadProducts(rows.map(rowToProduct), 'sample (3 products)');
   };
 
-  document.getElementById('btn-next').onclick = () => {
+  // STEP 2 — file
+  document.getElementById('btn-pick').onclick = function () {
+    document.getElementById('file').click();
+  };
+  document.getElementById('file').onchange = function () {
+    const f = this.files && this.files[0];
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = function () {
+      const rows = parseCsv(String(reader.result || ''));
+      const products = rows.map(rowToProduct).filter(function (p) {
+        return p.asin || (p.productTitle && !/^Item \d+$/.test(p.productTitle));
+      });
+      if (!products.length) {
+        toast('No products found. CSV needs Title and/or ASIN columns.');
+        setStatus('CSV opened but no products found. Check it has ASIN or Title columns.', true);
+        return;
+      }
+      loadProducts(products, f.name + ' · ' + products.length + ' products');
+    };
+    reader.onerror = function () { toast('Could not read that file'); };
+    reader.readAsText(f);
+  };
+
+  document.getElementById('btn-next').onclick = function () {
     if (state.index < state.products.length - 1) {
       state.index++;
-      renderAll();
-    } else toast('End of list');
+      render();
+    } else toast('That was the last product.');
   };
-  document.getElementById('btn-prev').onclick = () => {
+  document.getElementById('btn-prev').onclick = function () {
     if (state.index > 0) {
       state.index--;
-      renderAll();
+      render();
     }
   };
-  document.getElementById('btn-open').onclick = () => {
-    const p = state.products[state.index];
-    if (p && p.productUrl) window.open(p.productUrl, '_blank', 'noopener');
-    else toast('No product URL');
-  };
-  document.getElementById('btn-copy').onclick = async () => {
+  document.getElementById('btn-copy').onclick = async function () {
     const text = document.getElementById('pack').value;
     try {
       await navigator.clipboard.writeText(text);
-      toast('Listing pack copied');
-    } catch {
+      toast('Listing text copied — paste into Marketplace.');
+    } catch (e) {
       document.getElementById('pack').select();
-      toast('Select text and copy (Ctrl+C)');
+      toast('Press Ctrl+C to copy the selected text.');
     }
   };
+
+  // Amazon button: if someone clicks when hidden/no href, explain
+  document.getElementById('btn-amazon').addEventListener('click', function (e) {
+    if (!this.getAttribute('href')) {
+      e.preventDefault();
+      toast('Load products first (green button), then orange opens Amazon.');
+    }
+  });
 })();
   </script>
 </body>


### PR DESCRIPTION
UX rewrite so click-here is not confused with product links. Green START loads samples; orange opens Amazon for current product.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR redesigns the Amazon orders upload page to fix user confusion around which elements are clickable product links versus file upload controls. The interface now uses a prominent **green START button** to load sample products (teaching the workflow) and a large **orange OPEN THIS PRODUCT ON AMAZON button** to navigate to actual product pages. The previous design's "click here" dashed box was mistaken for a product link when it was actually a file picker, so the new version explicitly labels it as `Choose my orders CSV file…` and restructures the page into numbered steps with color-coded buttons to guide users through the correct sequence: load a list first, then use the orange button to open Amazon for each product.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/vine-orders/README.md` |
| 2 | `docs/vine-orders/index.html` |
| 3 | `vine-orders.html` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Amazon orders upload page so users clearly see the green START to load a list and the orange button to open the product on Amazon, eliminating confusion with the file picker.

- **Bug Fixes**
  - Step-based flow with a green "START — load 3 sample products" and a large orange "OPEN THIS PRODUCT ON AMAZON" for the current item.
  - Replaced the vague drop zone with a clear dashed "Choose my orders CSV file…" button (local file chooser, not a link).
  - Added status hints, toasts, and disabled states; shows when a row has no ASIN (no Amazon link).
  - Streamlined the product panel and listing text editor with Next/Previous controls; removed noisy stats/table.

<sup>Written for commit 161a38422daa6c31ae1c01c701f659151c4353f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

