### PR TITLE
feat: simple Vercel marketplace relister (one URL, no local hoops)

### DIFF
--- a/START_HERE_CALL_CHAIN.md
+++ b/START_HERE_CALL_CHAIN.md
@@ -216,3 +216,11 @@ _Last intent: stop hunting folders; one root file for start → next. Detail liv
 
 That page accepts your CSV in the browser. The main Vercel site only shows docs/folders.
 
+
+---
+
+## Simple Marketplace Relister (Vercel — no local hoops)
+
+App code: `products/marketplace-relister`  
+Deploy as its **own** Vercel project (Root Directory = `products/marketplace-relister`).  
+Set `OPENROUTER_API_KEY` once in Vercel. Bookmark that app URL only.

--- a/products/marketplace-relister/README.md
+++ b/products/marketplace-relister/README.md
@@ -1,0 +1,36 @@
+# Marketplace Relister (simple Vercel app)
+
+**One URL. No local npm. No hopping.**
+
+1. Open the deployed site  
+2. Upload Amazon order CSV  
+3. Click **Generate 3 lifestyle pictures**  
+4. **Download** the images to your computer  
+5. **Next product**
+
+## Deploy (one-time setup)
+
+1. [Vercel](https://vercel.com) → Add New Project → import `midnghtsapphire/revvel-standards`
+2. **Root Directory:** `products/marketplace-relister`
+3. Framework: Next.js (auto)
+4. Environment variables:
+   - `OPENROUTER_API_KEY` = your key  
+   - optional: `OPENROUTER_IMAGE_MODEL` = `google/gemini-2.5-flash-image-preview`
+5. Deploy → copy the URL (e.g. `https://marketplace-relister.vercel.app`)
+
+That URL is the only one you bookmark.
+
+## Local dev (optional)
+
+```bash
+cd products/marketplace-relister
+npm install
+npm run dev
+# http://localhost:3040
+```
+
+## Notes
+
+- CSV is parsed **in the browser** (not stored on the server).
+- Images are generated on the server, shown in the page, downloaded by you.
+- Not the main hub (`revvel-standards.vercel.app`) — this is its **own** Vercel project.

--- a/products/marketplace-relister/app/api/generate/route.js
+++ b/products/marketplace-relister/app/api/generate/route.js
@@ -1,0 +1,111 @@
+/**
+ * Generate 3 lifestyle images for one product.
+ * Secret: OPENROUTER_API_KEY on Vercel (you set once — never in the browser).
+ */
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+const PROMPTS = [
+  (t) =>
+    `Amateur smartphone photo of this product in real home use: ${t}. Lived-in room, natural light, product in use, not a white-background stock shot. No readable faces.`,
+  (t) =>
+    `Casual close-up phone photo showing a key feature of: ${t}. Hands only (no face) in a real house. Not studio stock photography.`,
+  (t) =>
+    `Realistic amateur photo of: ${t} in another everyday home spot (kitchen, laundry, desk, or hallway). Phone-camera quality, ordinary clutter, not catalog stock.`,
+];
+
+async function openRouterImage(prompt, apiKey, model) {
+  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://github.com/midnghtsapphire/revvel-standards',
+      'X-Title': 'marketplace-relister',
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(data.error?.message || data.message || `OpenRouter ${res.status}`);
+  }
+  const msg = data.choices?.[0]?.message;
+  if (msg?.images?.[0]?.image_url?.url) return msg.images[0].image_url.url;
+  if (Array.isArray(msg?.content)) {
+    for (const p of msg.content) {
+      if (p.type === 'image_url' && p.image_url?.url) return p.image_url.url;
+      if (p.inline_data?.data) {
+        return `data:image/jpeg;base64,${p.inline_data.data}`;
+      }
+    }
+  }
+  if (typeof msg?.content === 'string') {
+    const m = msg.content.match(/data:image\/[a-zA-Z0-9+.-]+;base64,[A-Za-z0-9+/=]+/);
+    if (m) return m[0];
+  }
+  throw new Error('No image in model response — check OPENROUTER_IMAGE_MODEL supports images');
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const title = String(body.title || '').trim();
+    const asin = body.asin ? String(body.asin).trim().toUpperCase() : '';
+    const count = Math.min(5, Math.max(1, parseInt(body.count || '3', 10) || 3));
+
+    if (!title && !asin) {
+      return Response.json({ error: 'Need product title or ASIN' }, { status: 400 });
+    }
+
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    if (!apiKey) {
+      return Response.json(
+        {
+          error:
+            'OPENROUTER_API_KEY is not set on this Vercel project. Add it once under Project → Settings → Environment Variables, then redeploy.',
+          setup: true,
+        },
+        { status: 503 }
+      );
+    }
+
+    const model =
+      process.env.OPENROUTER_IMAGE_MODEL || 'google/gemini-2.5-flash-image-preview';
+    const label = title || `Amazon product ${asin}`;
+    const images = [];
+    const errors = [];
+
+    for (let i = 0; i < count; i++) {
+      try {
+        const url = await openRouterImage(PROMPTS[i % PROMPTS.length](label), apiKey, model);
+        images.push({ index: i + 1, url });
+      } catch (err) {
+        errors.push({ index: i + 1, message: err.message });
+      }
+    }
+
+    return Response.json({
+      ok: images.length > 0,
+      asin: asin || null,
+      title: label,
+      productUrl: asin ? `https://www.amazon.com/dp/${asin}` : null,
+      images,
+      errors,
+      listing: [
+        label,
+        '',
+        asin ? `ASIN: ${asin}` : '',
+        asin ? `https://www.amazon.com/dp/${asin}` : '',
+        '',
+        'From my orders. Message with questions. Local pickup / shipping as agreed.',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    });
+  } catch (err) {
+    return Response.json({ error: err.message || 'Server error' }, { status: 500 });
+  }
+}

