### PR TITLE
fix(security): pass gh secret value via stdin, not argv

### DIFF
--- a/scripts/credential-autonomy-agent.js
+++ b/scripts/credential-autonomy-agent.js
@@ -86,13 +86,13 @@ function log(message, type = 'info') {
 function run(command, args = [], options = {}) {
   // spawnSync with an explicit argv array does NOT spawn a shell, so args
   // cannot be shell-injected. All callers pass a fixed command ('gh').
-  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process -- arg array (no shell); command is a fixed literal at every call site
   //
   // Callers may pass `options.input` to feed data (e.g. secret values) to
   // the child's stdin instead of argv, since argv is visible to any other
   // process on the host for the process's lifetime via
   // /proc/<pid>/cmdline or `ps aux`. stdio[0] must be 'pipe' (not
   // 'ignore') for `input` to actually reach the child.
+  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process -- arg array (no shell); command is a fixed literal at every call site
   const result = spawnSync(command, args, {
     encoding: 'utf8',
     stdio: [options.input !== undefined ? 'pipe' : 'ignore', 'pipe', 'pipe'],

--- a/scripts/credential-autonomy-agent.js
+++ b/scripts/credential-autonomy-agent.js
@@ -87,9 +87,15 @@ function run(command, args = [], options = {}) {
   // spawnSync with an explicit argv array does NOT spawn a shell, so args
   // cannot be shell-injected. All callers pass a fixed command ('gh').
   // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process -- arg array (no shell); command is a fixed literal at every call site
+  //
+  // Callers may pass `options.input` to feed data (e.g. secret values) to
+  // the child's stdin instead of argv, since argv is visible to any other
+  // process on the host for the process's lifetime via
+  // /proc/<pid>/cmdline or `ps aux`. stdio[0] must be 'pipe' (not
+  // 'ignore') for `input` to actually reach the child.
   const result = spawnSync(command, args, {
     encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: [options.input !== undefined ? 'pipe' : 'ignore', 'pipe', 'pipe'],
     ...options,
   });
   return {
@@ -206,7 +212,11 @@ async function restore(secretsToRestore) {
     if (DRY_RUN) {
       log(`${name}: would restore (DRY RUN)`, 'action');
     } else {
-      const result = run('gh', ['secret', 'set', name, '--body', value, '--repo', REPO]);
+      // Pass the plaintext value via stdin (not argv/--body) so it never
+      // appears in `ps aux` / /proc/<pid>/cmdline. `gh secret set` reads
+      // from stdin by default when --body is omitted — same safe pattern
+      // already established in scripts/provision-repo-secrets.sh.
+      const result = run('gh', ['secret', 'set', name, '--repo', REPO], { input: value });
       if (result.ok) {
         log(`${name}: restored`, 'success');
         restored.push(name);


### PR DESCRIPTION
## Summary

**Security fix (MEDIUM severity).** `scripts/credential-autonomy-agent.js`'s `restore()` function called:

```js
run('gh', ['secret', 'set', name, '--body', value, '--repo', REPO]);
```

This placed the plaintext secret `value` as a literal argv element of the child process. Argv is visible to any other process on the same host for the process's lifetime via `/proc/<pid>/cmdline` or `ps aux`. `restore()` is wired live via `.github/workflows/credential-autonomy-agent.yml`, so this ran with real credentials.

This repo already identified and avoided this exact leak elsewhere: `scripts/provision-repo-secrets.sh` (~lines 125-129) explicitly documents and uses the safe pattern — `gh secret set` reads the value from stdin by default when `--body` is omitted, so the plaintext never appears on a command line visible to `ps`. `credential-autonomy-agent.js` did not follow that established guard.

## Changes

- `run()` now accepts an optional `options.input`. When present, `stdio[0]` is switched from `'ignore'` to `'pipe'` so `spawnSync` actually delivers `input` to the child's stdin (confirmed by testing: Node silently drops `input` if `stdio[0]` is `'ignore'`, despite what the general `spawnSync` docs imply).
- `restore()` drops `--body`/`value` from argv entirely and instead calls `run('gh', ['secret', 'set', name, '--repo', REPO], { input: value })`.
- The other two `run('gh', ...)` call sites in this file (`secret list`, `secret remove`) pass no `input` and are unaffected — verified they keep their previous `stdio: ['ignore', 'pipe', 'pipe']` behavior.

## Validation

- `npm ci && npm test` — all 558 tests pass, no regressions.
- `node -c scripts/credential-autonomy-agent.js` — syntax OK.
- Manual functional check with a stub `gh` binary that logs argv and stdin separately: confirmed the secret value no longer appears in the `secret set` argv (`ARGV: secret set OPENROUTER_API_KEY --repo ...`), and is delivered correctly via stdin (exact-match verified). Also confirmed nothing leaks into the script's own stdout/log output.
- No secret values were logged or printed anywhere during this work.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge *(no tracking issue was provided for this fix — audit-driven)*
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above


---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a **medium severity security vulnerability** where GitHub secret values were being passed as command-line arguments (argv) instead of via stdin. This exposed plaintext secrets through `/proc/<pid>/cmdline` and `ps aux` for the lifetime of the process. The fix modifies the `run()` helper function to accept an optional `input` parameter that pipes data to stdin when provided, and updates the `restore()` function to pass secret values via stdin instead of the `--body` flag. This aligns with the safe pattern already established elsewhere in the codebase (`provision-repo-secrets.sh`).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/credential-autonomy-agent.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route secret values to stdin for `gh secret set` so plaintext never appears in argv and can’t leak via ps/proc. Also fixes a Semgrep suppression placement to keep CI passing.

- **Bug Fixes**
  - `run()` now accepts `options.input` and sets `stdio[0] = 'pipe'` when provided.
  - `restore()` sends the secret via stdin and drops `--body VALUE`; other `gh` calls are unchanged.
  - Moved the nosemgrep suppression back above `spawnSync` to restore the intended rule suppression.

<sup>Written for commit 408587fa49b692382ca269e4420490b6024a2154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

