### PR TITLE
fix(openrouter-coder): reject already-merged PRs and closed issues

### DIFF
--- a/.github/workflows/openrouter-coder.yml
+++ b/.github/workflows/openrouter-coder.yml
@@ -74,6 +74,29 @@ jobs:
               repo: context.repo.repo,
               issue_number: issueNumber,
             });
+
+            // GitHub fires the `issues` webhook event (and `issue_comment` on
+            // its thread) even when the target is actually a pull request —
+            // e.g. labeling a PR via the Issues API still triggers
+            // `issues.labeled`. Without this guard, a PR mislabeled `wr:code`
+            // /`spec-approved` (or an already-merged PR whose thread later
+            // gets a "Research Findings:" comment) gets treated as a fresh
+            // issue and re-dispatched here, producing a duplicate
+            // "[openrouter] ... apply openrouter changes for #N" PR on top
+            // of already-merged work (confirmed root cause of the 2026-07-13
+            // main-breaking interleaved-merge incidents; see PR #15910).
+            if (issue.pull_request) {
+              core.notice(`#${issueNumber} is a pull request, not an issue — openrouter-coder only processes issues. Skipping.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (issue.state !== 'open') {
+              core.notice(`#${issueNumber} is not open (state=${issue.state}) — skipping.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            core.setOutput('skip', 'false');
             core.setOutput('issue_number', String(issue.number));
             core.setOutput('issue_title', issue.title || '');
             core.setOutput('issue_body', issue.body || '');
@@ -84,7 +107,7 @@ jobs:
         # so the integration must be wired explicitly via ROO_RUN_COMMAND. We
         # require BOTH the key and a run command so we never silently 404 on
         # a missing package; if either is absent, OpenRouter is the only lane.
-        if: env.ROO_API_KEY != '' && env.ROO_RUN_COMMAND != ''
+        if: steps.issue.outputs.skip != 'true' && env.ROO_API_KEY != '' && env.ROO_RUN_COMMAND != ''
         continue-on-error: true
         env:
           ROO_API_KEY: ${{ secrets.ROO_API_KEY }}
@@ -110,7 +133,7 @@ jobs:
           echo "files_written=$files" >> "$GITHUB_OUTPUT"
       - name: Generate code changes with OpenRouter (fallback)
         id: coder
-        if: steps.roo.outcome != 'success' || steps.roo.outputs.files_written == '0' || steps.roo.outputs.files_written == ''
+        if: steps.issue.outputs.skip != 'true' && (steps.roo.outcome != 'success' || steps.roo.outputs.files_written == '0' || steps.roo.outputs.files_written == '')
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,7 +171,7 @@ jobs:
           PY
       - name: Create pull request
         id: cpr
-        if: steps.coder.outputs.files_written != '0'
+        if: steps.issue.outputs.skip != 'true' && steps.coder.outputs.files_written != '0'
         uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -175,7 +198,7 @@ jobs:
               body: `✅ OpenRouter opened PR: ${{ steps.cpr.outputs.pull-request-url }}`,
             });
       - name: Comment issue when no changes were generated
-        if: steps.coder.outputs.files_written == '0'
+        if: steps.issue.outputs.skip != 'true' && steps.coder.outputs.files_written == '0'
         uses: actions/github-script@v9.0.0
         with:
           script: |


### PR DESCRIPTION
## Summary

Root cause of today's (2026-07-13) repeated main-breaking interleaved-merge incidents, most recently reconciled in #15910. This PR fixes the *cause*, not more of the damage.

## Root cause

`.github/workflows/openrouter-coder.yml`'s dispatch `if:` condition checks `github.event_name` and the applied label name, but never confirms the target is actually an **open issue**. GitHub fires the `issues` webhook event (and `issue_comment` on its thread) even when the target is a **pull request** — labeling a PR via the Issues API still triggers `issues.labeled`, and a comment on a PR's conversation thread still fires `issue_comment.created`.

So whenever something mislabels an already-merged PR with `wr:code`/`spec-approved` (or a comment containing "Research Findings:" lands on a merged PR's thread), this workflow dispatched a coding agent against it and opened a duplicate `[openrouter] ... apply openrouter changes for #N` PR on top of already-merged work — re-implementing a change that already landed, producing a duplicate copy that collides with the original when merged.

Confirmed occurrences today: #15880 (dup of #15844), #15881/#15900 (dup of the conflict-helper fix), #15894 (dup of #15887), #15909 (dup of #15821), plus at least one more folded into the #15910 restoration. This is not a one-off — it fired at least 6 times in a few hours and is still live as of this PR.

## Fix

Added a guard in the "Resolve issue context" step (applies uniformly across the `issues`, `issue_comment`, and `workflow_dispatch` trigger paths, since it runs after the initial `github.rest.issues.get()` call regardless of which event fired): after fetching the target, skip if `issue.pull_request` is present (it's actually a PR, not an issue) or `issue.state !== 'open'` (already closed/merged). The resulting `skip` output is threaded through every downstream step's `if:` condition so a skipped target does nothing further in the job — no Roo/OpenRouter invocation, no PR creation, no comment.

## Scope note

This is surgical to the confirmed culprit — `openrouter-coder.yml` is the only workflow in the fleet that actually writes code and opens PRs from issue labels/comments. Five other workflows share the same `event_name == 'issues'` + label-check shape (`openrouter-agent.yml`, `openrouter-assignee.yml`, `openrouter-auto-route.yml`, `openrouter-triage.yml`, `credential-label-router.yml`, `octopus-route.yml`, `pdf-work-request-router.yml`) but only label/route/comment — they don't write code or open PRs, so a mislabeled PR passing through them is much lower-risk (redundant labels/comments, not duplicate merged code). Recommend a follow-up audit pass on those for the same `issue.pull_request`/`issue.state` guard as defense-in-depth, but that's out of scope here — this PR targets the one workflow with actual confirmed production impact.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/openrouter-coder.yml'))"` — parses clean.
- Rebased onto current `main` (post-#15910). `npm test` shows the same failures already present on `main` independent of this change (unrelated, newer interleave damage from `a5ea140e`/`a71686dd` — separate follow-up in progress) — confirmed by diffing failure sets before/after this commit; this PR's own change introduces zero new failures.

## Checklist

- [ ] Closes #N — no single owning issue; this is a direct root-cause fix for today's incident pattern (see #15910)
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format
- [x] Scope delivered in full; broader defense-in-depth audit explicitly deferred above

---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical workflow bug where the `openrouter-coder` workflow was incorrectly processing pull requests and closed issues as if they were open issues. The root cause was that GitHub fires the `issues` webhook event even for pull requests, which led to duplicate PRs being created on top of already-merged work when someone mislabeled a merged PR. The fix adds guards to check if the target is actually a pull request (via `issue.pull_request`) or if the issue is not open (via `issue.state`), and threads a `skip` flag through all downstream workflow steps to prevent any action when these conditions are met.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/workflows/openrouter-coder.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate code-gen PRs by skipping `openrouter-coder` when the target is a PR or a closed issue. Stops reapplying changes to already-merged work (root cause of #15910).

- **Bug Fixes**
  - Add guard after `issues.get`: set `skip` when `issue.pull_request` exists or `issue.state !== 'open'`.
  - Gate all downstream steps on `skip` (Roo run, OpenRouter fallback, PR creation, comments) so nothing runs when skipped.

<sup>Written for commit c42d1bb00279be4e9751e71fcfb30bde6a4e0719. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