--- a/products/marketplace-relister/app/layout.js
+++ b/products/marketplace-relister/app/layout.js
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: 'My Orders → Lifestyle Pics',
+  description: 'Upload Amazon order CSV. One product at a time. Get 3 real-life style images.',
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, fontFamily: 'system-ui, sans-serif', background: '#0b0b12', color: '#f4f4ff' }}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/products/marketplace-relister/app/page.js
+++ b/products/marketplace-relister/app/page.js
@@ -1,0 +1,324 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { parseCsv, rowsToProducts } from '../lib/csv';
+
+export default function Page() {
+  const [products, setProducts] = useState([]);
+  const [index, setIndex] = useState(0);
+  const [fileName, setFileName] = useState('');
+  const [status, setStatus] = useState('Upload your Amazon order CSV (or try sample).');
+  const [busy, setBusy] = useState(false);
+  const [steps, setSteps] = useState([]);
+  const [images, setImages] = useState([]);
+  const [listing, setListing] = useState('');
+  const [error, setError] = useState('');
+
+  const current = products[index] || null;
+
+  function loadText(text, name) {
+    const rows = parseCsv(text);
+    const list = rowsToProducts(rows);
+    if (!list.length) {
+      setError('No products found. Need columns like Product Name and ASIN.');
+      setProducts([]);
+      return;
+    }
+    setError('');
+    setProducts(list);
+    setIndex(0);
+    setFileName(name || `${list.length} products`);
+    setImages([]);
+    setListing('');
+    setSteps([]);
+    setStatus(`Loaded ${list.length} products. Showing #1. Press Generate.`);
+  }
+
+  function onFile(e) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = () => loadText(String(reader.result || ''), f.name);
+    reader.readAsText(f);
+  }
+
+  function loadSample() {
+    const sample = [
+      'Order ID,Order Date,Product Name,ASIN,Unit Price,Quantity',
+      '111-1,2024-01-01,Slim 4-Tier Kitchen Storage Cart Black Brown,B0CGHRRN17,59.99,1',
+      '111-2,2024-01-02,Crystal Bracelet Rose Gold Sample,B0GV3N5QNY,18.99,1',
+      '111-3,2024-01-03,Panda Building Blocks Set Sample,B0GKP3292D,49.89,1',
+    ].join('\n');
+    loadText(sample, 'sample.csv');
+  }
+
+  async function generate() {
+    if (!current) return;
+    setBusy(true);
+    setError('');
+    setImages([]);
+    setListing('');
+    setSteps([
+      { t: '1. Read this product from your list', s: 'done' },
+      { t: '2. Sending to image generator…', s: 'run' },
+      { t: '3. Making 3 lifestyle pictures', s: 'wait' },
+      { t: '4. Show you the results', s: 'wait' },
+    ]);
+    setStatus(`Working on product ${index + 1} of ${products.length}…`);
+
+    try {
+      const res = await fetch('/api/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: current.title,
+          asin: current.asin,
+          count: 3,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setSteps((prev) =>
+          prev.map((x, i) =>
+            i === 1 ? { ...x, s: 'err', t: data.error || 'Failed' } : x
+          )
+        );
+        setError(data.error || 'Generation failed');
+        setStatus('Stopped — see error below.');
+        return;
+      }
+      setSteps([
+        { t: '1. Read this product from your list', s: 'done' },
+        { t: '2. Sent to image generator', s: 'done' },
+        {
+          t: `3. Made ${data.images?.length || 0} lifestyle pictures`,
+          s: data.images?.length ? 'done' : 'err',
+        },
+        { t: '4. Ready — download what you like', s: 'done' },
+      ]);
+      setImages(data.images || []);
+      setListing(data.listing || '');
+      setStatus(
+        data.images?.length
+          ? `Done — ${data.images.length} pictures for this product. Download them, then Next.`
+          : 'Finished but no pictures returned.'
+      );
+      if (data.errors?.length) {
+        setError(data.errors.map((e) => `#${e.index}: ${e.message}`).join(' · '));
+      }
+    } catch (err) {
+      setError(err.message || 'Network error');
+      setStatus('Something went wrong.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function downloadImage(url, n) {
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${current?.asin || 'product'}-lifestyle-${n}.jpg`;
+    a.click();
+  }
+
+  const stepColor = useMemo(
+    () => ({ done: '#3dd68c', run: '#8b7cf7', wait: '#666', err: '#ff6b7a' }),
+    []
+  );
+
+  return (
+    <main style={{ maxWidth: 720, margin: '0 auto', padding: '28px 16px 64px' }}>
+      <h1 style={{ fontSize: '1.5rem', marginBottom: 8 }}>My orders → lifestyle pics</h1>
+      <p style={{ color: '#a0a0b8', marginBottom: 20, lineHeight: 1.5 }}>
+        One page. Upload your Amazon order CSV. Pick a product. Get 3 real-life style images
+        (not stock). Download them. Next product when you want.
+      </p>
+
+      <div
+        style={{
+          background: '#14141f',
+          border: '1px solid #2a2a3d',
+          borderRadius: 14,
+          padding: 18,
+          marginBottom: 14,
+        }}
+      >
+        <div style={{ fontSize: 12, color: '#a0a0b8', marginBottom: 10, textTransform: 'uppercase' }}>
+          Step 1 · Your file
+        </div>
+        <input type="file" accept=".csv,text/csv" onChange={onFile} disabled={busy} />
+        <div style={{ marginTop: 12 }}>
+          <button type="button" onClick={loadSample} disabled={busy} style={btnGhost}>
+            Or try with 3 sample products
+          </button>
+        </div>
+        {fileName ? (
+          <p style={{ marginTop: 10, fontSize: 13, color: '#a89cff' }}>{fileName}</p>
+        ) : null}
+      </div>
+
+      <div
+        style={{
+          background: '#0f1a14',
+          border: '1px solid #1f3d2e',
+          borderRadius: 12,
+          padding: 12,
+          marginBottom: 14,
+          fontSize: 14,
+        }}
+      >
+        <strong style={{ color: '#3dd68c' }}>Status:</strong> {status}
+      </div>
+
+      {current ? (
+        <div
+          style={{
+            background: '#14141f',
+            border: '1px solid #2a2a3d',
+            borderRadius: 14,
+            padding: 18,
+            marginBottom: 14,
+          }}
+        >
+          <div style={{ fontSize: 12, color: '#a0a0b8', marginBottom: 10, textTransform: 'uppercase' }}>
+            Step 2 · Product {index + 1} of {products.length}
+          </div>
+          <h2 style={{ fontSize: '1.05rem', marginBottom: 8 }}>{current.title}</h2>
+          <p style={{ fontSize: 13, color: '#a0a0b8', marginBottom: 14 }}>
+            {current.asin ? `ASIN ${current.asin}` : 'No ASIN'}
+            {current.paid ? ` · paid $${current.paid.toFixed(2)}` : ''}
+          </p>
+
+          <button type="button" onClick={generate} disabled={busy} style={btnMain}>
+            {busy ? 'Working… watch the steps below' : 'Generate 3 lifestyle pictures'}
+          </button>
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 10, flexWrap: 'wrap' }}>
+            <button
+              type="button"
+              disabled={busy || index <= 0}
+              onClick={() => {
+                setIndex((i) => i - 1);
+                setImages([]);
+                setListing('');
+                setSteps([]);
+                setStatus(`Product ${index} of ${products.length}`);
+              }}
+              style={btnGhost}
+            >
+              ← Prev
+            </button>
+            <button
+              type="button"
+              disabled={busy || index >= products.length - 1}
+              onClick={() => {
+                setIndex((i) => i + 1);
+                setImages([]);
+                setListing('');
+                setSteps([]);
+                setStatus(`Product ${index + 2} of ${products.length}`);
+              }}
+              style={btnGhost}
+            >
+              Next product →
+            </button>
+          </div>
+
+          {steps.length ? (
+            <div style={{ marginTop: 16 }}>
+              {steps.map((s, i) => (
+                <div key={i} style={{ color: stepColor[s.s] || '#aaa', padding: '4px 0', fontSize: 14 }}>
+                  {s.s === 'done' ? '✓' : s.s === 'run' ? '◎' : s.s === 'err' ? '✗' : '○'} {s.t}
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {error ? (
+            <p style={{ marginTop: 12, color: '#ff6b7a', fontSize: 14 }}>{error}</p>
+          ) : null}
+
+          {images.length ? (
+            <div style={{ marginTop: 16 }}>
+              <div style={{ fontSize: 12, color: '#a0a0b8', marginBottom: 8 }}>Your pictures · click download</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
+                {images.map((im) => (
+                  <div key={im.index} style={{ textAlign: 'center' }}>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={im.url}
+                      alt={`Lifestyle ${im.index}`}
+                      style={{
+                        width: 160,
+                        height: 200,
+                        objectFit: 'cover',
+                        borderRadius: 10,
+                        background: '#222',
+                        display: 'block',
+                      }}
+                    />
+                    <button
+                      type="button"
+                      style={{ ...btnGhost, marginTop: 6, width: '100%' }}
+                      onClick={() => downloadImage(im.url, im.index)}
+                    >
+                      Download {im.index}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {listing ? (
+            <div style={{ marginTop: 16 }}>
+              <div style={{ fontSize: 12, color: '#a0a0b8', marginBottom: 6 }}>Listing text</div>
+              <textarea
+                readOnly
+                value={listing}
+                style={{
+                  width: '100%',
+                  minHeight: 100,
+                  background: '#0a0a10',
+                  border: '1px solid #2a2a3d',
+                  borderRadius: 10,
+                  color: '#f4f4ff',
+                  padding: 10,
+                  fontSize: 13,
+                }}
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <p style={{ fontSize: 13, color: '#666', marginTop: 20 }}>
+        No local install. Images download to your computer when you click Download.
+        One OpenRouter key is set on the server once — you never paste it here.
+      </p>
+    </main>
+  );
+}
+
+const btnMain = {
+  width: '100%',
+  padding: '14px 16px',
+  borderRadius: 12,
+  border: 'none',
+  background: '#3dd68c',
+  color: '#042',
+  fontWeight: 700,
+  fontSize: 16,
+  cursor: 'pointer',
+};
+
+const btnGhost = {
+  padding: '10px 14px',
+  borderRadius: 10,
+  border: '1px solid #2a2a3d',
+  background: '#1a1a28',
+  color: '#f4f4ff',
+  fontWeight: 600,
+  fontSize: 13,
+  cursor: 'pointer',
+};

--- a/products/marketplace-relister/lib/csv.js
+++ b/products/marketplace-relister/lib/csv.js
@@ -1,0 +1,102 @@
+/** Browser + server safe CSV helpers for Amazon order history. */
+
+export function parseCsvLine(line) {
+  const out = [];
+  let cur = '';
+  let q = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (q) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else q = false;
+      } else cur += ch;
+    } else if (ch === '"') q = true;
+    else if (ch === ',') {
+      out.push(cur);
+      cur = '';
+    } else cur += ch;
+  }
+  out.push(cur);
+  return out;
+}
+
+export function normHeader(h) {
+  return String(h || '')
+    .replace(/^\uFEFF/, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[_]+/g, ' ')
+    .replace(/\s+/g, ' ');
+}
+
+export function parseCsv(text) {
+  const lines = String(text || '')
+    .replace(/^\uFEFF/, '')
+    .trim()
+    .split(/\r?\n/)
+    .filter((l) => l.trim());
+  if (!lines.length) return [];
+  const headers = parseCsvLine(lines[0]).map(normHeader);
+  const rows = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cells = parseCsvLine(lines[i]);
+    const row = {};
+    headers.forEach((h, idx) => {
+      row[h] = (cells[idx] || '').trim();
+    });
+    rows.push(row);
+  }
+  return rows;
+}
+
+function pick(row, names) {
+  for (const n of names) {
+    const k = normHeader(n);
+    if (row[k]) return row[k];
+  }
+  for (const n of names) {
+    const want = normHeader(n);
+    for (const [k, v] of Object.entries(row)) {
+      if (k.includes(want) && v) return v;
+    }
+  }
+  return '';
+}
+
+export function extractAsin(raw) {
+  if (!raw) return null;
+  const s = String(raw).trim();
+  const fromUrl = s.match(/\/(?:dp|gp\/product|product)\/([A-Z0-9]{10})/i);
+  if (fromUrl) return fromUrl[1].toUpperCase();
+  if (/^[A-Z0-9]{10}$/i.test(s)) return s.toUpperCase();
+  const m = s.match(/\b([A-Z0-9]{10})\b/i);
+  return m ? m[1].toUpperCase() : null;
+}
+
+export function rowsToProducts(rows) {
+  return rows
+    .map((row, i) => {
+      const asin = extractAsin(pick(row, ['asin', 'asin/isbn', 'asin isbn', 'isbn']));
+      const title =
+        pick(row, ['title', 'product name', 'product title', 'item name']) ||
+        (asin ? `Amazon product ${asin}` : null);
+      if (!asin && !title) return null;
+      const paid = parseFloat(
+        String(pick(row, ['unit price', 'item total', 'total owed', 'price']) || '').replace(
+          /[^0-9.-]/g,
+          ''
+        )
+      );
+      return {
+        id: pick(row, ['order id', 'order number']) || `row-${i + 1}`,
+        asin,
+        title: (title || '').slice(0, 200),
+        paid: Number.isFinite(paid) ? paid : 0,
+        url: asin ? `https://www.amazon.com/dp/${asin}` : null,
+      };
+    })
+    .filter(Boolean);
+}

