### PR TITLE
feat: private family batch marketplace app (Vercel)

### DIFF
--- a/START_HERE_CALL_CHAIN.md
+++ b/START_HERE_CALL_CHAIN.md
@@ -224,3 +224,11 @@ That page accepts your CSV in the browser. The main Vercel site only shows docs/
 App code: `products/marketplace-relister`  
 Deploy as its **own** Vercel project (Root Directory = `products/marketplace-relister`).  
 Set `OPENROUTER_API_KEY` once in Vercel. Bookmark that app URL only.
+
+
+## Family Order Packs (private Vercel)
+
+Code: `products/marketplace-relister`.
+Deploy once on Vercel (Root Directory = that folder). Env: `OPENROUTER_API_KEY` + `FAMILY_APP_PASSWORD`.
+Daily use: one bookmark, upload CSV, Process next 10/25, download packs.
+

--- a/products/marketplace-relister/README.md
+++ b/products/marketplace-relister/README.md
@@ -1,36 +1,51 @@
-# Marketplace Relister (simple Vercel app)
+# Family Order Packs (private Vercel app)
 
-**One URL. No local npm. No hopping.**
+**This is the real family tool** — not a demo, not PowerShell.
 
-1. Open the deployed site  
-2. Upload Amazon order CSV  
-3. Click **Generate 3 lifestyle pictures**  
-4. **Download** the images to your computer  
-5. **Next product**
+## What you and your daughter do (every day)
 
-## Deploy (one-time setup)
+1. Open the **bookmark** (one link)
+2. Enter the **family password** (once in a while)
+3. **Upload** Amazon order CSV
+4. Press **Process next 10** (or 25 / all)
+5. Wait — progress bar runs through products
+6. **Download** pictures for each finished pack
 
