### PR TITLE
fix(biome): degrade gracefully instead of crashing on transient API errors

### DIFF
--- a/scripts/biome/medic.js
+++ b/scripts/biome/medic.js
@@ -79,8 +79,15 @@ if (require.main === module) {
 
     const allowReruns = String(process.env.BIOME_ALLOW_RERUNS || '').toLowerCase() === 'true';
 
-    const runsResp = await repoApi('/actions/runs?per_page=100');
-    const issuesResp = (await repoApi('/issues?state=open&per_page=100&filter=all')) || [];
+    // allowError: true — a single transient API error (rate limit, 5xx) here must
+    // degrade this sweep gracefully, not crash the whole crew (see gh.js: allowError
+    // callers get null back instead of a throw). Warn loudly so a degraded sweep is
+    // never mistaken for "genuinely healthy".
+    const runsResp = await repoApi('/actions/runs?per_page=100', { allowError: true });
+    if (!runsResp) console.warn('[biome-medic] warning: failed to fetch recent workflow runs (API error) — treating as 0 runs for this sweep');
+    const issuesRespRaw = await repoApi('/issues?state=open&per_page=100&filter=all', { allowError: true });
+    if (!issuesRespRaw) console.warn('[biome-medic] warning: failed to fetch open issues (API error) — treating as 0 issues for this sweep');
+    const issuesResp = issuesRespRaw || [];
     const runClass = classifyRuns((runsResp && runsResp.workflow_runs) || []);
     const stuck = detectStuckIssues(issuesResp, Date.now());
     const assessment = assessKeyHealth(process.env);

--- a/scripts/biome/sentinel.js
+++ b/scripts/biome/sentinel.js
@@ -143,8 +143,14 @@ module.exports = {
 if (require.main === module) {
   (async () => {
     const { repoApi } = require('./gh');
-    const runsResp = await repoApi('/actions/runs?per_page=100');
-    const issuesResp = await repoApi('/issues?state=open&per_page=100&filter=all');
+    // allowError: true — a single transient API error (rate limit, 5xx) here must
+    // degrade this sweep gracefully, not crash the whole crew (see gh.js: allowError
+    // callers get null back instead of a throw). Warn loudly so a degraded sweep is
+    // never mistaken for "genuinely healthy".
+    const runsResp = await repoApi('/actions/runs?per_page=100', { allowError: true });
+    if (!runsResp) console.warn('[biome-sentinel] warning: failed to fetch recent workflow runs (API error) — treating as 0 runs for this sweep');
+    const issuesResp = await repoApi('/issues?state=open&per_page=100&filter=all', { allowError: true });
+    if (!issuesResp) console.warn('[biome-sentinel] warning: failed to fetch open issues (API error) — treating as 0 issues for this sweep');
     const runClass = classifyRuns((runsResp && runsResp.workflow_runs) || []);
     const stuck = detectStuckIssues(issuesResp || [], Date.now(), DEFAULTS.stuckDays);
     const section = buildSentinelSection(runClass, stuck);

--- a/scripts/biome/sheaf.js
+++ b/scripts/biome/sheaf.js
@@ -118,9 +118,15 @@ if (require.main === module) {
 
     const generatedAt = new Date().toISOString();
 
-    // Read-only data gather.
-    const runsResp = await repoApi('/actions/runs?per_page=100');
-    const issuesResp = (await repoApi('/issues?state=open&per_page=100&filter=all')) || [];
+    // Read-only data gather. allowError: true — a single transient API error (rate
+    // limit, 5xx) here must degrade this sweep gracefully, not crash the whole crew
+    // (see gh.js: allowError callers get null back instead of a throw). Warn loudly
+    // so a degraded feed is never mistaken for "genuinely healthy".
+    const runsResp = await repoApi('/actions/runs?per_page=100', { allowError: true });
+    if (!runsResp) console.warn('[biome-sheaf] warning: failed to fetch recent workflow runs (API error) — treating as 0 runs for this sweep');
+    const issuesRespRaw = await repoApi('/issues?state=open&per_page=100&filter=all', { allowError: true });
+    if (!issuesRespRaw) console.warn('[biome-sheaf] warning: failed to fetch open issues (API error) — treating as 0 issues for this sweep');
+    const issuesResp = issuesRespRaw || [];
     const runs = (runsResp && runsResp.workflow_runs) || [];
 
     const runClass = sentinel.classifyRuns(runs);


### PR DESCRIPTION
## Summary

`sentinel.js`, `medic.js`, and `sheaf.js` each called `repoApi()` (`scripts/biome/gh.js`) for their primary data-gathering calls (`/actions/runs` and `/issues`) without `allowError: true`. `gh.js`'s `api()` throws on any non-2xx response unless `allowError` is set, so a single transient GitHub API error (rate limit, 5xx) on any of these calls threw, propagated out of the CLI's async IIFE, hit the top-level `.catch`, and called `process.exit(1)` — killing the entire sweep (no incident detection, no remediation, no status-feed write) instead of degrading gracefully. This defeats these workers' own design goal (resilient, always-up self-healing) and matches the failure class already logged in `learnings.md` (2026-07-13 entry: self-healing jobs dying mid-sweep on transient API errors).

No linked issue — this fix came out of a direct code audit rather than a filed WR/issue.

## Changes

- `scripts/biome/sentinel.js` (~line 146-149): added `allowError: true` to the `/actions/runs` and `/issues` fetches; log a `console.warn` and fall back to an empty list when either fetch fails, instead of throwing.
- `scripts/biome/medic.js` (~line 82-85): same fix — `allowError: true` on both primary fetches, with a warn + empty-list fallback for the issues fetch (runs fetch already degraded via `(runsResp && runsResp.workflow_runs) || []`, now it just no longer throws upstream).
- `scripts/biome/sheaf.js` (~line 122-124): same fix — `allowError: true` on both primary fetches, with warn + empty-list fallback, so a transient error only degrades that section of the status feed instead of aborting the whole feed write.

The fallback convention (warn loudly, then continue with an empty list) mirrors how `homeostat.js` and `inspector.js` already use `allowError: true` elsewhere in the crew — the fix does not invent a new pattern, it applies the existing one to the three primary calls the audit found missing it.

## Validation

`npm ci && npm test` passes locally (558/558 tests, 0 failures) with no changes needed elsewhere. Confirmed the three modules still `require()` cleanly after the edit. No existing unit tests exercise the CLI (`require.main === module`) blocks in these files — the exported pure functions (`classifyRuns`, `detectStuckIssues`, `decideRemediations`, `glueSections`, etc.) are unit-tested and unaffected by this change, so no test changes were needed; adding CLI-level tests would require refactoring the inline IIFEs into exported functions, which is out of scope for this fix (no unrelated code touched, per repo convention).

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — N/A, no linked issue (audit-discovered bug)
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above


---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves the resilience of three biome monitoring scripts (`sentinel.js`, `medic.js`, and `sheaf.js`) by preventing them from crashing on transient GitHub API errors. Previously, rate limits or 5xx responses would terminate the entire sweep, defeating the self-healing design goal. The fix adds `allowError: true` to critical API calls and implements graceful degradation: when fetches fail, the scripts now log a warning and continue with empty data sets instead of aborting. This applies an existing error-handling pattern already used elsewhere in the codebase to three calls that were missing it.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/biome/sentinel.js` |
| 2 | `scripts/biome/medic.js` |
| 3 | `scripts/biome/sheaf.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents biome sweeps from crashing on transient GitHub API errors. Adds `allowError: true` to key `repoApi` calls and degrades to empty data with warnings so workers keep running.

- **Bug Fixes**
  - `scripts/biome/sentinel.js`: add `allowError: true` for `/actions/runs` and `/issues`; warn on null responses; use empty lists so section build continues.
  - `scripts/biome/medic.js`: same handling for both endpoints; warn on missing runs/issues; fall back to empty lists to keep the sweep alive.
  - `scripts/biome/sheaf.js`: same handling; warn and degrade to empty lists so status feed still writes.

<sup>Written for commit a6d6f9098f2f6e8e8132f2069db18348354ccdff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