--- a/products/marketplace-relister/next.config.js
+++ b/products/marketplace-relister/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/products/marketplace-relister/package.json
+++ b/products/marketplace-relister/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "marketplace-relister",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3040",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/products/marketplace-relister/vercel.json
+++ b/products/marketplace-relister/vercel.json
@@ -1,0 +1,9 @@
+{
+  "framework": "nextjs",
+  "regions": ["iad1"],
+  "functions": {
+    "app/api/generate/route.js": {
+      "maxDuration": 60
+    }
+  }
+}


### PR DESCRIPTION
Simple Next.js app: upload CSV, one product, generate 3 lifestyle images, download. Deploy as separate Vercel project with OPENROUTER_API_KEY. No localhost required for daily use.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary

This PR adds a standalone Next.js application called **Marketplace Relister** that allows users to upload Amazon order CSV files, select products, and generate lifestyle product images using OpenRouter's AI image generation API. The app is designed to be deployed as a separate Vercel project (not part of the main site) with minimal setup: users bookmark one URL, set the `OPENROUTER_API_KEY` environment variable once, and can then process products entirely in the browser without needing local development tools. The workflow is: upload CSV, pick a product, generate 3 lifestyle photos, download them, and move to the next product.


⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `START_HERE_CALL_CHAIN.md` |
| 2 | `products/marketplace-relister/README.md` |
| 3 | `products/marketplace-relister/package.json` |
| 4 | `products/marketplace-relister/next.config.js` |
| 5 | `products/marketplace-relister/vercel.json` |
| 6 | `products/marketplace-relister/lib/csv.js` |
| 7 | `products/marketplace-relister/app/layout.js` |
| 8 | `products/marketplace-relister/app/api/generate/route.js` |
| 9 | `products/marketplace-relister/app/page.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone marketplace relister app: upload an Amazon order CSV, pick a product, generate 3 lifestyle images, and download. Deploys as its own Vercel project with one URL and a server-side `OPENROUTER_API_KEY`, so no local setup.

- **New Features**
  - Client-side CSV parsing (ASIN/title support) with a sample CSV option.
  - Simple flow: product picker, step status, download buttons, and auto-generated listing text.
  - Server route `/api/generate` uses OpenRouter to create images (default model `google/gemini-2.5-flash-image-preview`), returning image URLs and handling errors.

- **Migration**
  - Deploy as a separate Vercel project with Root Directory `products/marketplace-relister`.
  - Set `OPENROUTER_API_KEY` (optional `OPENROUTER_IMAGE_MODEL`) in project env vars.
  - Deploy and bookmark the app URL.

<sup>Written for commit 8de2665f449696f4538afde6f3627a15dc53ed06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

