### PR TITLE
feat(vine-marketplace): Path A — local packs + lifestyle image pipeline

### DIFF
--- a/reesereviews/vine-marketplace/.env.example
+++ b/reesereviews/vine-marketplace/.env.example
@@ -77,3 +77,16 @@ FETCH_CRON=0 8,14,20 * * *
 
 # Cron schedule for reposting stale listings (default: Monday 10am)
 REPOST_CRON=0 10 * * 1
+
+# ─────────────────────────────────────────────
+# Path A — Lifestyle marketplace packs (local)
+# ─────────────────────────────────────────────
+
+# Where packs are written (default: Documents/MarketplacePacks)
+# MARKETPLACE_PACKS_DIR=C:\Users\YOU\Documents\MarketplacePacks
+
+# Required for lifestyle / in-use image generation (not stock-only)
+OPENROUTER_API_KEY=
+
+# Optional image model on OpenRouter (must support image output)
+# OPENROUTER_IMAGE_MODEL=google/gemini-2.5-flash-image-preview

--- a/reesereviews/vine-marketplace/README.md
+++ b/reesereviews/vine-marketplace/README.md
@@ -84,10 +84,46 @@ curl -s "http://localhost:3030/api/queue/next?enrich=1" | jq .
 curl -s "http://localhost:3030/api/products/ORDER-ID/listing-pack" | jq .
 ```
 
-### 6. Vercel
+### 6. Path A — personal launch (YOU run this on your PC)
+
+This is the real app for generating **lifestyle (non-stock) images** and saving packs to **your drive**.
+
+```bash
+cd reesereviews/vine-marketplace
+cp .env.example .env
+# Edit .env → set OPENROUTER_API_KEY=...  (required for lifestyle images)
+npm install
+npm start
+```
+
+Open **http://localhost:3030**
+
+1. **Import CSV** (your Order History.csv)  
+2. **Next product**  
+3. **Generate 3 lifestyle images → save pack**  
+4. Watch the **step list** (parse → link → reference → lifestyle 1/3… → save)  
+5. Files appear under:
+
+```text
+Documents\MarketplacePacks\{ASIN}\
+  listing.txt
+  meta.json
+  00-product-reference.jpg   (if Amazon fetch worked)
+  01-lifestyle.jpg
+  02-lifestyle.jpg
+  03-lifestyle.jpg
+```
+
+Override folder: `MARKETPLACE_PACKS_DIR=C:\path\to\folder` in `.env`.
+
+Without `OPENROUTER_API_KEY`, the job still saves **listing.txt** and shows the process; lifestyle step will error clearly.
+
+### 7. Vercel (static / API only — not the main personal path)
 
 Root directory for deploy: `reesereviews/vine-marketplace`  
-Entry: `api/index.js` + `vercel.json`. Inventory on serverless uses `/tmp` (ephemeral unless you add a DB later).
+Entry: `api/index.js` + `vercel.json`. Inventory on serverless uses `/tmp` (ephemeral).  
+**Lifestyle packs need a long-running local server** (Path A above) so images write to your Documents folder.
+
 
 
 ---

--- a/reesereviews/vine-marketplace/index.js
+++ b/reesereviews/vine-marketplace/index.js
@@ -23,6 +23,8 @@ const { calculateListingPrice, formatUSD } = require('./lib/price-calculator');
 const { postProduct, repostProduct } = require('./lib/facebook-poster');
 const { importOrderCsv } = require('./lib/csv-import');
 const { enrichProduct, buildListingPack } = require('./lib/product-link');
+const packStore = require('./lib/pack-store');
+const { startPipeline, getJob } = require('./lib/lifestyle-pipeline');
 const inventory = require('./lib/inventory');
 const rfy = require('./lib/rfy-tracker');
 
@@ -285,6 +287,67 @@ app.get('/api/products/:orderId/listing-pack', (req, res) => {
   }
 });
 
+// ── Path A: local Marketplace packs (progress + disk storage) ─────────────
+
+app.get('/api/packs/config', (_req, res) => {
+  res.json({
+    ...packStore.openHint(),
+    openRouterConfigured: Boolean(process.env.OPENROUTER_API_KEY),
+    imageModel: process.env.OPENROUTER_IMAGE_MODEL || 'google/gemini-2.5-flash-image-preview',
+    port: PORT,
+  });
+});
+
+/** Start lifestyle pack job for one inventory product (one-at-a-time). */
+app.post('/api/packs/generate', (req, res) => {
+  try {
+    const { orderId, count } = req.body || {};
+    if (!orderId) return res.status(400).json({ error: 'orderId required' });
+    const product = inventory.getByOrderId(orderId);
+    if (!product) return res.status(404).json({ error: 'Product not in inventory — import CSV first' });
+    const job = startPipeline(product, { count: count || 3 });
+    res.status(202).json({
+      jobId: job.id,
+      status: job.status,
+      packDir: job.packDir,
+      steps: job.steps,
+      hasOpenRouter: job.hasOpenRouter,
+      poll: `/api/packs/jobs/${job.id}`,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/packs/jobs/:jobId', (req, res) => {
+  const job = getJob(req.params.jobId);
+  if (!job) return res.status(404).json({ error: 'Job not found' });
+  res.json(job);
+});
+
+app.get('/api/packs/:key', (req, res) => {
+  try {
+    const key = req.params.key;
+    // Prefer inventory lookup by orderId, else treat as ASIN folder name
+    let product = inventory.getByOrderId(key);
+    if (!product) product = { asin: key, orderId: key };
+    const listed = packStore.listPack(product);
+    res.json(listed);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Serve saved pack files so the dashboard can show thumbnails
+app.use(
+  '/pack-files',
+  express.static(packStore.packsRoot(), {
+    fallthrough: true,
+    index: false,
+    maxAge: '1h',
+  })
+);
+
 // Post selected (or all unlisted) products
 app.post('/api/post', async (req, res) => {
   const { orderIds, dryRun = false, limit } = req.body;
@@ -501,9 +564,12 @@ function main() {
 
   // Local server mode
   app.listen(PORT, () => {
-    console.log(`\n🛒  Vine → Marketplace Dashboard`);
-    console.log(`   http://localhost:${PORT}`);
-    console.log(`   CSV: POST /api/import/csv  |  Next: GET /api/queue/next?enrich=1\n`);
+    const packs = packStore.openHint();
+    console.log(`\n🛒  Vine → Marketplace Dashboard (Path A — personal packs)`);
+    console.log(`   Open:  http://localhost:${PORT}`);
+    console.log(`   Packs: ${packs.packsRoot}`);
+    console.log(`   OpenRouter image key: ${process.env.OPENROUTER_API_KEY ? 'yes' : 'NO — set OPENROUTER_API_KEY in .env'}`);
+    console.log(`   CSV import → select product → Generate 3 lifestyle images → files on disk\n`);
     startScheduler();
   });
 }

