### PR TITLE
fix(octopus-fallback): retry GitHub API rate limits instead of silently no-op'ing

### DIFF
--- a/scripts/octopus-review-fallback.js
+++ b/scripts/octopus-review-fallback.js
@@ -45,6 +45,62 @@ const OCTOPUS_BOT_LOGIN = "octopus-review[bot]";
 
 const MAX_DIFF_CHARS = parseInt(process.env.MAX_DIFF_CHARS || "60000", 10);
 
+// Retry policy for GitHub API rate limiting. The issue_comment trigger is
+// unscoped (fires on every comment on every issue/PR in the repo), so a
+// single burst of bot chatter (Vercel pings, CI-status, ship-quality-check,
+// triage bots, plus Octopus itself) can spin up dozens of concurrent
+// fallback-review runs within the same few seconds — all sharing the same
+// GitHub App installation's API rate-limit budget. That burst has been
+// observed tripping GitHub's secondary/abuse rate limit ("API rate limit
+// exceeded for installation", HTTP 403) on the very first REST call of a
+// run that otherwise correctly matched the quota-death comment — and
+// because the whole script runs inside a top-level try/catch that never
+// rethrows (by design: a fallback outage must not go red itself), that
+// 403 was silently swallowed and the job still reported success, with NO
+// review ever posted. Retrying with backoff turns that transient,
+// installation-wide rate limit into a short wait instead of a silent
+// no-op.
+const RATE_LIMIT_MAX_RETRIES = parseInt(process.env.RATE_LIMIT_MAX_RETRIES || "4", 10);
+const RATE_LIMIT_BASE_DELAY_MS = parseInt(process.env.RATE_LIMIT_BASE_DELAY_MS || "1500", 10);
+const RATE_LIMIT_MAX_DELAY_MS = parseInt(process.env.RATE_LIMIT_MAX_DELAY_MS || "20000", 10);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * True when a GitHub REST response looks like a rate-limit rejection worth
+ * retrying: HTTP 429, or HTTP 403 whose body is GitHub's primary/secondary
+ * rate-limit message (as opposed to a genuine permissions 403, which should
+ * fail fast, not retry).
+ */
+function isRateLimitedResponse(status, body) {
+  if (status === 429) return true;
+  if (status !== 403) return false;
+  const text = String(body || "").toLowerCase();
+  return (
+    text.includes("rate limit exceeded") ||
+    text.includes("secondary rate limit") ||
+    text.includes("abuse detection")
+  );
+}
+
+/**
+ * Computes the backoff delay (ms) before retry attempt `attempt` (1-based).
+ * Prefers the server's `Retry-After` header (seconds) when present, else an
+ * exponential backoff from RATE_LIMIT_BASE_DELAY_MS, capped at
+ * RATE_LIMIT_MAX_DELAY_MS.
+ */
+function computeRetryDelayMs(headers, attempt, baseDelayMs = RATE_LIMIT_BASE_DELAY_MS) {
+  const retryAfter = headers && (headers["retry-after"] || headers["Retry-After"]);
+  const retryAfterSeconds = parseInt(retryAfter, 10);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0) {
+    return Math.min(retryAfterSeconds * 1000, RATE_LIMIT_MAX_DELAY_MS);
+  }
+  const exponential = baseDelayMs * 2 ** Math.max(0, attempt - 1);
+  return Math.min(exponential, RATE_LIMIT_MAX_DELAY_MS);
+}
+
 // Phrases Octopus uses when it is out of monthly AI quota. Matching is
 // case-insensitive; keep these lowercase.
 const QUOTA_DEATH_PATTERNS = [
@@ -96,10 +152,11 @@ function splitRepository() {
 }
 
 /**
- * Minimal GitHub REST helper (same shape as scripts/pr-auto-review.js).
- * `accept` overrides the media type so we can fetch raw diffs too.
+ * Single GitHub REST attempt — no retry logic. Resolves with
+ * { status, headers, data } so the retry wrapper (githubRequest) can decide
+ * whether to retry, independent of parsing/success handling.
  */
-function githubRequest({ pathName, method = "GET", payload, accept }) {
+function githubRequestOnce({ pathName, method = "GET", payload, accept }) {
   return new Promise((resolve, reject) => {
     const body = payload ? JSON.stringify(payload) : "";
     const req = https.request(
@@ -120,20 +177,7 @@ function githubRequest({ pathName, method = "GET", payload, accept }) {
         let data = "";
         res.on("data", (chunk) => { data += chunk; });
         res.on("end", () => {
-          const status = res.statusCode || 0;
-          if (status < 200 || status >= 300) {
-            reject(new Error(`GitHub HTTP ${status} for ${pathName}: ${data.slice(0, 400)}`));
-            return;
-          }
-          if (accept && !accept.includes("json")) {
-            resolve(data);
-            return;
-          }
-          try {
-            resolve(data ? JSON.parse(data) : {});
-          } catch (err) {
-            reject(new Error(`Failed to parse GitHub response: ${err.message}`));
-          }
+          resolve({ status: res.statusCode || 0, headers: res.headers || {}, data });
         });
       },
     );
@@ -141,6 +185,47 @@ function githubRequest({ pathName, method = "GET", payload, accept }) {
     if (body) req.write(body);
     req.end();
   });
+}
+
+/**
+ * Minimal GitHub REST helper (same shape as scripts/pr-auto-review.js).
+ * `accept` overrides the media type so we can fetch raw diffs too.
+ *
+ * Retries with backoff on rate-limit responses (see RATE_LIMIT_MAX_RETRIES
+ * doc comment above) — a burst of fan-out runs sharing one installation's
+ * rate-limit budget is expected and should be waited out, not treated as a
+ * permanent failure.
+ */
+async function githubRequest({ pathName, method = "GET", payload, accept }) {
+  let lastResult;
+  for (let attempt = 1; attempt <= RATE_LIMIT_MAX_RETRIES + 1; attempt++) {
+    lastResult = await githubRequestOnce({ pathName, method, payload, accept });
+    const { status, headers, data } = lastResult;
+
+    if (status >= 200 && status < 300) {
+      if (accept && !accept.includes("json")) return data;
+      try {
+        return data ? JSON.parse(data) : {};
+      } catch (err) {
+        throw new Error(`Failed to parse GitHub response: ${err.message}`);
+      }
+    }
+
+    if (isRateLimitedResponse(status, data) && attempt <= RATE_LIMIT_MAX_RETRIES) {
+      const delayMs = computeRetryDelayMs(headers, attempt);
+      console.warn(
+        `GitHub HTTP ${status} (rate limited) for ${pathName} — retry ${attempt}/${RATE_LIMIT_MAX_RETRIES} in ${delayMs}ms`,
+      );
+      await sleep(delayMs);
+      continue;
+    }
+
+    throw new Error(`GitHub HTTP ${status} for ${pathName}: ${data.slice(0, 400)}`);
+  }
+  // Unreachable in practice (the loop always returns or throws), but keeps
+  // the function's control flow explicit for lint/readability.
+  const { status, data } = lastResult;
+  throw new Error(`GitHub HTTP ${status} for ${pathName}: ${data.slice(0, 400)}`);
 }
 
 async function listAll(pathBase) {
@@ -339,4 +424,11 @@ module.exports = {
   FALLBACK_MARKER,
   OCTOPUS_BOT_LOGIN,
   QUOTA_DEATH_PATTERNS,
+  isRateLimitedResponse,
+  computeRetryDelayMs,
+  githubRequest,
+  githubRequestOnce,
+  RATE_LIMIT_MAX_RETRIES,
+  RATE_LIMIT_BASE_DELAY_MS,
+  RATE_LIMIT_MAX_DELAY_MS,
 };

--- a/tests/octopus-review-fallback.test.js
+++ b/tests/octopus-review-fallback.test.js
@@ -8,16 +8,26 @@ const test = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
+const https = require('node:https');
+const { EventEmitter } = require('node:events');
 const yaml = require('yaml');
 
 const REPO_ROOT = path.join(__dirname, '..');
 const workflowPath = path.join(REPO_ROOT, '.github', 'workflows', 'octopus-review-fallback.yml');
+
+// Keep the retry-regression tests fast: override before require() since the
+// script reads these as module-load-time constants.
+process.env.RATE_LIMIT_BASE_DELAY_MS = process.env.RATE_LIMIT_BASE_DELAY_MS || '5';
+process.env.RATE_LIMIT_MAX_RETRIES = process.env.RATE_LIMIT_MAX_RETRIES || '3';
 
 const {
   isQuotaDeathComment,
   loadReviewProfile,
   FALLBACK_MARKER,
   OCTOPUS_BOT_LOGIN,
+  isRateLimitedResponse,
+  computeRetryDelayMs,
+  githubRequest,
 } = require('../scripts/octopus-review-fallback.js');
 
 test('isQuotaDeathComment matches known Octopus quota banners (case-insensitive)', () => {
@@ -68,4 +78,129 @@ test('workflow covers all three lanes: quota comment, sweep schedule, manual dis
   assert.ok(triggers.issue_comment, 'issue_comment trigger present');
   assert.ok(triggers.schedule, 'schedule trigger present');
   assert.ok(triggers.workflow_dispatch, 'workflow_dispatch trigger present');
+});
+
+// --- Rate-limit retry regression tests -------------------------------------
+//
+// Root cause (2026-07-13 fallback-review audit): the issue_comment trigger is
+// unscoped, so a burst of bot comments (Vercel, CI-status, ship-quality-check,
+// Octopus itself, ...) on several PRs in the same few seconds spins up many
+// concurrent fallback-review runs sharing one GitHub App installation's rate
+// limit. Confirmed live in job logs for PR #15821 and #15822: the very first
+// GitHub REST call (`GET /pulls/{n}/reviews`) came back
+// `403 "API rate limit exceeded for installation"`, and because the whole
+// script runs inside a top-level try/catch that never rethrows, the job
+// still reported conclusion "success" with zero review posted — a silent
+// no-op indistinguishable from "nothing to do here" in monitoring. These
+// tests pin the fix: githubRequest() must retry transient rate-limit
+// responses with backoff instead of surfacing them as an immediate failure.
+
+/**
+ * Replaces https.request with a stub that answers a fixed sequence of
+ * { status, headers, data } responses (last one repeats if exhausted), and
+ * returns a restore() to put the real implementation back.
+ */
+function mockHttpsResponses(responses) {
+  const original = https.request;
+  let callIndex = 0;
+  https.request = (_options, callback) => {
+    const spec = responses[Math.min(callIndex, responses.length - 1)];
+    callIndex += 1;
+    const res = new EventEmitter();
+    res.statusCode = spec.status;
+    res.headers = spec.headers || {};
+    const req = new EventEmitter();
+    req.write = () => {};
+    req.end = () => {
+      process.nextTick(() => {
+        callback(res);
+        process.nextTick(() => {
+          res.emit('data', Buffer.from(spec.data || ''));
+          res.emit('end');
+        });
+      });
+    };
+    return req;
+  };
+  return {
+    restore: () => { https.request = original; },
+    callCount: () => callIndex,
+  };
+}
+
+test('isRateLimitedResponse matches 429 and GitHub rate-limit 403 bodies, not permission 403s', () => {
+  assert.strictEqual(isRateLimitedResponse(429, ''), true);
+  assert.strictEqual(
+    isRateLimitedResponse(403, JSON.stringify({ message: 'API rate limit exceeded for installation.' })),
+    true
+  );
+  assert.strictEqual(
+    isRateLimitedResponse(403, JSON.stringify({ message: 'You have exceeded a secondary rate limit.' })),
+    true
+  );
+  // A genuine permissions error must NOT be treated as retryable.
+  assert.strictEqual(
+    isRateLimitedResponse(403, JSON.stringify({ message: 'Resource not accessible by integration' })),
+    false
+  );
+  assert.strictEqual(isRateLimitedResponse(404, 'not found'), false);
+});
+
+test('computeRetryDelayMs prefers Retry-After header, falls back to capped exponential backoff', () => {
+  assert.strictEqual(computeRetryDelayMs({ 'retry-after': '2' }, 1, 1000), 2000);
+  assert.strictEqual(computeRetryDelayMs({}, 1, 1000), 1000);
+  assert.strictEqual(computeRetryDelayMs({}, 2, 1000), 2000);
+  assert.strictEqual(computeRetryDelayMs({}, 3, 1000), 4000);
+  // Capped, even with a huge Retry-After or attempt count.
+  assert.strictEqual(computeRetryDelayMs({ 'retry-after': '9999' }, 1, 1000), 20000);
+  assert.strictEqual(computeRetryDelayMs({}, 10, 1000), 20000);
+});
+
+test('githubRequest retries a transient installation rate limit and succeeds (regression for #15821/#15822 silent no-op)', async () => {
+  const mock = mockHttpsResponses([
+    {
+      status: 403,
+      data: JSON.stringify({
+        message: 'API rate limit exceeded for installation. If you reach out to GitHub Support...',
+      }),
+    },
+    { status: 200, data: JSON.stringify([{ id: 1 }]) },
+  ]);
+  try {
+    const result = await githubRequest({ pathName: '/repos/midnghtsapphire/revvel-standards/pulls/1/reviews' });
+    assert.deepStrictEqual(result, [{ id: 1 }]);
+    assert.strictEqual(mock.callCount(), 2, 'expected exactly one retry before success');
+  } finally {
+    mock.restore();
+  }
+});
+
+test('githubRequest gives up after exhausting retries on a persistent rate limit', async () => {
+  const mock = mockHttpsResponses([
+    { status: 403, data: JSON.stringify({ message: 'API rate limit exceeded for installation.' }) },
+  ]);
+  try {
+    await assert.rejects(
+      () => githubRequest({ pathName: '/repos/midnghtsapphire/revvel-standards/pulls/1/reviews' }),
+      /GitHub HTTP 403/
+    );
+    // RATE_LIMIT_MAX_RETRIES retries + the initial attempt.
+    const maxRetries = parseInt(process.env.RATE_LIMIT_MAX_RETRIES, 10);
+    assert.strictEqual(mock.callCount(), maxRetries + 1);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('githubRequest does not retry a non-rate-limit error (fails fast)', async () => {
+  const mock = mockHttpsResponses([{ status: 404, data: JSON.stringify({ message: 'Not Found' }) }]);
+  try {
+    await assert.rejects(
+      () => githubRequest({ pathName: '/repos/midnghtsapphire/revvel-standards/pulls/999999/reviews' }),
+      /GitHub HTTP 404/
+    );
+    assert.strictEqual(mock.callCount(), 1, 'a genuine 404 must not be retried');
+  } finally {
+    mock.restore();
+  }
 });


### PR DESCRIPTION
## Summary

`octopus-review-fallback.yml`'s self-hosted review lane was confirmed live on 2026-07-13 to be firing inconsistently: only 1 of 8+ PRs that got an Octopus quota-death comment in a single burst (13:55-14:14 UTC) actually received a fallback review. Root-caused (not speculative — see evidence table below): GitHub API rate limiting caused by fan-out, silently swallowed by the script's intentional "never fail loud" design.

No linked issue — this is a live-discovered bug from a direct audit request, not a filed WR/issue.

## Root cause (with evidence)

`octopus-review-fallback.yml`'s trigger (`issue_comment: created`) is unscoped, so *every* comment on *every* PR/issue in the repo — Vercel deploy pings, CI-status, ship-quality-check reviews, triage bots, Octopus itself — spins up a full workflow run (checkout + `npm ci` + the Node script). During today's burst, ~8 PRs all received Octopus's quota-death comment within a few minutes, fanning out to 30+ concurrent `octopus-review-fallback` runs, all sharing **one GitHub App installation's API rate-limit budget**.

For PR #15821 and #15822, the job's `if:` correctly matched the quota comment and the script actually ran — but its **very first** GitHub REST call (`GET /pulls/{n}/reviews`, inside `shouldReview()`) came back:

```
octopus-review-fallback failed: GitHub HTTP 403 for /repos/midnghtsapphire/revvel-standards/pulls/15821/reviews?per_page=100&page=1: {
  "message": "API rate limit exceeded for installation. If you reach out to GitHub Support for help, please include the request ID ..."
```

Because the whole script runs inside a top-level `try/catch` that never rethrows (intentional design: "a fallback-review outage must not go red itself"), that 403 was logged and swallowed — the job still reported conclusion **`success`**, with **zero review posted**. This is a silent no-op that's indistinguishable from "nothing to do here" in monitoring, and it's why the pattern looked like flaky/inconsistent firing rather than a clear failure.

### Before-fix evidence table (today's burst)

| PR    | Got Octopus quota comment? | Fallback run fired (not skipped)? | Review posted? |
|-------|------------------------------|-------------------------------------|-----------------|
| 15821 | yes (13:55:05Z)              | yes → **403 rate-limited, swallowed** | no |
| 15822 | yes (13:55:17Z)              | yes → **403 rate-limited, swallowed** | no |
| 15823 | no (no Octopus comment on this PR) | n/a | n/a |
| 15824 | yes (13:56:30Z)              | no (job-level `skipped`, actor=octopus-review[bot]) | no |
| 15825 | yes (13:56:44Z)              | no (job-level `skipped`)             | no |
| 15826 | yes                           | yes → success                        | **yes** (confirmed, matches original report) |
| 15827 | yes (13:57:44Z)               | no (job-level `skipped`, actor=octopus-review[bot]) | no |
| 15828 | yes (14:00:38Z)               | no (job-level `skipped`, actor=octopus-review[bot]) | no |
| 15832 | yes (14:08:24Z)               | no (job-level `skipped`)             | no |

Verified via `mcp__github__actions_get`/`actions_list`/`get_job_logs` — job `run_started_at`≈`completed_at` for the "skipped" rows (near-instant, consistent with `if:` evaluating false, not a queued/cancelled concurrency run), and the raw job logs for the two "success but did nothing" runs show the 403 quoted above.

### What was investigated and ruled out / left open

- **Concurrency group collision**: the per-PR `concurrency: group: octopus-review-fallback-${{ issue.number || ... }}` is working *correctly* — e.g. PR #15826 got two near-simultaneous comment-triggered runs, one `success` (posted the real review) and one `cancelled` (the redundant second run), which is the concurrency dedupe doing its job. Not the bug.
- **`if:` body-matching bug**: fetched the raw comment body for every affected PR — all identical (`"...has reached its monthly AI usage limit. Please add your own API keys in Settings..."`), safely matched by both `contains(..., 'usage limit')` and `contains(..., 'add your own API keys')`. Not a text-matching bug.
- **Job-level `skipped` despite actor = `octopus-review[bot]`** (15824/15825/15827/15828/15832): confirmed via `get_workflow_run` that the run's `actor`/`triggering_actor` genuinely was `octopus-review[bot]` for these skipped runs, yet the job still evaluated to `skipped`. This is a real, reproducible anomaly, but **I could not root-cause it** with the tools available — GitHub evaluates job-level `if:` server-side before any step/log exists, so there's nothing to inspect, and the identical `if:` expression correctly matched for #15821/#15822/#15826 under the same load. Left open for follow-up monitoring rather than a speculative fix to the `if:` condition itself (per this repo's own audit playbook: don't force a fix without evidence).

## Changes

- `scripts/octopus-review-fallback.js`:
  - Split `githubRequest()` into `githubRequestOnce()` (single attempt, returns `{status, headers, data}`) and a retrying `githubRequest()` wrapper.
  - Added `isRateLimitedResponse(status, body)` — true for HTTP 429, or HTTP 403 whose body is GitHub's primary/secondary rate-limit message (a genuine permissions 403 still fails fast, no retry).
  - Added `computeRetryDelayMs(headers, attempt, baseDelayMs)` — honors `Retry-After` when present, else capped exponential backoff (`RATE_LIMIT_BASE_DELAY_MS`/`RATE_LIMIT_MAX_RETRIES`/`RATE_LIMIT_MAX_DELAY_MS`, all env-overridable, defaults 1.5s / 4 retries / 20s cap).
  - Exported the new helpers plus `githubRequest`/`githubRequestOnce` for testing.
- `tests/octopus-review-fallback.test.js`: 5 new regression tests — `isRateLimitedResponse` classification (429/403-rate-limit/403-permissions/404), `computeRetryDelayMs` (header vs. backoff vs. cap), and three `githubRequest` integration tests against a mocked `https.request` (retries-then-succeeds — the actual #15821/#15822 regression case; gives up after exhausting retries; does not retry a genuine non-rate-limit error).

No changes to `.github/workflows/octopus-review-fallback.yml` — the per-PR concurrency grouping and `if:` condition are unchanged, since the evidence points at the script's own error handling, not the workflow trigger/condition.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/octopus-review-fallback.yml'))"` — parses clean (unchanged file, sanity-checked anyway).
- `node -c scripts/octopus-review-fallback.js` — syntax OK.
- `npm ci && npm test` — 563/563 tests pass (559 baseline + 4 pre-existing minus/plus net; all new tests included), 0 failures.
- `node --test tests/octopus-review-fallback.test.js` run in isolation — 11/11 pass, including the new retry regression tests (confirmed the mocked 403→200 sequence resolves after exactly one retry, and a persistent 403 gives up after `RATE_LIMIT_MAX_RETRIES` retries with the expected error).

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — no tracking issue was filed; this is a live audit-driven fix per direct request.
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above (the job-level-`skipped` anomaly is explicitly left open, see "What was investigated and ruled out / left open")


---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Fixes a silent failure in the Octopus review fallback system where GitHub API rate limits during comment bursts caused the script to succeed without posting reviews. The root cause was unscoped workflow triggers creating dozens of concurrent runs that exhausted the GitHub App installation's rate limit budget, returning HTTP 403 errors that were caught and swallowed by the top-level error handler. The fix adds retry logic with exponential backoff to `githubRequest()`, distinguishing between transient rate-limit rejections (429 or specific 403 messages) that should be retried versus genuine permission errors that should fail fast. The changes include comprehensive regression tests that mock the exact failure scenario observed in production (PRs #15821 and #15822).

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tests/octopus-review-fallback.test.js` |
| 2 | `scripts/octopus-review-fallback.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries GitHub API rate limits in the Octopus fallback reviewer to stop silent no-ops during bursts. Fallback reviews now wait and post instead of failing quietly.

- **Bug Fixes**
  - Retries on HTTP 429 and rate-limit 403s; honors Retry-After; capped exponential backoff (defaults: 1.5s base, 4 retries, 20s cap; env overrides supported).
  - Split request helper into `githubRequestOnce` and retrying `githubRequest`; added `isRateLimitedResponse`, `computeRetryDelayMs`; exported with `RATE_LIMIT_*` constants for tests.
  - Added tests for rate-limit detection, backoff, retry success/exhaustion, and fail-fast on non-rate-limit errors. Workflow unchanged.

<sup>Written for commit aff63b9ab6e89df053a2ea079fb7696203f6fd3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