-1. [Vercel](https://vercel.com) → Add New Project → import `midnghtsapphire/revvel-standards`
-2. **Root Directory:** `products/marketplace-relister`
-3. Framework: Next.js (auto)
-4. Environment variables:
-   - `OPENROUTER_API_KEY` = your key  
-   - optional: `OPENROUTER_IMAGE_MODEL` = `google/gemini-2.5-flash-image-preview`
-5. Deploy → copy the URL (e.g. `https://marketplace-relister.vercel.app`)
+No npm. No GitHub. No “one product manually forever.”
 
-That URL is the only one you bookmark.
+---
 
-## Local dev (optional)
+## One-time deploy (you or a helper — not your daughter)
+
+In [vercel.com](https://vercel.com):
+
+1. **Add New Project** → import `midnghtsapphire/revvel-standards`
+2. **Root Directory** → `products/marketplace-relister`  
+   (click Edit next to Root Directory)
+3. **Environment Variables** (Production + Preview):
+
+| Name | Value |
+|------|--------|
+| `OPENROUTER_API_KEY` | your OpenRouter key |
+| `FAMILY_APP_PASSWORD` | shared family password (pick one) |
+| `OPENROUTER_IMAGE_MODEL` | optional — default image model if unset |
+
+4. **Deploy**
+5. Copy the URL → bookmark → text to your daughter with the password
+
+That’s the only hard step. After that, only the bookmark.
+
+---
+
+## Env notes
+
+- Without `OPENROUTER_API_KEY`, Generate fails with a clear message.
+- Without `FAMILY_APP_PASSWORD`, the app is open (set a password for family privacy).
+
+## Local (optional, developers only)
 
 ```bash
 cd products/marketplace-relister
 npm install
 npm run dev
-# http://localhost:3040
 ```
-
-## Notes
-
-- CSV is parsed **in the browser** (not stored on the server).
-- Images are generated on the server, shown in the page, downloaded by you.
-- Not the main hub (`revvel-standards.vercel.app`) — this is its **own** Vercel project.

--- a/products/marketplace-relister/app/api/generate/route.js
+++ b/products/marketplace-relister/app/api/generate/route.js
@@ -1,17 +1,21 @@
 /**
- * Generate 3 lifestyle images for one product.
- * Secret: OPENROUTER_API_KEY on Vercel (you set once — never in the browser).
+ * One product → N lifestyle images (called repeatedly by the batch runner).
+ * Secrets stay on Vercel: OPENROUTER_API_KEY
  */
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
 const PROMPTS = [
   (t) =>
-    `Amateur smartphone photo of this product in real home use: ${t}. Lived-in room, natural light, product in use, not a white-background stock shot. No readable faces.`,
+    `Amateur smartphone photo of this product in real home use: ${t}. Lived-in home, natural light, product clearly in use for its purpose, not a white-background stock catalog shot. No readable faces.`,
   (t) =>
-    `Casual close-up phone photo showing a key feature of: ${t}. Hands only (no face) in a real house. Not studio stock photography.`,
+    `Casual close-up phone photo showing a key feature of: ${t}. Hands only (no face) demonstrating use in a real house. Realistic lighting, not studio stock photography.`,
   (t) =>
-    `Realistic amateur photo of: ${t} in another everyday home spot (kitchen, laundry, desk, or hallway). Phone-camera quality, ordinary clutter, not catalog stock.`,
+    `Realistic amateur photo of: ${t} in another everyday home place (kitchen, laundry, bathroom, desk, or hallway) with ordinary clutter. Phone-camera quality, not polished stock.`,
+  (t) =>
+    `Wide casual phone photo of: ${t} stored or used in a narrow real-home space, authentic resale-listing style, not e-commerce studio.`,
+  (t) =>
+    `Detail shot of: ${t} highlighting materials or features as a normal person would photograph for Facebook Marketplace. Amateur, honest, not stock.`,
 ];
 
 async function openRouterImage(prompt, apiKey, model) {
@@ -21,7 +25,7 @@ async function openRouterImage(prompt, apiKey, model) {
       Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
       'HTTP-Referer': 'https://github.com/midnghtsapphire/revvel-standards',
-      'X-Title': 'marketplace-relister',
+      'X-Title': 'family-marketplace-relister',
     },
     body: JSON.stringify({
       model,
@@ -37,16 +41,14 @@ async function openRouterImage(prompt, apiKey, model) {
   if (Array.isArray(msg?.content)) {
     for (const p of msg.content) {
       if (p.type === 'image_url' && p.image_url?.url) return p.image_url.url;
-      if (p.inline_data?.data) {
-        return `data:image/jpeg;base64,${p.inline_data.data}`;
-      }
+      if (p.inline_data?.data) return `data:image/jpeg;base64,${p.inline_data.data}`;
     }
   }
   if (typeof msg?.content === 'string') {
     const m = msg.content.match(/data:image\/[a-zA-Z0-9+.-]+;base64,[A-Za-z0-9+/=]+/);
     if (m) return m[0];
   }
-  throw new Error('No image in model response — check OPENROUTER_IMAGE_MODEL supports images');
+  throw new Error('No image returned — set OPENROUTER_IMAGE_MODEL to an image-capable model');
 }
 
 export async function POST(request) {
@@ -55,9 +57,8 @@ export async function POST(request) {
     const title = String(body.title || '').trim();
     const asin = body.asin ? String(body.asin).trim().toUpperCase() : '';
     const count = Math.min(5, Math.max(1, parseInt(body.count || '3', 10) || 3));
-
     if (!title && !asin) {
-      return Response.json({ error: 'Need product title or ASIN' }, { status: 400 });
+      return Response.json({ error: 'Need title or ASIN' }, { status: 400 });
     }
 
     const apiKey = process.env.OPENROUTER_API_KEY;
@@ -65,7 +66,7 @@ export async function POST(request) {
       return Response.json(
         {
           error:
-            'OPENROUTER_API_KEY is not set on this Vercel project. Add it once under Project → Settings → Environment Variables, then redeploy.',
+            'Server missing OPENROUTER_API_KEY. Add it in Vercel → Project → Settings → Environment Variables, then Redeploy.',
           setup: true,
         },
         { status: 503 }
@@ -83,7 +84,7 @@ export async function POST(request) {
         const url = await openRouterImage(PROMPTS[i % PROMPTS.length](label), apiKey, model);
         images.push({ index: i + 1, url });
       } catch (err) {
-        errors.push({ index: i + 1, message: err.message });
+        errors.push({ index: i + 1, message: err.message || String(err) });
       }
     }
 
@@ -100,7 +101,7 @@ export async function POST(request) {
         asin ? `ASIN: ${asin}` : '',
         asin ? `https://www.amazon.com/dp/${asin}` : '',
         '',
-        'From my orders. Message with questions. Local pickup / shipping as agreed.',
+        'From our orders. Message with questions. Local pickup / shipping as agreed.',
       ]
         .filter(Boolean)
         .join('\n'),

--- a/products/marketplace-relister/app/api/login/route.js
+++ b/products/marketplace-relister/app/api/login/route.js
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const password = process.env.FAMILY_APP_PASSWORD;
+
+    if (!password) {
+      // No password configured — allow through for first deploy testing
+      const res = NextResponse.json({ ok: true, open: true });
+      res.cookies.set('family_ok', '1', {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 30,
+      });
+      return res;
+    }
+
+    if (String(body.password || '') !== password) {
+      return NextResponse.json({ error: 'Wrong password' }, { status: 401 });
+    }
+
+    const res = NextResponse.json({ ok: true });
+    res.cookies.set('family_ok', '1', {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 30,
+    });
+    return res;
+  } catch (err) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/products/marketplace-relister/app/api/session/route.js
+++ b/products/marketplace-relister/app/api/session/route.js
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const password = process.env.FAMILY_APP_PASSWORD;
+  if (!password) {
+    return NextResponse.json({ ok: true, open: true });
+  }
+  const jar = await cookies();
+  const ok = jar.get('family_ok')?.value === '1';
+  return NextResponse.json({ ok, open: false });
+}

--- a/products/marketplace-relister/app/layout.js
+++ b/products/marketplace-relister/app/layout.js
@@ -1,12 +1,20 @@
 export const metadata = {
-  title: 'My Orders → Lifestyle Pics',
-  description: 'Upload Amazon order CSV. One product at a time. Get 3 real-life style images.',
+  title: 'Family Order Packs',
+  description: 'Private family tool: Amazon orders → lifestyle listing pictures',
 };
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body style={{ margin: 0, fontFamily: 'system-ui, sans-serif', background: '#0b0b12', color: '#f4f4ff' }}>
+      <body
+        style={{
+          margin: 0,
+          fontFamily: 'system-ui, Segoe UI, sans-serif',
+          background: '#0b0b12',
+          color: '#f4f4ff',
+          minHeight: '100vh',
+        }}
+      >
         {children}
       </body>
     </html>

--- a/products/marketplace-relister/app/page.js
+++ b/products/marketplace-relister/app/page.js
@@ -1,37 +1,76 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { parseCsv, rowsToProducts } from '../lib/csv';
 
+/**
+ * Private family batch app:
+ * 1) Login once
+ * 2) Upload CSV once
+ * 3) Process batch (auto walks products)
+ * 4) Download images per product
+ */
 export default function Page() {
-  const [products, setProducts] = useState([]);
-  const [index, setIndex] = useState(0);
-  const [fileName, setFileName] = useState('');
-  const [status, setStatus] = useState('Upload your Amazon order CSV (or try sample).');
-  const [busy, setBusy] = useState(false);
-  const [steps, setSteps] = useState([]);
-  const [images, setImages] = useState([]);
-  const [listing, setListing] = useState('');
-  const [error, setError] = useState('');
+  const [needLogin, setNeedLogin] = useState(false);
+  const [password, setPassword] = useState('');
+  const [loginError, setLoginError] = useState('');
 
-  const current = products[index] || null;
+  const [products, setProducts] = useState([]);
+  const [fileName, setFileName] = useState('');
+  const [packs, setPacks] = useState({}); // id -> { status, images, listing, error }
+  const [batchRunning, setBatchRunning] = useState(false);
+  const [batchCursor, setBatchCursor] = useState(0);
+  const [batchTotal, setBatchTotal] = useState(0);
+  const [logLine, setLogLine] = useState('Upload your Amazon order CSV to begin.');
+  const stopRef = useRef(false);
+
+  useEffect(() => {
+    fetch('/api/session')
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.open) {
+          setNeedLogin(false);
+          return;
+        }
+        setNeedLogin(!d.ok);
+      })
+      .catch(() => setNeedLogin(false));
+  }, []);
+
+  async function doLogin(e) {
+    e?.preventDefault?.();
+    setLoginError('');
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setLoginError(data.error || 'Login failed');
+        return;
+      }
+      setNeedLogin(false);
+      setLogLine('Logged in. Upload your order CSV.');
+    } catch (err) {
+      setLoginError(err.message);
+    }
+  }
 
   function loadText(text, name) {
     const rows = parseCsv(text);
     const list = rowsToProducts(rows);
     if (!list.length) {
-      setError('No products found. Need columns like Product Name and ASIN.');
-      setProducts([]);
+      setLogLine('No products found — need Product Name / ASIN columns.');
       return;
     }
-    setError('');
     setProducts(list);
-    setIndex(0);
     setFileName(name || `${list.length} products`);
-    setImages([]);
-    setListing('');
-    setSteps([]);
-    setStatus(`Loaded ${list.length} products. Showing #1. Press Generate.`);
+    setPacks({});
+    setBatchCursor(0);
+    setBatchTotal(0);
+    setLogLine(`Loaded ${list.length} products. Press “Process batch” when ready.`);
   }
 
   function onFile(e) {
@@ -42,283 +81,388 @@ export default function Page() {
     reader.readAsText(f);
   }
 
-  function loadSample() {
-    const sample = [
-      'Order ID,Order Date,Product Name,ASIN,Unit Price,Quantity',
-      '111-1,2024-01-01,Slim 4-Tier Kitchen Storage Cart Black Brown,B0CGHRRN17,59.99,1',
-      '111-2,2024-01-02,Crystal Bracelet Rose Gold Sample,B0GV3N5QNY,18.99,1',
-      '111-3,2024-01-03,Panda Building Blocks Set Sample,B0GKP3292D,49.89,1',
-    ].join('\n');
-    loadText(sample, 'sample.csv');
-  }
-
-  async function generate() {
-    if (!current) return;
-    setBusy(true);
-    setError('');
-    setImages([]);
-    setListing('');
-    setSteps([
-      { t: '1. Read this product from your list', s: 'done' },
-      { t: '2. Sending to image generator…', s: 'run' },
-      { t: '3. Making 3 lifestyle pictures', s: 'wait' },
-      { t: '4. Show you the results', s: 'wait' },
-    ]);
-    setStatus(`Working on product ${index + 1} of ${products.length}…`);
-
+  const processOne = useCallback(async (product) => {
+    setPacks((prev) => ({
+      ...prev,
+      [product.id]: { status: 'running', images: [], listing: '', error: '' },
+    }));
     try {
       const res = await fetch('/api/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          title: current.title,
-          asin: current.asin,
+          title: product.title,
+          asin: product.asin,
           count: 3,
         }),
       });
       const data = await res.json();
       if (!res.ok) {
-        setSteps((prev) =>
-          prev.map((x, i) =>
-            i === 1 ? { ...x, s: 'err', t: data.error || 'Failed' } : x
-          )
-        );
-        setError(data.error || 'Generation failed');
-        setStatus('Stopped — see error below.');
-        return;
+        setPacks((prev) => ({
+          ...prev,
+          [product.id]: {
+            status: 'error',
+            images: [],
+            listing: '',
+            error: data.error || 'Failed',
+          },
+        }));
+        return false;
       }
-      setSteps([
-        { t: '1. Read this product from your list', s: 'done' },
-        { t: '2. Sent to image generator', s: 'done' },
-        {
-          t: `3. Made ${data.images?.length || 0} lifestyle pictures`,
-          s: data.images?.length ? 'done' : 'err',
+      setPacks((prev) => ({
+        ...prev,
+        [product.id]: {
+          status: data.images?.length ? 'done' : 'error',
+          images: data.images || [],
+          listing: data.listing || '',
+          error: data.errors?.map((x) => x.message).join('; ') || '',
         },
-        { t: '4. Ready — download what you like', s: 'done' },
-      ]);
-      setImages(data.images || []);
-      setListing(data.listing || '');
-      setStatus(
-        data.images?.length
-          ? `Done — ${data.images.length} pictures for this product. Download them, then Next.`
-          : 'Finished but no pictures returned.'
-      );
-      if (data.errors?.length) {
-        setError(data.errors.map((e) => `#${e.index}: ${e.message}`).join(' · '));
-      }
+      }));
+      return Boolean(data.images?.length);
     } catch (err) {
-      setError(err.message || 'Network error');
-      setStatus('Something went wrong.');
-    } finally {
-      setBusy(false);
+      setPacks((prev) => ({
+        ...prev,
+        [product.id]: {
+          status: 'error',
+          images: [],
+          listing: '',
+          error: err.message,
+        },
+      }));
+      return false;
+    }
+  }, []);
+
+  async function runBatch(limit) {
+    if (!products.length || batchRunning) return;
+    stopRef.current = false;
+    setBatchRunning(true);
+
+    // Only process products not already done
+    const pending = products.filter((p) => packs[p.id]?.status !== 'done');
+    const slice = typeof limit === 'number' ? pending.slice(0, limit) : pending;
+    setBatchTotal(slice.length);
+    setBatchCursor(0);
+    setLogLine(`Processing ${slice.length} products in the background of this tab…`);
+
+    let ok = 0;
+    for (let i = 0; i < slice.length; i++) {
+      if (stopRef.current) {
+        setLogLine(`Stopped. Finished ${ok} packs. You can resume anytime.`);
+        break;
+      }
+      setBatchCursor(i + 1);
+      setLogLine(`Working ${i + 1} of ${slice.length}: ${slice[i].title.slice(0, 60)}…`);
+      const success = await processOne(slice[i]);
+      if (success) ok += 1;
+    }
+
+    setBatchRunning(false);
+    if (!stopRef.current) {
+      setLogLine(`Batch finished. ${ok} of ${slice.length} packs ready. Scroll down to download.`);
     }
   }
 
-  function downloadImage(url, n) {
+  function stopBatch() {
+    stopRef.current = true;
+    setLogLine('Stopping after current product…');
+  }
+
+  function downloadImg(url, asin, n) {
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${current?.asin || 'product'}-lifestyle-${n}.jpg`;
+    a.download = `${asin || 'item'}-lifestyle-${n}.jpg`;
     a.click();
   }
 
-  const stepColor = useMemo(
-    () => ({ done: '#3dd68c', run: '#8b7cf7', wait: '#666', err: '#ff6b7a' }),
-    []
-  );
+  function downloadListing(text, asin) {
+    const blob = new Blob([text], { type: 'text/plain' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `${asin || 'item'}-listing.txt`;
+    a.click();
+  }
+
+  const doneCount = Object.values(packs).filter((p) => p.status === 'done').length;
+  const errorCount = Object.values(packs).filter((p) => p.status === 'error').length;
+
+  if (needLogin) {
+    return (
+      <main style={styles.wrap}>
+        <h1 style={styles.h1}>Family order packs</h1>
+        <p style={styles.sub}>Private. Enter the family password.</p>
+        <form onSubmit={doLogin} style={styles.card}>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            style={styles.input}
+            autoFocus
+          />
+          <button type="submit" style={styles.btnGreen}>
+            Open app
+          </button>
+          {loginError ? <p style={styles.err}>{loginError}</p> : null}
+        </form>
+      </main>
+    );
+  }
 
   return (
-    <main style={{ maxWidth: 720, margin: '0 auto', padding: '28px 16px 64px' }}>
-      <h1 style={{ fontSize: '1.5rem', marginBottom: 8 }}>My orders → lifestyle pics</h1>
-      <p style={{ color: '#a0a0b8', marginBottom: 20, lineHeight: 1.5 }}>
-        One page. Upload your Amazon order CSV. Pick a product. Get 3 real-life style images
-        (not stock). Download them. Next product when you want.
+    <main style={styles.wrap}>
+      <h1 style={styles.h1}>Family order packs</h1>
+      <p style={styles.sub}>
+        Private tool for you and your family. Upload orders once, process a batch, download lifestyle
+        pictures. Leave this tab open while it runs.
       </p>
 
-      <div
-        style={{
-          background: '#14141f',
-          border: '1px solid #2a2a3d',
-          borderRadius: 14,
-          padding: 18,
-          marginBottom: 14,
-        }}
-      >
-        <div style={{ fontSize: 12, color: '#a0a0b8', marginBottom: 10, textTransform: 'uppercase' }}>
-          Step 1 · Your file
-        </div>
-        <input type="file" accept=".csv,text/csv" onChange={onFile} disabled={busy} />
-        <div style={{ marginTop: 12 }}>
-          <button type="button" onClick={loadSample} disabled={busy} style={btnGhost}>
-            Or try with 3 sample products
-          </button>
-        </div>
+      <section style={styles.card}>
+        <div style={styles.label}>1 · Upload Amazon order CSV</div>
+        <input type="file" accept=".csv,text/csv" onChange={onFile} disabled={batchRunning} />
         {fileName ? (
-          <p style={{ marginTop: 10, fontSize: 13, color: '#a89cff' }}>{fileName}</p>
-        ) : null}
-      </div>
-
-      <div
-        style={{
-          background: '#0f1a14',
-          border: '1px solid #1f3d2e',
-          borderRadius: 12,
-          padding: 12,
-          marginBottom: 14,
-          fontSize: 14,
-        }}
-      >
-        <strong style={{ color: '#3dd68c' }}>Status:</strong> {status}
-      </div>
-
-      {current ? (
-        <div
-          style={{
-            background: '#14141f',
-            border: '1px solid #2a2a3d',
-            borderRadius: 14,
-            padding: 18,
-            marginBottom: 14,
-          }}
-        >
-          <div style={{ fontSize: 12, color: '#a0a0b8', marginBottom: 10, textTransform: 'uppercase' }}>
-            Step 2 · Product {index + 1} of {products.length}
-          </div>
-          <h2 style={{ fontSize: '1.05rem', marginBottom: 8 }}>{current.title}</h2>
-          <p style={{ fontSize: 13, color: '#a0a0b8', marginBottom: 14 }}>
-            {current.asin ? `ASIN ${current.asin}` : 'No ASIN'}
-            {current.paid ? ` · paid $${current.paid.toFixed(2)}` : ''}
+          <p style={{ marginTop: 10, color: '#a89cff', fontSize: 14 }}>
+            {fileName} · {products.length} products · {doneCount} packs ready
+            {errorCount ? ` · ${errorCount} errors` : ''}
           </p>
+        ) : null}
+      </section>
 
-          <button type="button" onClick={generate} disabled={busy} style={btnMain}>
-            {busy ? 'Working… watch the steps below' : 'Generate 3 lifestyle pictures'}
+      <section style={styles.card}>
+        <div style={styles.label}>2 · Run a batch</div>
+        <p style={{ color: '#a0a0b8', fontSize: 14, marginBottom: 12 }}>
+          The app walks products for you (not one manual click each). Start with 10 if you want a
+          shorter run.
+        </p>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+          <button
+            type="button"
+            style={styles.btnGreen}
+            disabled={!products.length || batchRunning}
+            onClick={() => runBatch(10)}
+          >
+            Process next 10
           </button>
-
-          <div style={{ display: 'flex', gap: 8, marginTop: 10, flexWrap: 'wrap' }}>
-            <button
-              type="button"
-              disabled={busy || index <= 0}
-              onClick={() => {
-                setIndex((i) => i - 1);
-                setImages([]);
-                setListing('');
-                setSteps([]);
-                setStatus(`Product ${index} of ${products.length}`);
-              }}
-              style={btnGhost}
-            >
-              ← Prev
+          <button
+            type="button"
+            style={styles.btnPurple}
+            disabled={!products.length || batchRunning}
+            onClick={() => runBatch(25)}
+          >
+            Process next 25
+          </button>
+          <button
+            type="button"
+            style={styles.btnGhost}
+            disabled={!products.length || batchRunning}
+            onClick={() => runBatch(null)}
+          >
+            Process all remaining
+          </button>
+          {batchRunning ? (
+            <button type="button" style={styles.btnStop} onClick={stopBatch}>
+              Stop after this one
             </button>
-            <button
-              type="button"
-              disabled={busy || index >= products.length - 1}
-              onClick={() => {
-                setIndex((i) => i + 1);
-                setImages([]);
-                setListing('');
-                setSteps([]);
-                setStatus(`Product ${index + 2} of ${products.length}`);
-              }}
-              style={btnGhost}
-            >
-              Next product →
-            </button>
-          </div>
-
-          {steps.length ? (
-            <div style={{ marginTop: 16 }}>
-              {steps.map((s, i) => (
-                <div key={i} style={{ color: stepColor[s.s] || '#aaa', padding: '4px 0', fontSize: 14 }}>
-                  {s.s === 'done' ? '✓' : s.s === 'run' ? '◎' : s.s === 'err' ? '✗' : '○'} {s.t}
-                </div>
-              ))}
-            </div>
           ) : null}
-
-          {error ? (
-            <p style={{ marginTop: 12, color: '#ff6b7a', fontSize: 14 }}>{error}</p>
-          ) : null}
-
-          {images.length ? (
-            <div style={{ marginTop: 16 }}>
-              <div style={{ fontSize: 12, color: '#a0a0b8', marginBottom: 8 }}>Your pictures · click download</div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
-                {images.map((im) => (
-                  <div key={im.index} style={{ textAlign: 'center' }}>
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={im.url}
-                      alt={`Lifestyle ${im.index}`}
-                      style={{
-                        width: 160,
-                        height: 200,
-                        objectFit: 'cover',
-                        borderRadius: 10,
-                        background: '#222',
-                        display: 'block',
-                      }}
-                    />
-                    <button
-                      type="button"
-                      style={{ ...btnGhost, marginTop: 6, width: '100%' }}
-                      onClick={() => downloadImage(im.url, im.index)}
-                    >
-                      Download {im.index}
-                    </button>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          {listing ? (
-            <div style={{ marginTop: 16 }}>
-              <div style={{ fontSize: 12, color: '#a0a0b8', marginBottom: 6 }}>Listing text</div>
-              <textarea
-                readOnly
-                value={listing}
+        </div>
+        {batchRunning || batchTotal ? (
+          <div style={{ marginTop: 14 }}>
+            <div style={styles.barBg}>
+              <div
                 style={{
-                  width: '100%',
-                  minHeight: 100,
-                  background: '#0a0a10',
-                  border: '1px solid #2a2a3d',
-                  borderRadius: 10,
-                  color: '#f4f4ff',
-                  padding: 10,
-                  fontSize: 13,
+                  ...styles.barFill,
+                  width: batchTotal ? `${Math.round((batchCursor / batchTotal) * 100)}%` : '0%',
                 }}
               />
             </div>
-          ) : null}
-        </div>
-      ) : null}
+            <p style={{ fontSize: 13, color: '#a89cff', marginTop: 8 }}>
+              {batchRunning
+                ? `Running ${batchCursor} / ${batchTotal}`
+                : `Last batch: ${batchCursor} / ${batchTotal}`}
+            </p>
+          </div>
+        ) : null}
+      </section>
 
-      <p style={{ fontSize: 13, color: '#666', marginTop: 20 }}>
-        No local install. Images download to your computer when you click Download.
-        One OpenRouter key is set on the server once — you never paste it here.
+      <div style={styles.status}>{logLine}</div>
+
+      <section style={styles.card}>
+        <div style={styles.label}>3 · Packs ready to download</div>
+        {!doneCount && !errorCount ? (
+          <p style={{ color: '#666', fontSize: 14 }}>Nothing yet — run a batch above.</p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {products
+              .filter((p) => packs[p.id])
+              .map((p) => {
+                const pack = packs[p.id];
+                return (
+                  <div key={p.id} style={styles.packRow}>
+                    <div style={{ flex: 1, minWidth: 200 }}>
+                      <div style={{ fontWeight: 600, marginBottom: 4 }}>{p.title}</div>
+                      <div style={{ fontSize: 12, color: '#a0a0b8' }}>
+                        {p.asin || 'no ASIN'} ·{' '}
+                        <span
+                          style={{
+                            color:
+                              pack.status === 'done'
+                                ? '#3dd68c'
+                                : pack.status === 'running'
+                                  ? '#8b7cf7'
+                                  : '#ff6b7a',
+                          }}
+                        >
+                          {pack.status}
+                        </span>
+                        {pack.error ? ` · ${pack.error}` : ''}
+                      </div>
+                      {pack.listing ? (
+                        <button
+                          type="button"
+                          style={{ ...styles.btnGhost, marginTop: 8 }}
+                          onClick={() => downloadListing(pack.listing, p.asin)}
+                        >
+                          Download listing.txt
+                        </button>
+                      ) : null}
+                    </div>
+                    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                      {(pack.images || []).map((im) => (
+                        <div key={im.index}>
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={im.url}
+                            alt=""
+                            style={{
+                              width: 96,
+                              height: 120,
+                              objectFit: 'cover',
+                              borderRadius: 8,
+                              display: 'block',
+                              background: '#222',
+                            }}
+                          />
+                          <button
+                            type="button"
+                            style={{ ...styles.btnGhost, width: '100%', marginTop: 4, fontSize: 11 }}
+                            onClick={() => downloadImg(im.url, p.asin, im.index)}
+                          >
+                            Save {im.index}
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+          </div>
+        )}
+      </section>
+
+      <p style={{ fontSize: 13, color: '#555', marginTop: 24, lineHeight: 1.5 }}>
+        Family-only. Bookmark this site. Your daughter only needs the password and this page — no
+        PowerShell, no GitHub.
       </p>
     </main>
   );
 }
 
-const btnMain = {
-  width: '100%',
-  padding: '14px 16px',
-  borderRadius: 12,
-  border: 'none',
-  background: '#3dd68c',
-  color: '#042',
-  fontWeight: 700,
-  fontSize: 16,
-  cursor: 'pointer',
-};
-
-const btnGhost = {
-  padding: '10px 14px',
-  borderRadius: 10,
-  border: '1px solid #2a2a3d',
-  background: '#1a1a28',
-  color: '#f4f4ff',
-  fontWeight: 600,
-  fontSize: 13,
-  cursor: 'pointer',
+const styles = {
+  wrap: { maxWidth: 880, margin: '0 auto', padding: '28px 16px 72px' },
+  h1: { fontSize: '1.55rem', marginBottom: 8 },
+  sub: { color: '#a0a0b8', marginBottom: 20, lineHeight: 1.5, fontSize: 15 },
+  card: {
+    background: '#14141f',
+    border: '1px solid #2a2a3d',
+    borderRadius: 14,
+    padding: 18,
+    marginBottom: 14,
+  },
+  label: {
+    fontSize: 12,
+    color: '#a0a0b8',
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    marginBottom: 12,
+  },
+  status: {
+    background: '#0f1a14',
+    border: '1px solid #1f3d2e',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 14,
+    fontSize: 14,
+    color: '#c8f0d8',
+  },
+  packRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 14,
+    padding: 12,
+    borderRadius: 12,
+    background: 'rgba(0,0,0,0.25)',
+    border: '1px solid #2a2a3d',
+  },
+  input: {
+    width: '100%',
+    padding: 12,
+    borderRadius: 10,
+    border: '1px solid #2a2a3d',
+    background: '#0a0a10',
+    color: '#fff',
+    marginBottom: 10,
+    fontSize: 16,
+  },
+  btnGreen: {
+    padding: '12px 16px',
+    borderRadius: 12,
+    border: 'none',
+    background: '#3dd68c',
+    color: '#042',
+    fontWeight: 700,
+    fontSize: 15,
+    cursor: 'pointer',
+  },
+  btnPurple: {
+    padding: '12px 16px',
+    borderRadius: 12,
+    border: 'none',
+    background: '#7c6af7',
+    color: '#fff',
+    fontWeight: 700,
+    fontSize: 15,
+    cursor: 'pointer',
+  },
+  btnGhost: {
+    padding: '10px 14px',
+    borderRadius: 10,
+    border: '1px solid #2a2a3d',
+    background: '#1a1a28',
+    color: '#f4f4ff',
+    fontWeight: 600,
+    fontSize: 13,
+    cursor: 'pointer',
+  },
+  btnStop: {
+    padding: '12px 16px',
+    borderRadius: 12,
+    border: 'none',
+    background: '#ff6b7a',
+    color: '#1a0000',
+    fontWeight: 700,
+    fontSize: 15,
+    cursor: 'pointer',
+  },
+  barBg: {
+    height: 10,
+    borderRadius: 999,
+    background: '#222',
+    overflow: 'hidden',
+  },
+  barFill: {
+    height: '100%',
+    background: 'linear-gradient(90deg,#7c6af7,#3dd68c)',
+    transition: 'width 0.3s',
+  },
+  err: { color: '#ff6b7a', marginTop: 10 },
 };

--- a/products/marketplace-relister/middleware.js
+++ b/products/marketplace-relister/middleware.js
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+
+/** Protect API routes when FAMILY_APP_PASSWORD is set. */
+export function middleware(request) {
+  const password = process.env.FAMILY_APP_PASSWORD;
+  if (!password) return NextResponse.next();
+
+  const { pathname } = request.nextUrl;
+  if (
+    pathname.startsWith('/api/login') ||
+    pathname.startsWith('/api/session') ||
+    pathname.startsWith('/_next')
+  ) {
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith('/api/')) {
+    const cookie = request.cookies.get('family_ok')?.value;
+    if (cookie !== '1') {
+      return NextResponse.json({ error: 'Login required' }, { status: 401 });
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+};

--- a/products/marketplace-relister/package.json
+++ b/products/marketplace-relister/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marketplace-relister",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3040",


### PR DESCRIPTION
Real private family app: password gate, upload CSV once, process batches of 10/25/all with progress bar, lifestyle images per product, download packs. Deploy products/marketplace-relister on Vercel with OPENROUTER_API_KEY + FAMILY_APP_PASSWORD. No PowerShell for daily use.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR transforms the marketplace-relister app from a single-product manual tool into a **private family batch processing app** with password authentication. The new version allows users to upload a CSV once, process products in configurable batches (10/25/all) with a progress bar, view lifestyle images for each product, and download image packs. Key additions include a password gate using cookies (`FAMILY_APP_PASSWORD` environment variable), batch processing with automatic iteration through products, middleware to protect API routes, and improved UX for daily non-technical use without PowerShell or manual workflows.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `products/marketplace-relister/README.md` |
| 2 | `products/marketplace-relister/app/api/login/route.js` |
| 3 | `products/marketplace-relister/app/api/session/route.js` |
| 4 | `products/marketplace-relister/middleware.js` |
| 5 | `products/marketplace-relister/app/page.js` |
| 6 | `products/marketplace-relister/app/api/generate/route.js` |
| 7 | `products/marketplace-relister/app/layout.js` |
| 8 | `products/marketplace-relister/package.json` |
| 9 | `START_HERE_CALL_CHAIN.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a private, password‑protected family batch app on Vercel that turns Amazon order CSVs into per‑product lifestyle photo packs with a progress bar and easy downloads. Replaces the demo flow with a real daily tool: login, upload once, process next 10/25/all, download packs.

- New Features
  - Password gate with login/session cookies and middleware; if `FAMILY_APP_PASSWORD` is unset the app stays open.
  - Batch controls to process next 10/25/all, with progress bar and a stop button; runs in the background of the open tab.
  - Per‑product packs: 3 images plus a generated `listing.txt`, with inline previews and one‑click downloads.
  - Stronger prompts (now 5 variants) and clearer errors when `OPENROUTER_API_KEY` or an image‑capable `OPENROUTER_IMAGE_MODEL` is missing.
  - API updates: `/api/generate` returns images, listing, and per‑image errors; new `/api/login` and `/api/session`.
  - UI rewrite and copy updates under “Family Order Packs”; CSV still parsed in‑browser, secrets stay on Vercel.

- Migration
  - Deploy `products/marketplace-relister` as its own Vercel project (Root Directory = `products/marketplace-relister`).
  - Set env vars: `OPENROUTER_API_KEY` and `FAMILY_APP_PASSWORD` (optional `OPENROUTER_IMAGE_MODEL`).
  - Redeploy existing instances after adding `FAMILY_APP_PASSWORD`; bookmark and share the app URL + password.
  - Version bumped to 2.0.0.

<sup>Written for commit 22d4e3589484cb1ae110a7746eeace864585562b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