--- a/reesereviews/vine-marketplace/lib/lifestyle-pipeline.js
+++ b/reesereviews/vine-marketplace/lib/lifestyle-pipeline.js
@@ -1,0 +1,325 @@
+/**
+ * One-product pipeline: parse identity → product ref image → 3–5 lifestyle shots → local pack.
+ *
+ * Progress is recorded on a job object the UI can poll.
+ * Image generation uses OpenRouter when OPENROUTER_API_KEY is set.
+ * Without a key, the pack still gets listing.txt + product reference (if fetchable).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { attachProductLink, productUrlFromAsin } = require('./amazon-parser');
+const { enrichProduct, buildListingPack } = require('./product-link');
+const { calculateListingPrice } = require('./price-calculator');
+const packStore = require('./pack-store');
+
+const fetchFn =
+  typeof globalThis.fetch === 'function'
+    ? globalThis.fetch.bind(globalThis)
+    : (...args) => require('node-fetch')(...args);
+
+/** @type {Map<string, object>} */
+const jobs = new Map();
+
+function newJobId() {
+  return `job_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function getJob(id) {
+  return jobs.get(id) || null;
+}
+
+function setStep(job, id, status, detail = '') {
+  const step = job.steps.find((s) => s.id === id);
+  if (step) {
+    step.status = status; // pending | running | done | error | skipped
+    step.detail = detail;
+    step.updatedAt = new Date().toISOString();
+  }
+  job.updatedAt = new Date().toISOString();
+}
+
+function createJob(product, opts = {}) {
+  const count = Math.min(5, Math.max(3, parseInt(opts.count || '3', 10) || 3));
+  const job = {
+    id: newJobId(),
+    status: 'queued', // queued | running | done | error
+    product: attachProductLink({ ...product }),
+    count,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    packDir: null,
+    images: [],
+    error: null,
+    hasOpenRouter: Boolean(process.env.OPENROUTER_API_KEY),
+    steps: [
+      { id: 'parse', label: 'Parse product from order', status: 'pending', detail: '' },
+      { id: 'link', label: 'Build Amazon product link (ASIN)', status: 'pending', detail: '' },
+      { id: 'ref', label: 'Fetch product reference image', status: 'pending', detail: '' },
+      { id: 'lifestyle', label: `Generate ${count} lifestyle / in-use images`, status: 'pending', detail: '' },
+      { id: 'save', label: 'Save pack to your Documents folder', status: 'pending', detail: '' },
+    ],
+  };
+  jobs.set(job.id, job);
+  return job;
+}
+
+const LIFESTYLE_PROMPTS = [
+  (title) =>
+    `Amateur smartphone photo of this product in real home use: ${title}. Lived-in kitchen or living space, natural light, slight phone grain, show the product being used for its purpose, not a white-background stock catalog shot. No readable faces.`,
+  (title) =>
+    `Casual close-up phone photo showing a key feature of: ${title}. Hands only (no face) demonstrating how it works in a real house. Realistic lighting, not studio stock photography.`,
+  (title) =>
+    `Realistic amateur photo of: ${title} in another everyday room (laundry, bathroom, hallway, or desk) with ordinary clutter, product clearly visible and in use. Phone-camera quality, not polished stock.`,
+  (title) =>
+    `Wide casual phone photo of: ${title} stored or used in a narrow real-home space, demonstrating why someone bought it. Natural window light, authentic home, not e-commerce studio.`,
+  (title) =>
+    `Detail shot of: ${title} highlighting materials/features (wheels, buttons, texture, fit) as a normal person would photograph for a resale listing. Amateur, honest, not stock.`,
+];
+
+async function downloadToFile(url, destPath) {
+  const res = await fetchFn(url, {
+    redirect: 'follow',
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      Accept: 'image/*,*/*',
+    },
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} downloading image`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  packStore.writeBinary(destPath, buf);
+  return destPath;
+}
+
+/**
+ * Call OpenRouter for an image. Supports a few response shapes used by image models.
+ */
+async function openRouterImage(prompt, { refPath = null, model = null } = {}) {
+  const key = process.env.OPENROUTER_API_KEY;
+  if (!key) throw new Error('OPENROUTER_API_KEY not set');
+
+  const modelId =
+    model ||
+    process.env.OPENROUTER_IMAGE_MODEL ||
+    'google/gemini-2.5-flash-image-preview';
+
+  const content = [{ type: 'text', text: prompt }];
+  if (refPath && fs.existsSync(refPath)) {
+    const b64 = fs.readFileSync(refPath).toString('base64');
+    const ext = path.extname(refPath).toLowerCase().replace('.', '') || 'jpeg';
+    const mime = ext === 'png' ? 'image/png' : ext === 'webp' ? 'image/webp' : 'image/jpeg';
+    content.push({
+      type: 'image_url',
+      image_url: { url: `data:${mime};base64,${b64}` },
+    });
+  }
+
+  const res = await fetchFn('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://github.com/midnghtsapphire/revvel-standards',
+      'X-Title': 'vine-marketplace-lifestyle-packs',
+    },
+    body: JSON.stringify({
+      model: modelId,
+      messages: [{ role: 'user', content }],
+    }),
+  });
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const msg = data.error?.message || data.message || JSON.stringify(data).slice(0, 200);
+    throw new Error(`OpenRouter ${res.status}: ${msg}`);
+  }
+
+  // Try message images array (some models)
+  const msg = data.choices?.[0]?.message;
+  if (msg?.images?.[0]?.image_url?.url) {
+    return bufferFromDataUrl(msg.images[0].image_url.url);
+  }
+  // content parts
+  const parts = Array.isArray(msg?.content) ? msg.content : null;
+  if (parts) {
+    for (const p of parts) {
+      if (p.type === 'image_url' && p.image_url?.url) return bufferFromDataUrl(p.image_url.url);
+      if (p.inline_data?.data) {
+        return Buffer.from(p.inline_data.data, 'base64');
+      }
+    }
+  }
+  // string content with data URL
+  if (typeof msg?.content === 'string') {
+    const m = msg.content.match(/data:image\/[a-zA-Z0-9+.-]+;base64,[A-Za-z0-9+/=]+/);
+    if (m) return bufferFromDataUrl(m[0]);
+    // markdown image with http
+    const http = msg.content.match(/https?:\/\/\S+\.(?:jpg|jpeg|png|webp)/i);
+    if (http) {
+      const r2 = await fetchFn(http[0]);
+      if (r2.ok) return Buffer.from(await r2.arrayBuffer());
+    }
+  }
+
+  throw new Error('OpenRouter returned no image bytes (check OPENROUTER_IMAGE_MODEL supports images)');
+}
+
+function bufferFromDataUrl(url) {
+  if (url.startsWith('data:')) {
+    const b64 = url.split(',')[1];
+    return Buffer.from(b64, 'base64');
+  }
+  throw new Error('Expected data URL for image');
+}
+
+/**
+ * Run full pipeline for one product. Updates job in place.
+ */
+async function runPipeline(job) {
+  job.status = 'running';
+  const product = attachProductLink({ ...job.product });
+  const dir = packStore.packDir(product);
+  job.packDir = dir;
+
+  try {
+    // 1 parse
+    setStep(job, 'parse', 'running', 'Reading title, ASIN, price…');
+    if (!product.productTitle && !product.asin) {
+      throw new Error('Product missing title and ASIN');
+    }
+    setStep(
+      job,
+      'parse',
+      'done',
+      `${(product.productTitle || '').slice(0, 80)} · ASIN ${product.asin || 'none'}`
+    );
+
+    // 2 link
+    setStep(job, 'link', 'running');
+    product.productUrl = product.productUrl || productUrlFromAsin(product.asin);
+    if (!product.productUrl) {
+      setStep(job, 'link', 'error', 'No ASIN — cannot build product URL');
+    } else {
+      setStep(job, 'link', 'done', product.productUrl);
+    }
+
+    // 3 reference image
+    setStep(job, 'ref', 'running', 'Enriching from product page…');
+    let refPath = path.join(dir, '00-product-reference.jpg');
+    try {
+      const enriched = await enrichProduct(product, { fetchImages: true });
+      Object.assign(product, enriched.product);
+      const urls = enriched.imageUrls || [];
+      if (urls[0]) {
+        await downloadToFile(urls[0], refPath);
+        setStep(job, 'ref', 'done', `Saved reference · ${urls.length} candidate URL(s)`);
+      } else {
+        refPath = null;
+        setStep(job, 'ref', 'skipped', enriched.fetchError || 'No product image URL (Amazon may block bots)');
+      }
+    } catch (err) {
+      refPath = null;
+      setStep(job, 'ref', 'skipped', err.message);
+    }
+
+    // 4 lifestyle
+    setStep(job, 'lifestyle', 'running', 'Starting…');
+    const images = [];
+    const key = process.env.OPENROUTER_API_KEY;
+    if (!key) {
+      setStep(
+        job,
+        'lifestyle',
+        'error',
+        'Set OPENROUTER_API_KEY in .env to generate lifestyle images. Pack will still save listing + reference.'
+      );
+    } else {
+      for (let i = 0; i < job.count; i++) {
+        const n = i + 1;
+        setStep(job, 'lifestyle', 'running', `Generating lifestyle image ${n} of ${job.count}…`);
+        const prompt = LIFESTYLE_PROMPTS[i % LIFESTYLE_PROMPTS.length](product.productTitle || product.asin);
+        try {
+          const buf = await openRouterImage(prompt, { refPath });
+          const name = `${String(n).padStart(2, '0')}-lifestyle.jpg`;
+          const full = path.join(dir, name);
+          packStore.writeBinary(full, buf);
+          images.push({ name, path: full, kind: 'lifestyle' });
+        } catch (err) {
+          setStep(job, 'lifestyle', 'error', `Image ${n} failed: ${err.message}`);
+          // continue others
+        }
+      }
+      if (images.length) {
+        setStep(job, 'lifestyle', 'done', `${images.length} lifestyle file(s) written`);
+      } else if (job.steps.find((s) => s.id === 'lifestyle').status !== 'error') {
+        setStep(job, 'lifestyle', 'error', 'No lifestyle images produced');
+      }
+    }
+    job.images = images;
+
+    // 5 save pack metadata
+    setStep(job, 'save', 'running');
+    const pricing = calculateListingPrice(product);
+    const listing = buildListingPack(product, pricing);
+    packStore.writeText(path.join(dir, 'listing.txt'), [
+      listing.title,
+      '',
+      `Asking: $${listing.suggestedPrice ?? '?'}`,
+      '',
+      listing.description,
+      '',
+      'Images in this folder:',
+      ...images.map((im) => ` - ${im.name}`),
+      refPath && fs.existsSync(refPath) ? ' - 00-product-reference.jpg' : null,
+      '',
+      `Product URL: ${product.productUrl || ''}`,
+      `Pack folder: ${dir}`,
+    ].filter(Boolean).join('\n'));
+
+    packStore.writeJson(path.join(dir, 'meta.json'), {
+      product,
+      pricing,
+      listing,
+      images: images.map((im) => im.name),
+      packDir: dir,
+      generatedAt: new Date().toISOString(),
+      jobId: job.id,
+    });
+
+    job.product = product;
+    setStep(job, 'save', 'done', dir);
+    job.status = images.length || fs.existsSync(path.join(dir, 'listing.txt')) ? 'done' : 'error';
+    if (job.status === 'error' && !job.error) job.error = 'Pack incomplete';
+  } catch (err) {
+    job.status = 'error';
+    job.error = err.message;
+    const running = job.steps.find((s) => s.status === 'running');
+    if (running) setStep(job, running.id, 'error', err.message);
+  }
+
+  job.updatedAt = new Date().toISOString();
+  return job;
+}
+
+function startPipeline(product, opts = {}) {
+  const job = createJob(product, opts);
+  // fire and forget
+  setImmediate(() => {
+    runPipeline(job).catch((err) => {
+      job.status = 'error';
+      job.error = err.message;
+    });
+  });
+  return job;
+}
+
+module.exports = {
+  startPipeline,
+  runPipeline,
+  getJob,
+  createJob,
+  jobs,
+};

--- a/reesereviews/vine-marketplace/lib/lifestyle-pipeline.test-helpers.js
+++ b/reesereviews/vine-marketplace/lib/lifestyle-pipeline.test-helpers.js
@@ -1,0 +1,6 @@
+/** Exported for unit tests that avoid network. */
+'use strict';
+
+module.exports = {
+  LIFESTYLE_COUNT_DEFAULT: 3,
+};

--- a/reesereviews/vine-marketplace/lib/pack-store.js
+++ b/reesereviews/vine-marketplace/lib/pack-store.js
@@ -1,0 +1,81 @@
+/**
+ * Marketplace pack storage on the owner's machine.
+ *
+ * Default: ~/Documents/MarketplacePacks/{asin-or-orderId}/
+ * Override: MARKETPLACE_PACKS_DIR
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function packsRoot() {
+  if (process.env.MARKETPLACE_PACKS_DIR) {
+    return path.resolve(process.env.MARKETPLACE_PACKS_DIR);
+  }
+  return path.join(os.homedir(), 'Documents', 'MarketplacePacks');
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function packKey(product) {
+  const asin = product.asin && String(product.asin).trim();
+  if (asin) return asin.toUpperCase();
+  return String(product.orderId || 'unknown').replace(/[^\w.-]+/g, '_');
+}
+
+function packDir(product) {
+  return ensureDir(path.join(packsRoot(), packKey(product)));
+}
+
+function writeJson(filePath, obj) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, JSON.stringify(obj, null, 2), 'utf8');
+}
+
+function writeText(filePath, text) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, text, 'utf8');
+}
+
+function writeBinary(filePath, buf) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, buf);
+}
+
+function listPack(product) {
+  const dir = packDir(product);
+  if (!fs.existsSync(dir)) return { dir, files: [] };
+  const files = fs.readdirSync(dir).map((name) => {
+    const full = path.join(dir, name);
+    const st = fs.statSync(full);
+    return { name, bytes: st.size, mtime: st.mtime.toISOString() };
+  });
+  return { dir, files };
+}
+
+function openHint() {
+  const root = packsRoot();
+  return {
+    packsRoot: root,
+    windowsExplorer: `explorer "${root}"`,
+    note: 'Lifestyle images and listing.txt are written here on YOUR computer.',
+  };
+}
+
+module.exports = {
+  packsRoot,
+  packKey,
+  packDir,
+  writeJson,
+  writeText,
+  writeBinary,
+  listPack,
+  openHint,
+  ensureDir,
+};

--- a/reesereviews/vine-marketplace/public/index.html
+++ b/reesereviews/vine-marketplace/public/index.html
@@ -257,20 +257,19 @@
     <button class="btn btn-primary" onclick="postSelected()" id="btn-post">🚀 Post to Marketplace</button>
   </div>
 
-  <!-- CSV import + one-at-a-time queue (no personal photos — ASIN → Amazon product link/images) -->
-  <div class="card" style="margin-bottom:20px;">
+  <!-- Path A: personal packs — CSV → one product → lifestyle images on YOUR disk -->
+  <div class="card" style="margin-bottom:20px;border-color:rgba(124,106,247,.45);">
     <div class="card-header">
-      <div class="card-title">Orders CSV → product links (vine-parser shape)</div>
-      <div style="font-size:12px;color:var(--mist);">No photos from you — ASIN builds amazon.com/dp/… then we pull product images</div>
+      <div class="card-title">Path A · My packs (local drive)</div>
+      <div style="font-size:12px;color:var(--mist);" id="packs-path-label">Loading pack folder…</div>
     </div>
     <div style="padding:16px 18px;display:flex;flex-wrap:wrap;gap:14px;align-items:flex-end;">
       <div class="field" style="flex:1;min-width:220px;">
-        <label>Amazon order history CSV</label>
+        <label>1 · Amazon order history CSV</label>
         <input type="file" id="csv-file" accept=".csv,text/csv" style="color:var(--mist);font-size:12px;">
       </div>
       <button class="btn btn-primary" onclick="importCsv()" id="btn-csv">⬆ Import CSV</button>
-      <button class="btn btn-ghost" onclick="queueNext(true)" id="btn-next">▶ Next item (enrich images)</button>
-      <button class="btn btn-ghost" onclick="queueNext(false)">▶ Next (link only)</button>
+      <button class="btn btn-ghost" onclick="queueNext(true)" id="btn-next">2 · Next product</button>
     </div>
     <div id="queue-panel" style="display:none;padding:0 18px 18px;">
       <div style="display:flex;gap:16px;flex-wrap:wrap;align-items:flex-start;background:rgba(0,0,0,.25);border-radius:12px;padding:14px;border:1px solid var(--border);">
@@ -279,14 +278,22 @@
           <div id="queue-title" style="font-weight:600;margin-bottom:6px;"></div>
           <div id="queue-meta" style="font-size:12px;color:var(--mist);margin-bottom:8px;"></div>
           <div id="queue-images" style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px;"></div>
-          <div style="display:flex;gap:8px;flex-wrap:wrap;">
-            <a id="queue-link" class="btn btn-sm btn-ghost" target="_blank" rel="noopener">Open product page</a>
-            <button class="btn btn-sm btn-primary" onclick="showListingPack()">Listing pack (copy)</button>
-            <button class="btn btn-sm btn-success" onclick="enrichCurrent()">Re-fetch images</button>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px;">
+            <button class="btn btn-success" onclick="generateLifestylePack()" id="btn-gen">3 · Generate 3 lifestyle images → save pack</button>
+            <a id="queue-link" class="btn btn-sm btn-ghost" target="_blank" rel="noopener">Amazon link (source)</a>
+            <button class="btn btn-sm btn-ghost" onclick="showListingPack()">Copy listing text</button>
           </div>
+          <!-- Live process steps -->
+          <div id="job-steps" style="font-size:13px;margin-bottom:10px;"></div>
+          <div id="job-thumbs" style="display:flex;gap:8px;flex-wrap:wrap;"></div>
+          <div id="job-pack-dir" style="font-size:12px;color:var(--accent-light);margin-top:8px;word-break:break-all;"></div>
           <pre id="queue-pack" style="display:none;margin-top:12px;font-size:11px;white-space:pre-wrap;color:var(--mist);max-height:220px;overflow:auto;"></pre>
         </div>
       </div>
+    </div>
+    <div style="padding:0 18px 16px;font-size:12px;color:var(--mist);">
+      Process you will see: parse → product link → reference image → lifestyle 1/3 · 2/3 · 3/3 → saved under Documents\MarketplacePacks\{ASIN}\
+      · Needs <code>OPENROUTER_API_KEY</code> in <code>.env</code> for lifestyle generation.
     </div>
   </div>
 
@@ -685,6 +692,101 @@ async function showListingPack() {
   }
 }
 
+// ── Path A: generate lifestyle pack with visible process ───────────────────
+let packPollTimer = null;
+
+function renderJobSteps(job) {
+  const box = document.getElementById('job-steps');
+  if (!job || !job.steps) { box.innerHTML = ''; return; }
+  const icon = { pending: '○', running: '◎', done: '✓', error: '✗', skipped: '–' };
+  const color = { pending: 'var(--mist)', running: 'var(--accent-light)', done: 'var(--success)', error: 'var(--danger)', skipped: 'var(--warn)' };
+  box.innerHTML = job.steps.map((s) =>
+    `<div style="padding:4px 0;color:${color[s.status] || 'var(--mist)'}">
+      <strong>${icon[s.status] || '·'} ${escHtml(s.label)}</strong>
+      <span style="opacity:.85"> — ${escHtml(s.detail || s.status)}</span>
+    </div>`
+  ).join('');
+  if (job.packDir) {
+    document.getElementById('job-pack-dir').textContent = 'Saved on your PC: ' + job.packDir;
+  }
+  const thumbs = document.getElementById('job-thumbs');
+  const key = (job.product && (job.product.asin || job.product.orderId)) || '';
+  if (job.images && job.images.length && key) {
+    thumbs.innerHTML = job.images.map((im) =>
+      `<img src="/pack-files/${encodeURIComponent(String(key).toUpperCase())}/${encodeURIComponent(im.name)}" 
+        class="thumb" style="width:88px;height:88px;object-fit:cover;border-radius:8px;border:1px solid var(--border);" alt="">`
+    ).join('');
+  }
+}
+
+async function generateLifestylePack() {
+  if (!currentQueueProduct) return toast('Import CSV and click Next product first');
+  const btn = document.getElementById('btn-gen');
+  btn.disabled = true;
+  log('Starting lifestyle pack job…', 'log-info');
+  try {
+    const r = await fetch(`${API}/packs/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orderId: currentQueueProduct.orderId, count: 3 }),
+    });
+    const data = await r.json();
+    if (data.error) throw new Error(data.error);
+    if (!data.hasOpenRouter) {
+      toast('No OPENROUTER_API_KEY — will save listing only. Add key to .env for lifestyle pics.');
+    }
+    renderJobSteps({ steps: data.steps, packDir: null, images: [], product: currentQueueProduct });
+    pollJob(data.jobId);
+  } catch (e) {
+    log('❌ ' + e.message, 'log-err');
+    toast(e.message);
+    btn.disabled = false;
+  }
+}
+
+function pollJob(jobId) {
+  if (packPollTimer) clearInterval(packPollTimer);
+  packPollTimer = setInterval(async () => {
+    try {
+      const r = await fetch(`${API}/packs/jobs/${encodeURIComponent(jobId)}`);
+      const job = await r.json();
+      if (job.error && job.status === 'error' && !job.steps) throw new Error(job.error);
+      renderJobSteps(job);
+      log(`Job ${job.status}: ${(job.steps || []).filter(s => s.status === 'done').length} steps done`, 'log-info');
+      if (job.status === 'done' || job.status === 'error') {
+        clearInterval(packPollTimer);
+        packPollTimer = null;
+        document.getElementById('btn-gen').disabled = false;
+        if (job.status === 'done') {
+          toast('Pack ready on your disk');
+          log('✅ Pack: ' + (job.packDir || ''), 'log-ok');
+        } else {
+          toast('Job finished with errors — check steps');
+        }
+      }
+    } catch (e) {
+      clearInterval(packPollTimer);
+      packPollTimer = null;
+      document.getElementById('btn-gen').disabled = false;
+      toast(e.message);
+    }
+  }, 1200);
+}
+
+async function loadPacksConfig() {
+  try {
+    const r = await fetch(`${API}/packs/config`);
+    const c = await r.json();
+    const el = document.getElementById('packs-path-label');
+    if (el) {
+      el.textContent = (c.openRouterConfigured ? '🟢 OpenRouter ready · ' : '🟠 Add OPENROUTER_API_KEY for lifestyle images · ')
+        + 'Saves to: ' + (c.packsRoot || '');
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
 async function postSelected() {
   const selected = [...selectedOrders];
   if (selected.length === 0) {
@@ -999,6 +1101,7 @@ document.addEventListener('click', async (evt) => {
   await loadProducts();
   await loadRfy();
   await loadRfySummary();
+  await loadPacksConfig();
 
   // Auto-refresh summary every 60s
   setInterval(async () => { await loadSummary(); await loadRfySummary(); }, 60000);

--- a/reesereviews/vine-marketplace/tests/vine-marketplace.test.js
+++ b/reesereviews/vine-marketplace/tests/vine-marketplace.test.js
@@ -248,6 +248,42 @@ test('attachProductLink is idempotent', () => {
   assert.strictEqual(p2.productUrl, p.productUrl);
 });
 
+// ── Pack store (local Documents path) ─────────────────────────────────────
+
+console.log('\n📁  Pack store');
+
+const packStore = require('../lib/pack-store');
+const os = require('os');
+const fs = require('fs');
+
+test('packsRoot defaults under home Documents', () => {
+  const prev = process.env.MARKETPLACE_PACKS_DIR;
+  delete process.env.MARKETPLACE_PACKS_DIR;
+  const root = packStore.packsRoot();
+  assert.ok(root.includes('MarketplacePacks'));
+  assert.ok(root.startsWith(os.homedir()) || root.includes(os.homedir()));
+  if (prev) process.env.MARKETPLACE_PACKS_DIR = prev;
+});
+
+test('packDir writes listing under MARKETPLACE_PACKS_DIR', () => {
+  const tmp = path.join(os.tmpdir(), 'mp-packs-test-' + Date.now());
+  process.env.MARKETPLACE_PACKS_DIR = tmp;
+  const dir = packStore.packDir({ asin: 'B08C4KWM9T', orderId: 'X' });
+  assert.ok(dir.includes('B08C4KWM9T'));
+  packStore.writeText(path.join(dir, 'listing.txt'), 'hello');
+  assert.ok(fs.existsSync(path.join(dir, 'listing.txt')));
+  const listed = packStore.listPack({ asin: 'B08C4KWM9T' });
+  assert.ok(listed.files.some((f) => f.name === 'listing.txt'));
+});
+
+test('createJob exposes visible process steps', () => {
+  const { createJob } = require('../lib/lifestyle-pipeline');
+  const job = createJob({ orderId: 'T1', asin: 'B08C4KWM9T', productTitle: 'Widget' }, { count: 3 });
+  assert.strictEqual(job.steps.length, 5);
+  assert.ok(job.steps.some((s) => s.id === 'lifestyle'));
+  assert.strictEqual(job.status, 'queued');
+});
+
 // ── Inventory ──────────────────────────────────────────────────────────────
 
 console.log('\n📦  Inventory');


### PR DESCRIPTION
Personal launch path: import CSV, process one product, watch steps (parse/link/ref/lifestyle/save), write packs to Documents/MarketplacePacks/{ASIN}/. Needs OPENROUTER_API_KEY for lifestyle images. UI progress on localhost:3030.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements **Path A**, a personal marketplace listing pipeline that lets users import Amazon order CSV files, select products one-at-a-time, and automatically generate lifestyle (in-use) images using OpenRouter AI models. The full process (parse → link → fetch reference image → generate 3 lifestyle images → save) is visible in real-time via a localhost dashboard at port 3030. All generated packs (listing text, metadata JSON, product reference image, and AI-generated lifestyle photos) are saved locally to the user's `Documents/MarketplacePacks/{ASIN}/` folder. The implementation includes a job-based pipeline with five visible steps, progress polling via REST endpoints, static file serving for image thumbnails, and graceful handling when the `OPENROUTER_API_KEY` is missing (listing still saves, but lifestyle generation is skipped).

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `reesereviews/vine-marketplace/.env.example` |
| 2 | `reesereviews/vine-marketplace/README.md` |
| 3 | `reesereviews/vine-marketplace/lib/pack-store.js` |
| 4 | `reesereviews/vine-marketplace/lib/lifestyle-pipeline.js` |
| 5 | `reesereviews/vine-marketplace/lib/lifestyle-pipeline.test-helpers.js` |
| 6 | `reesereviews/vine-marketplace/index.js` |
| 7 | `reesereviews/vine-marketplace/public/index.html` |
| 8 | `reesereviews/vine-marketplace/tests/vine-marketplace.test.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Path A: local marketplace packs. Generate lifestyle images on your PC via OpenRouter and save listing packs to Documents with a live progress UI.

- New Features
  - Local pack storage under Documents/MarketplacePacks (override with `MARKETPLACE_PACKS_DIR`).
  - One-product lifestyle pipeline with visible steps (parse → link → reference → lifestyle → save). Defaults to 3 images; saves listing-only if `OPENROUTER_API_KEY` is not set.
  - New API: GET `/api/packs/config`, POST `/api/packs/generate`, GET `/api/packs/jobs/:jobId`, GET `/api/packs/:key`, and static `/pack-files` for thumbnails.
  - Dashboard Path A panel: Import CSV → Next product → Generate lifestyle images. Shows step status, thumbnails, and pack folder path.

- Migration
  - Copy `.env.example` to `.env`. Set `OPENROUTER_API_KEY`. Optional: `OPENROUTER_IMAGE_MODEL`, `MARKETPLACE_PACKS_DIR`.
  - Run `npm start`, open http://localhost:3030, import CSV, click Next product, then Generate.
  - Vercel deploy remains API/static only; lifestyle packs must run locally.

<sup>Written for commit 93478fc28121aa1cb2744141a52372df29e992ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

