### PR TITLE
fix(ci): reconcile round-3 openrouter interleave duplicates that reddened main

### DIFF
--- a/.github/workflows/daily-diagnostic-audit.yml
+++ b/.github/workflows/daily-diagnostic-audit.yml
@@ -1,34 +1,78 @@
+# ============================================================
+# DAILY DIAGNOSTIC AUDIT — bounded code-level bug diagnosis
+# ============================================================
+# NOT a duplicate of self-healing.yml. self-healing.yml (every 4h) scans
+# recent GitHub Actions RUN history, stuck issues, and agent health for
+# OPERATIONAL failures ("a workflow crashed", "an issue is stuck"). This
+# workflow is a different lens entirely: static CODE-LEVEL bug diagnosis —
+# the kind of thing a manual audit pass finds (missing `allowError`,
+# unguarded label races, token/permission gaps, exit-code-as-proxy-metric
+# bugs — see standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md). It never reads
+# workflow run history or issue state at all.
+#
+# BOUNDED SCOPE, EVERY RUN: only files under `.github/workflows/*.yml` and
+# `scripts/*.js` changed on `main` in the last 48 hours (never a full-repo
+# sweep). A quiet 48h window means zero files to diagnose and the run is a
+# clean no-op — that is expected and fine, not a failure.
+#
+# OUTPUT CAP: at most one WR issue per run, plus one comment addressed to
+# the implementing coding agent. This workflow NEVER opens a PR, NEVER
+# pushes a commit, and NEVER applies its own proposed fix — filing a WR is
+# a request for the existing openrouter-assignee.yml -> wr-pr-creation.yml
+# -> coding-agent -> review/merge pipeline to act on, never a bypass of it.
+#
+# Cost: at most one OpenRouter call per day (the `review` profile from
+# .github/agent-models.yml), zero calls on a quiet-scope day.
+#
+# The heavy lifting lives in scripts/daily-diagnostic-audit.js.
+# ============================================================
+
 name: Daily Diagnostic Audit
 
 on:
   schedule:
-    - cron: '40 6 * * *'
-  workflow_dispatch:
+    # 06:40 UTC daily — a distinct "morning" slot that doesn't collide with
+    # repo-self-healer.yml (3 AM), self-healing.yml (every 4h, on the hour),
+    # or other 06:xx/08:xx crons already scheduled in this repo (checked via
+    # `grep -n cron: .github/workflows/*.yml` before picking this minute).
+    - cron: "40 6 * * *"
+  workflow_dispatch: {}
 
 permissions:
   contents: read
   issues: write
 
+env:
+  # Prefer the ADMIN PAT so the new WR can trigger downstream WR-processing
+  # workflows (openrouter-assignee.yml, wr-pr-creation.yml) — the default
+  # GITHUB_TOKEN cannot trigger other workflows (CLAUDE.md gotcha #2 / #3 in
+  # the pattern catalog). Falls back to GITHUB_TOKEN so a missing PAT still
+  # lets the workflow run (issue just won't cascade automatically).
+  GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+  GITHUB_REPOSITORY: ${{ github.repository }}
+
 jobs:
-  audit:
+  diagnose:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
+          # Full history needed so the 48h scope scan (`git log --since`)
+          # can see commits older than the default shallow-clone depth.
           fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run daily diagnostic audit
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          SCOPE_WINDOW_HOURS: '48'
-          MAX_SCOPE_FILES: '8'
         run: node scripts/daily-diagnostic-audit.js

--- a/.github/workflows/issue-state-machine.yml
+++ b/.github/workflows/issue-state-machine.yml
@@ -25,12 +25,6 @@ on:
           - review
           - merge-ready
           - done
-
-jobs:
-  transition-state:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
 permissions:
   issues: write
 env:
@@ -57,26 +51,6 @@ jobs:
             const labelGroups = [
               ['wr:new', 'wr:research', 'wr:research-complete', 'wr:code', 'wr:pr-open', 'wr:checking', 'wr:check-failed', 'wr:review', 'wr:merge-ready', 'wr:done'],
               ['lifecycle:stuck', 'needs-human']
-          script: |
-            const issueNumber = parseInt('${{ inputs.issue_number }}', 10);
-            const targetState = '${{ inputs.target_state }}';
-            const lifecycleLabels = [
-              'state:triage',
-              'state:in-progress',
-              'state:blocked',
-              'state:review',
-              'state:done',
-            ];
-            const targetLabel = `state:${targetState}`;
-            const toRemove = lifecycleLabels.filter((l) => l !== targetLabel);
-
-            for (const label of toRemove) {
-              'lifecycle:triage',
-              'lifecycle:ready',
-              'lifecycle:in-progress',
-              'lifecycle:blocked',
-              'lifecycle:review',
-              'lifecycle:done'
             ];
 
 
@@ -115,15 +89,9 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issueNumber,
-                  name: label,
+                  name: label
                 });
                 console.log('Removed label:', label);
-                console.log(`Removed label ${label} from #${issueNumber}`);
-              } catch (e) {
-                console.log(`Label ${label} not present on #${issueNumber} (or already removed): ${e.message}`);
-              }
-            }
-                console.log(`Removed conflicting label: ${label}`);
               } catch (e) {
                 console.log('Could not remove label:', label, e.message);
               }
@@ -183,54 +151,55 @@ jobs:
               hint + '\n\n' +
               '---\n_Auto-closed by `issue-state-machine.yml` malformed-issue guard._';
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              body: closeBody,
-            });
-
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              state: 'closed',
-              state_reason: 'not_planned',
-            });
-
-            console.log('Closed malformed issue #' + issue.number);
-
-      - name: Add target lifecycle label
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issueNumber = parseInt('${{ inputs.issue_number }}', 10);
-            const targetState = '${{ inputs.target_state }}';
-            const targetLabel = `state:${targetState}`;
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              labels: [targetLabel],
-            });
-            console.log(`Added label ${targetLabel} to #${issueNumber}`);
-
-      - name: Post transition comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issueNumber = parseInt('${{ inputs.issue_number }}', 10);
-            const targetState = '${{ inputs.target_state }}';
-            const labels = context.payload.issue.labels.map(l => l.name);
-            if (!labels.some(l => l.startsWith('wr:'))) {
-              await github.rest.issues.addLabels({
+            // Guard both writes: this job fires on every issue opened event,
+            // so an installation rate-limit 403 here must degrade gracefully
+            // (log + stop this issue's processing) instead of hard-failing.
+            try {
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
-                labels: ['wr:new']
+                issue_number: issue.number,
+                body: closeBody,
               });
-              console.log('Added wr:new label');
+            } catch (e) {
+              const rateLimited = e?.status === 403 && /rate limit/i.test(e?.message || '');
+              core.warning(`createComment for issue #${issue.number} failed${rateLimited ? ' (API rate limit exceeded — degrading gracefully)' : ''}: ${e.message}`);
+            }
+
+            try {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+              console.log('Closed malformed issue #' + issue.number);
+            } catch (e) {
+              const rateLimited = e?.status === 403 && /rate limit/i.test(e?.message || '');
+              core.warning(`issues.update for issue #${issue.number} failed${rateLimited ? ' (API rate limit exceeded — degrading gracefully)' : ''}: ${e.message}`);
+              return;
+            }
+
+      - name: Add wr:new label
+        if: steps.malformed_check.outputs.is_malformed != 'true'
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(l => l.name);
+            if (!labels.some(l => l.startsWith('wr:'))) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.issue.number,
+                  labels: ['wr:new']
+                });
+                console.log('Added wr:new label');
+              } catch (e) {
+                const rateLimited = e?.status === 403 && /rate limit/i.test(e?.message || '');
+                core.warning(`addLabels(wr:new) for issue #${context.payload.issue.number} failed${rateLimited ? ' (API rate limit exceeded — degrading gracefully)' : ''}: ${e.message}`);
+              }
             } else {
               console.log('Issue already has wr:* label:', labels.filter(l => l.startsWith('wr:')));
             }
@@ -293,50 +262,66 @@ jobs:
             });
 
 
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              body: `🔄 Lifecycle state transitioned to \`${targetState}\` via manual workflow_dispatch.`,
-            });
+            for (const label of issueData.labels) {
+              if (allLifecycleLabels.includes(label.name)) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue,
+                    name: label.name
+                  });
+                  console.log('Removed label:', label.name);
+                } catch (e) {
+                  console.log('Could not remove label:', label.name, e.message);
+                }
+              }
+            }
 
-      - name: Cleanup stale lifecycle labels
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issueNumber = parseInt('${{ inputs.issue_number }}', 10);
-            const targetState = '${{ inputs.target_state }}';
-            const targetLabel = `state:${targetState}`;
 
-            // Belt-and-suspenders: re-sweep any lifecycle labels that shouldn't be here.
-            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-            });
+            // Add new label
 
-            // Add wr:done label
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: issue.number,
-              labels: ['wr:done']
+              issue_number: issue,
+              labels: [newLabel]
             });
-    timeout-minutes: 30
-            const staleLifecycleLabels = currentLabels
-              .map((l) => l.name)
-              .filter((n) => n.startsWith('state:') && n !== targetLabel);
 
-            for (const label of staleLifecycleLabels) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issueNumber,
-                  name: label,
-                });
-                console.log(`Cleaned up stale lifecycle label ${label} on #${issueNumber}`);
-              } catch (e) {
-                console.log(`Label ${label} race on #${issueNumber} (already removed): ${e.message}`);
-              }
+
+            console.log(' transitioned to:', newLabel);
+    timeout-minutes: 15
+  close-completed:
+    runs-on: ubuntu-latest
+    env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+    if: github.event_name == 'issues' && github.event.action == 'closed' &&
+      contains(github.event.issue.labels.*.name, 'wr:')
+    steps:
+      - name: Mark as done if not PR
+        if: "!github.event.issue.pull_request"
+        uses: actions/github-script@v9.0.0
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = issue.labels.map(l => l.name);
+
+            // Check if already marked as done
+            if (labels.includes('wr:done')) {
+              console.log('Issue already marked as done');
+              return;
             }
+
+            // Add wr:done label
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['wr:done']
+              });
+            } catch (e) {
+              const rateLimited = e?.status === 403 && /rate limit/i.test(e?.message || '');
+              core.warning(`addLabels(wr:done) for issue #${issue.number} failed${rateLimited ? ' (API rate limit exceeded — degrading gracefully)' : ''}: ${e.message}`);
+            }
+    timeout-minutes: 30

--- a/.github/workflows/saml-sso-registration.yml
+++ b/.github/workflows/saml-sso-registration.yml
@@ -19,69 +19,6 @@ jobs:
     steps:
       - name: Resolve triggering username
         id: resolve-user
-        env:
-          # organization member_added exposes the new member via .membership.user.login
-          # pull_request events expose the PR author via .pull_request.user.login
-          # Passed through env (not inline ${{ }}) so event data can't inject into the shell.
-          USERNAME: ${{ github.event.membership.user.login || github.event.pull_request.user.login }}
-        run: |
-          echo "username=${USERNAME}" >> "$GITHUB_OUTPUT"
-          echo "Checking SAML identity for: ${USERNAME}"
-      # NOTE: this step used to call gagoar/get-saml-identity-action@0.9.0, but that
-      # action's only published tag never committed its dist/ bundle, so every run
-      # failed with "File not found: .../dist/index.js" before any logic executed.
-      # We query the same GraphQL mapping (organization → samlIdentityProvider →
-      # externalIdentities) directly instead. Requires a token with admin:org scope
-      # (ADMIN_GITHUB_TOKEN); if that's missing, or the repo owner is a personal
-      # account with no SAML provider, the step degrades to a warning/notice rather
-      # than failing the PR.
-      - name: Resolve SAML identity via GraphQL
-        id: saml-identity
-        uses: actions/github-script@v9.0.0
-        env:
-          TARGET_USERNAME: ${{ steps.resolve-user.outputs.username }}
-        with:
-          github-token: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          script: |
-            const username = process.env.TARGET_USERNAME;
-            const owner = context.repo.owner;
-            let identity = '';
-            let providerConfigured = false;
-
-            if (!username) {
-              core.warning(`No username resolved from the '${context.eventName}' event (checked github.event.membership.user.login and github.event.pull_request.user.login); skipping SAML lookup.`);
-            } else {
-              try {
-                const result = await github.graphql(
-                  `query($org: String!, $login: String!) {
-                    organization(login: $org) {
-                      samlIdentityProvider {
-                        externalIdentities(first: 1, login: $login) {
-                          nodes { samlIdentity { nameId } }
-                        }
-                      }
-                    }
-                  }`,
-                  { org: owner, login: username }
-                );
-                const provider = result.organization && result.organization.samlIdentityProvider;
-                if (provider) {
-                  providerConfigured = true;
-                  const node = provider.externalIdentities.nodes[0];
-                  identity = (node && node.samlIdentity && node.samlIdentity.nameId) || '';
-                } else {
-                  // Personal accounts and orgs without SAML land here — nothing to verify.
-                  core.notice(`Owner '${owner}' has no SAML identity provider configured (or is a personal account); skipping SSO verification.`);
-                }
-              } catch (error) {
-                // Token lacks admin:org, or owner is not an organization. Never fail
-                // the PR for this — surface a warning and let the run stay green.
-                core.warning(`SAML identity lookup failed: ${error.message}. If SSO enforcement is expected, check that ADMIN_GITHUB_TOKEN has admin:org scope.`);
-              }
-            }
-
-            core.setOutput('identity', identity);
-            core.setOutput('provider_configured', String(providerConfigured));
         run: |
           # pull_request events expose the PR author via .pull_request.user.login
           USERNAME="${{ github.event.pull_request.user.login }}"
@@ -142,24 +79,7 @@ jobs:
 
             core.setOutput('identity', identity);
       - name: Report SAML identity result
-        env:
-          IDENTITY: ${{ steps.saml-identity.outputs.identity }}
-          USERNAME: ${{ steps.resolve-user.outputs.username }}
-          PROVIDER_CONFIGURED: ${{ steps.saml-identity.outputs.provider_configured }}
-          OWNER: ${{ github.repository_owner }}
         run: |
-          if [ "${PROVIDER_CONFIGURED}" != "true" ]; then
-            echo "::notice title=SAML Not Configured::No SAML identity provider for '${OWNER}'; nothing to verify."
-          elif [ -z "${IDENTITY}" ]; then
-            echo "::warning title=SAML Identity Missing::User '${USERNAME}' does not have a linked SAML/SSO identity in the organization. Ask them to authorize via SSO at https://github.com/orgs/${OWNER}/sso"
-          if [ -n "${{ steps.saml-identity.outputs.identity }}" ]; then
-            echo "::notice::SAML identity linked for ${{ github.event.pull_request.user.login }}: ${{ steps.saml-identity.outputs.identity }}"
-          else
-            echo "::warning::No SAML identity linked for ${{ github.event.pull_request.user.login }}"
-          fi
-
-      - name: Comment on PR if SAML identity not linked
-        if: steps.saml-identity.outputs.identity == ''
           IDENTITY="${{ steps.saml-identity.outputs.identity }}"
           USERNAME="${{ steps.resolve-user.outputs.username }}"
 
@@ -170,26 +90,11 @@ jobs:
           fi
       - name: Comment on PR if SAML identity is missing
         if: |
-          github.event_name == 'pull_request' &&
-          steps.saml-identity.outputs.provider_configured == 'true' &&
-          steps.saml-identity.outputs.identity == ''
+          github.event_name == 'pull_request' && steps.saml-identity.outputs.identity == ''
         uses: actions/github-script@v9.0.0
-        env:
-          TARGET_USERNAME: ${{ steps.resolve-user.outputs.username }}
         with:
           github-token: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
-            const username = process.env.TARGET_USERNAME;
-            const org = context.repo.owner;
-            const body = [
-              '## SAML SSO Identity Not Linked',
-              '',
-              `@${context.payload.pull_request.user.login}, your GitHub account does not appear to be linked to a SAML SSO identity for this organization.`,
-              '',
-              'Please ensure your account is linked to the organization\'s SAML SSO provider before contributing.',
-              '',
-              'If you believe this is an error, contact the organization administrators.'
-            ].join('\n');
             const username = '${{ steps.resolve-user.outputs.username }}';
             const org = '${{ github.repository_owner }}';
             await github.rest.issues.createComment({

--- a/.github/workflows/wr-auto-classify.yml
+++ b/.github/workflows/wr-auto-classify.yml
@@ -63,11 +63,6 @@ jobs:
        contains(format(' {0} ', github.event.issue.title), ' #skill ') ||
        contains(format(' {0} ', github.event.issue.title), ' #skills ') ||
        contains(format(' {0} ', github.event.issue.title), ' #website '))
-    if: contains(github.event.issue.labels.*.name, 'work-request')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-    if: contains(join(github.event.issue.labels.*.name, ','), 'work-request')
     runs-on: ubuntu-latest
     env:
       PAT: ${{ secrets.PROJECTS_PAT }}
@@ -172,64 +167,6 @@ jobs:
               ("technical-documentation", re.compile(r"(?:^|\s)#(?:doc|docs)(?=\s|$)", re.IGNORECASE)),
               ("internal-script-automation", re.compile(r"(?:^|\s)#(?:skill|skills)(?=\s|$)", re.IGNORECASE)),
               ("production-app", re.compile(r"(?:^|\s)#website(?=\s|$)", re.IGNORECASE)),
-          import json
-          import subprocess
-
-          # Keep this title-tag mapping in sync with weekly-research.yml and openrouter-auto-route.yml
-          TITLE_TAG_OUTPUT_TYPE = {
-              "#research": "research-report",
-              "#report": "research-report",
-              "#brief": "research-report",
-              "#tool": "desktop-tool",
-              "#cli": "desktop-tool",
-              "#tool": "desktop-tool",
-              "#cli": "cli-tool",
-              "#web": "web-app",
-              "#api": "api-service",
-              "#lib": "library",
-              "#library": "library",
-              "#doc": "documentation",
-              "#docs": "documentation",
-              "#spec": "specification",
-              "#api": "api",
-              "#service": "service",
-              "#dataset": "dataset",
-              "#analysis": "analysis-report",
-              "#report": "analysis-report",
-              "#automation": "automation-script",
-          }
-
-          ALLOWED_OUTPUT_TYPES = sorted(set(TITLE_TAG_OUTPUT_TYPE.values()) | {
-              "research-report",
-              "desktop-tool",
-              "library",
-              "documentation",
-              "specification",
-              "api",
-              "service",
-              "dataset",
-              "cli-tool",
-              "web-app",
-              "api-service",
-              "library",
-              "documentation",
-              "specification",
-              "analysis-report",
-              "automation-script",
-              "other",
-          })
-
-          DEFAULT_OUTPUT_TYPE = "research-report"
-
-          CLASSIFIABLE_FIELDS = [
-              "Output Type",
-              "Priority",
-              "Effort",
-          FORM_FIELDS = [
-              "Output Type",
-              "Priority",
-              "Effort",
-              "Deadline",
           ]
 
           def gh_graphql(query, variables=None, token=None):
@@ -278,35 +215,6 @@ jobs:
               parsed = {}
               for form_label, field_name in FORM_TO_FIELD.items():
                   parsed[field_name] = parse_form_section(body, form_label)
-              if not body:
-                  return parsed
-              # GitHub issue-form bodies have '### Field Name\n\nvalue\n\n' blocks
-              blocks = re.split(r"^###\s+", body, flags=re.MULTILINE)
-              for block in blocks:
-                  if not block.strip():
-                      continue
-                  lines = block.splitlines()
-                  if not lines:
-                      continue
-                  field = lines[0].strip()
-                  value = "\n".join(lines[1:]).strip()
-                  if value in ("_No response_", "", "None"):
-                      value = ""
-                  parsed[field] = value
-              return parsed
-              # Issue forms render as: ### Heading\n\nvalue\n\n### Next Heading ...
-              sections = re.split(r"^###\s+", body, flags=re.MULTILINE)
-              for section in sections:
-                  section = section.strip()
-                  if not section:
-                      continue
-                  lines = section.splitlines()
-                  heading = lines[0].strip()
-                  value = "\n".join(lines[1:]).strip()
-                  # GitHub renders unfilled fields as "_No response_"
-                  if value.lower() in ("_no response_", "no response", ""):
-                      value = ""
-                  parsed[heading] = value
               return parsed
 
           TITLE_TAG_OUTPUT_TYPE = {
@@ -340,23 +248,10 @@ jobs:
               return None
 
           def fields_needing_classification(parsed, title_output_type):
-              needing = []
-              for field in CLASSIFIABLE_FIELDS:
-                  value = parsed.get(field, "").strip()
+              needed = []
+              for field, value in parsed.items():
                   if field == "Output Type" and title_output_type:
-                      # Title tag already tells us the output type; no need to classify
                       continue
-                  if not value:
-                      needing.append(field)
-              return needing
-
-          def run_classifier(title, body, fields):
-              # Placeholder for OpenRouter classifier invocation.
-              # In real CI this shells out to scripts/openrouter-classify.py.
-              # For now, return an empty dict so the merge-precedence logic
-              # still exercises the explicit > title-tag > classifier > default chain.
-              return {}
-
                   if value is None or value == "auto-classify":
                       needed.append(field)
               return needed
@@ -516,105 +411,6 @@ jobs:
                       "Authorization": f"bearer {PAT}",
                       "Accept": "application/vnd.github+json",
                   },
-              needing = []
-              for field in FORM_FIELDS:
-                  if field == "Output Type" and title_output_type:
-                      continue
-                  if not parsed.get(field):
-                      needing.append(field)
-              return needing
-
-          def main():
-              title = os.environ.get("ISSUE_TITLE", "")
-              body = os.environ.get("ISSUE_BODY", "")
-              issue_number = os.environ.get("ISSUE_NUMBER", "")
-              repo = os.environ.get("REPO", "")
-
-              parsed = parse_form(body)
-              title_output_type = infer_output_type_from_title_tags(title)
-              needing = fields_needing_classification(parsed, title_output_type)
-              classifier_output = run_classifier(title, body, needing) if needing else {}
-
-              summary_lines = []
-              summary_lines.append("## Auto-classification")
-              summary_lines.append("")
-
-              resolved = {}
-              for field in CLASSIFIABLE_FIELDS:
-                  explicit = parsed.get(field, "").strip()
-                  classifier_value = (classifier_output.get(field) or "").strip()
-
-                  # Merge: explicit > title tags > classifier-output > defaults.
-                  if explicit:
-                      value = explicit
-                      source = "explicit"
-                  elif field == "Output Type" and title_output_type in ALLOWED_OUTPUT_TYPES:
-                      value = title_output_type
-                      source = "title-tag"
-                  elif classifier_value:
-                      value = classifier_value
-                      source = "classifier"
-                  elif field == "Output Type":
-                      value = DEFAULT_OUTPUT_TYPE
-                      source = "fallback"
-                  else:
-                      value = ""
-                      source = "fallback"
-
-                  resolved[field] = value
-                  summary_lines.append(f"- **{field}**: `{value}` _(source: {source})_")
-
-              summary_lines.append("")
-              summary_lines.append(
-                  "_Source: explicit = value from issue form; "
-                  "title-tag = inferred from `#tag` in title; "
-                  "classifier = OpenRouter classifier output; "
-                  "fallback = opinionated default._"
-              )
-
-              # Merge: explicit > title tags > classifier-output > defaults.
-              #
-              # We don't actually invoke the classifier here (that lives in a
-              # sibling workflow); this job just resolves what we already know
-              # deterministically and emits a summary comment describing the
-              # provenance of each field so downstream automation and humans
-              # can audit it.
-              resolved = {}
-              sources = {}
-              classifier_output = {}  # placeholder for future classifier hook
-
-              for field in FORM_FIELDS:
-                  explicit = parsed.get(field, "").strip()
-                  if explicit:
-                      resolved[field] = explicit
-                      sources[field] = "explicit"
-                  elif field == "Output Type" and title_output_type in ALLOWED_OUTPUT_TYPES and title_output_type:
-                      resolved[field] = title_output_type
-                      sources[field] = "title-tag"
-                  elif classifier_output.get(field):
-                      resolved[field] = classifier_output[field]
-                      sources[field] = "classifier"
-                  else:
-                      if field == "Output Type":
-                          resolved[field] = DEFAULT_OUTPUT_TYPE
-                      else:
-                          resolved[field] = ""
-                      sources[field] = "fallback"
-
-              lines = [
-                  "<!-- wr-auto-classify -->",
-                  "### Auto-classification summary",
-                  "",
-              ]
-              for field in FORM_FIELDS:
-                  value = resolved[field] or "_(unset)_"
-                  lines.append(f"- **{field}**: {value} _(source: {sources[field]})_")
-              lines.append("")
-              lines.append(
-                  "_Source legend: explicit = filled in the form; "
-                  "title-tag = inferred from #tag in issue title; "
-                  "classifier = inferred by OpenRouter classifier; "
-                  "fallback = opinionated default._"
               )
               try:
                   urllib.request.urlopen(req, timeout=15).read()
@@ -629,13 +425,10 @@ jobs:
           if title_output_type:
               print(f"Title route tag inferred Output Type: {title_output_type}")
 
-              comment = "\n".join(summary_lines)
+          print(f"Parsed form values: {parsed}")
+          needed = fields_needing_classification(parsed, title_output_type)
+          print(f"Fields needing classification: {needed}")
 
-              if issue_number and repo:
-                  subprocess.run(
-                      ["gh", "issue", "comment", str(issue_number),
-                       "--repo", repo, "--body", comment],
-                      check=False,
           classified = {}
           used_fallback = False
 
@@ -732,10 +525,50 @@ jobs:
                       f"- `PDF pipeline batch` = ⚠️ unrecognized (`{pdf_batch_raw}`); expected one of {sorted(pdf_batch_allowed)}"
                   )
 
-              print(json.dumps({"resolved": resolved, "title_output_type": title_output_type}))
+          comment_lines = [
+              "**WR Auto-Classify ran on this issue.**",
+              "",
+              *summary_lines,
+              *extra_summary,
+              "",
+              f"_Source: explicit = you picked it; title-tag = inferred from a route tag in the issue title; classifier = OpenRouter ({MODEL}); fallback = default applied because no explicit value, no classifier, or invalid value._",
+          ]
+          if used_fallback:
+              comment_lines.append("")
+              comment_lines.append("Label `auto:default-fallback` was added so this can be spot-checked.")
 
-          if __name__ == "__main__":
-              main()
+          if final.get("Output Type") == "sellable-pdf":
+              batch_note = "PDF pipeline batch not parsed — treat like **Not applicable** / single-concept unless you fix the form."
+              if pdf_batch_raw == "Autocreate 3":
+                  batch_note = "Produce **3** candidate concepts/outlines (then narrow to one ship candidate)."
+              elif pdf_batch_raw == "Autocreate 20":
+                  batch_note = "Produce **20** candidate concepts/outlines (then narrow to one ship candidate)."
+              elif pdf_batch_raw == "Not applicable":
+                  batch_note = "**Not applicable** selected — single-concept PDF pipeline unless you change this dropdown."
+
+              repo_html = f"https://github.com/{OWNER}/{REPO}"
+              comment_lines.extend(
+                  [
+                      "",
+                      "### PDF product playbook (form-driven)",
+                      "",
+                      f"**Routing:** `sellable-pdf` + `{pdf_batch_raw or 'PDF pipeline batch missing'}` — {batch_note}",
+                      "",
+                      "Execute in order (authoritative docs — **not** label gymnastics):",
+                      "",
+                      f"1. [`workflows/PDF_WR_PLAYBOOK.md`]({repo_html}/blob/main/workflows/PDF_WR_PLAYBOOK.md) — WR → automation hand-off.",
+                      f"2. [`standards/shapes/PDF.md`]({repo_html}/blob/main/standards/shapes/PDF.md) — folder layout, quality gates, tooling.",
+                      f"3. [`workflows/PDF_AUTOMATION_GUIDE.md`]({repo_html}/blob/main/workflows/PDF_AUTOMATION_GUIDE.md) — Make / n8n / Zapier / Gumloop wiring.",
+                      f"4. [`standards/AUTOMATED_PRODUCT_PIPELINE.md`]({repo_html}/blob/main/standards/AUTOMATED_PRODUCT_PIPELINE.md) — where PDF sits in Listen→Ship.",
+                      "",
+                      "External runners should read **`### PDF pipeline batch`** from this issue body for autocreate count (3 vs 20).",
+                      "",
+                      "_Note: the `output-type:sellable-pdf` label mirrors this dropdown for legacy integrations only._",
+                  ]
+              )
+
+          post_comment("\n".join(comment_lines))
+          print("Classification complete.")
           PYEOF
     timeout-minutes: 30
 env:

--- a/scripts/auto-resolve-mechanical-conflicts.js
+++ b/scripts/auto-resolve-mechanical-conflicts.js
@@ -7,29 +7,6 @@
  * walks each conflicted file, classifies every conflict hunk by pattern,
  * and resolves the safe patterns in place. Anything ambiguous is left
  * with conflict markers intact so a human still decides.
- * Attempts to mechanically auto-resolve simple merge conflicts in the current
- * working tree (e.g. GitHub Actions `uses:` version bumps, lockfile-style
- * additions, etc.). Any file that cannot be fully resolved is left alone so a
- * human can finish the merge.
- *
- * Exit code contract:
- *   0 -> EVERY conflicted file was fully, mechanically resolved. Safe for a
- *        CI workflow to `git add -A && git commit && git push` the result.
- *   2 -> At least one conflicted file was NOT fully resolved. This includes:
- *          - SKIP    (binary / too-large / unreadable)
- *          - PARTIAL (some hunks resolved, some ambiguous)
- *          - MANUAL  (nothing resolvable found in this file) -- INCLUDING the
- *                    zero-hunk case (e.g. binary "both modified" conflicts
- *                    that never contain `<<<<<<<` markers at all).
- *   1 -> Fatal script error.
- *
- * The zero-hunk MANUAL case is important: previously the exit code was gated
- * on a counter of *ambiguous hunks*, so a conflicted file with no detected
- * hunks contributed nothing and the script exited 0 -- causing the calling
- * workflow to push unresolved conflicts onto the PR branch. This script now
- * tracks unresolved *files* directly.
- * Attempts to mechanically resolve simple merge conflicts in a working tree
- * where `git merge` (or rebase) has left conflict markers in files.
  *
  * Safe patterns we resolve:
  *
@@ -68,236 +45,6 @@
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
-const { execSync, spawnSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
-
-const CONFLICT_START = '<<<<<<<';
-const CONFLICT_MID = '=======';
-const CONFLICT_END = '>>>>>>>';
-const MAX_FILE_BYTES = 2 * 1024 * 1024; // 2 MiB safety cap
-
-function listConflictedFiles() {
-  const out = spawnSync('git', ['diff', '--name-only', '--diff-filter=U'], {
-    encoding: 'utf8',
-  });
-  if (out.status !== 0) {
-    throw new Error(`git diff failed: ${out.stderr}`);
-  }
-  return out.stdout
-    .split('\n')
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
-function isProbablyBinary(buf) {
-  // Heuristic: NUL byte in first 8KiB => binary.
-  const slice = buf.slice(0, Math.min(buf.length, 8192));
-  for (let i = 0; i < slice.length; i++) {
-    if (slice[i] === 0) return true;
-  }
-  return false;
-}
-
-function* iterHunks(lines) {
-  let i = 0;
-  while (i < lines.length) {
-    if (lines[i].startsWith(CONFLICT_START)) {
-      const start = i;
-      let mid = -1;
-      let end = -1;
-      let j = i + 1;
-      while (j < lines.length) {
-        if (lines[j].startsWith(CONFLICT_START)) {
-          // nested/broken -> bail on this hunk
-          break;
-        }
-        if (mid === -1 && lines[j].startsWith(CONFLICT_MID)) {
-          mid = j;
-        } else if (mid !== -1 && lines[j].startsWith(CONFLICT_END)) {
-          end = j;
-          break;
-        }
-        j++;
-      }
-      if (mid !== -1 && end !== -1) {
-        yield {
-          start,
-          mid,
-          end,
-          ours: lines.slice(start + 1, mid),
-          theirs: lines.slice(mid + 1, end),
-        };
-        i = end + 1;
-        continue;
-      }
-      // Malformed -- skip past this marker so we don't infinite loop.
-      i = start + 1;
-      continue;
-    }
-    i++;
-  }
-}
-
-// Try to auto-resolve a single hunk. Return the resolved lines (array) or null
-// if the hunk is ambiguous / not safely mechanical.
-function resolveHunk(hunk) {
-  const { ours, theirs } = hunk;
-
-  // Trivially identical.
-  if (ours.join('\n') === theirs.join('\n')) {
-    return ours.slice();
-  }
-
-  // One side empty -> take the other.
-  if (ours.length === 0) return theirs.slice();
-  if (theirs.length === 0) return ours.slice();
-
-  // GitHub Actions `uses: owner/name@vX` version bump: same action, differing
-  // ref -> prefer the higher/newer semver-ish tag on `theirs` if both look
-  // like refs.
-  if (ours.length === 1 && theirs.length === 1) {
-    const reUses = /^(\s*(?:-\s*)?uses:\s*)([^\s@]+)@(\S+)(\s*)$/;
-    const mo = ours[0].match(reUses);
-    const mt = theirs[0].match(reUses);
-    if (mo && mt && mo[2] === mt[2]) {
-      // Same action reference. Prefer the ref that sorts higher lexicographically
-      // when both look like `v<semver>`; otherwise prefer theirs (incoming).
-      const ro = mo[3];
-      const rt = mt[3];
-      const semverish = /^v?\d+(\.\d+){0,2}$/;
-      if (semverish.test(ro) && semverish.test(rt)) {
-        const cmp = compareSemverish(ro, rt);
-        return cmp >= 0 ? [ours[0]] : [theirs[0]];
-      }
-      return [theirs[0]];
-    }
-  }
-
-  return null;
-}
-
-function compareSemverish(a, b) {
-  const parse = (s) =>
-    s
-      .replace(/^v/, '')
-      .split('.')
-      .map((p) => parseInt(p, 10) || 0);
-  const pa = parse(a);
-  const pb = parse(b);
-  const n = Math.max(pa.length, pb.length);
-  for (let i = 0; i < n; i++) {
-    const x = pa[i] || 0;
-    const y = pb[i] || 0;
-    if (x !== y) return x - y;
-  }
-  return 0;
-}
-
-function resolveFile(file) {
-  let stat;
-  try {
-    stat = fs.statSync(file);
-  } catch {
-    return { status: 'SKIP', ok: 0, ambiguous: 0, reason: 'missing' };
-  }
-  if (!stat.isFile()) {
-    return { status: 'SKIP', ok: 0, ambiguous: 0, reason: 'not-file' };
-  }
-  if (stat.size > MAX_FILE_BYTES) {
-    return { status: 'SKIP', ok: 0, ambiguous: 0, reason: 'too-large' };
-  }
-  let buf;
-  try {
-    buf = fs.readFileSync(file);
-  } catch (e) {
-    return { status: 'SKIP', ok: 0, ambiguous: 0, reason: `read: ${e.message}` };
-  }
-  if (isProbablyBinary(buf)) {
-    return { status: 'SKIP', ok: 0, ambiguous: 0, reason: 'binary' };
-  }
-
-  const text = buf.toString('utf8');
-  const lines = text.split('\n');
-
-  const hunks = [...iterHunks(lines)];
-  if (hunks.length === 0) {
-    // No detectable textual conflict markers. This does NOT mean the file is
-    // resolved -- it may still be in the index as "both modified" (e.g. binary
-    // that slipped past the heuristic, or an unknown conflict style). Report
-    // MANUAL so the caller treats it as unresolved.
-    return { status: 'MANUAL', ok: 0, ambiguous: 0 };
-  }
-
-  const resolutions = new Array(hunks.length);
-  let ambiguous = 0;
-  for (let i = 0; i < hunks.length; i++) {
-    const r = resolveHunk(hunks[i]);
-    if (r === null) {
-      ambiguous++;
-      resolutions[i] = null;
-    } else {
-      resolutions[i] = r;
-    }
-  }
-
-  if (ambiguous === hunks.length) {
-    return { status: 'MANUAL', ok: 0, ambiguous };
-  }
-
-  // Rebuild the file. Ambiguous hunks are left as-is (markers preserved).
-  const outLines = [];
-  let cursor = 0;
-  for (let i = 0; i < hunks.length; i++) {
-    const h = hunks[i];
-    for (let k = cursor; k < h.start; k++) outLines.push(lines[k]);
-    if (resolutions[i] === null) {
-      for (let k = h.start; k <= h.end; k++) outLines.push(lines[k]);
-    } else {
-      for (const l of resolutions[i]) outLines.push(l);
-    }
-    cursor = h.end + 1;
-  }
-  for (let k = cursor; k < lines.length; k++) outLines.push(lines[k]);
-
-  fs.writeFileSync(file, outLines.join('\n'));
-
-  if (ambiguous === 0) {
-    // Fully resolved -> stage it.
-    try {
-      execSync(`git add -- ${JSON.stringify(file)}`, { stdio: 'ignore' });
-    } catch {
-      /* best-effort */
-    }
-    return { status: 'RESOLVED', ok: hunks.length, ambiguous: 0 };
-  }
-  return {
-    status: 'PARTIAL',
-    ok: hunks.length - ambiguous,
-    ambiguous,
-  };
-}
-
-function main() {
-  let files;
-  try {
-    files = listConflictedFiles();
-  } catch (e) {
-    console.error(`fatal: ${e.message}`);
-    process.exit(1);
-  }
-
-  if (files.length === 0) {
-    console.log('no conflicted files');
-    process.exit(0);
-  }
-
-  let totalResolved = 0;
-  let totalAmbiguous = 0;
-  let totalUnresolved = 0; // files not fully in RESOLVED state
-const fs = require('fs');
-const path = require('path');
-const { execSync, spawnSync } = require('child_process');
 
 // ── Pattern detectors ───────────────────────────────────────────────────────
 
@@ -489,41 +236,14 @@ function main() {
   let totalUnresolved = 0;
   const lines = [];
 
-  for (const f of files) {
-    let r;
-    try {
-      r = resolveFile(f);
-    } catch (e) {
-      console.log(`ERROR   ${f}   ${e.message}`);
+  for (const file of conflicted) {
+    if (!fs.existsSync(file)) {
+      lines.push(`SKIP     ${file}   (deleted on one side — leave to human)`);
+      totalAmbiguous++;
       totalUnresolved++;
       continue;
     }
     const { ok, ambiguous } = resolveFile(file);
-    switch (r.status) {
-      case 'RESOLVED':
-        console.log(`RESOLVED ${f}   ${r.ok} hunk(s) auto-resolved`);
-        totalResolved += r.ok;
-        break;
-      case 'PARTIAL':
-        console.log(
-          `PARTIAL  ${f}   ${r.ok} resolved, ${r.ambiguous} ambiguous`,
-        );
-        totalResolved += r.ok;
-        totalAmbiguous += r.ambiguous;
-        totalUnresolved++;
-        break;
-      case 'MANUAL':
-        console.log(`MANUAL   ${f}   ${r.ambiguous} hunk(s) ambiguous`);
-        totalAmbiguous += r.ambiguous;
-        totalUnresolved++;
-        break;
-      case 'SKIP':
-      default:
-        console.log(`SKIP     ${f}   ${r.reason || 'skipped'}`);
-        totalUnresolved++;
-        break;
-    const { ok, ambiguous } = resolveFile(f);
-    totalOk += ok;
     totalAmbiguous += ambiguous;
     if (ambiguous === 0 && ok > 0) {
       lines.push(`RESOLVED ${file}   ${ok} hunk(s) auto-resolved`);
@@ -536,30 +256,6 @@ function main() {
     }
   }
 
-  console.log(
-    `summary: ${totalResolved} hunk(s) auto-resolved, ${totalAmbiguous} ambiguous, ${totalUnresolved} file(s) unresolved`,
-  );
-
-  // Exit 0 ONLY when every conflicted file was fully resolved.
-  process.exit(totalUnresolved > 0 ? 2 : 0);
-}
-
-if (require.main === module) {
-  main();
-}
-
-module.exports = {
-  iterHunks,
-  resolveHunk,
-  resolveFile,
-  compareSemverish,
-    `\nSummary: ${totalOk} resolved, ${totalAmbiguous} ambiguous hunk(s), ${totalUnresolved} unresolved file(s) across ${files.length} conflicted file(s).`
-  );
-  process.exit(totalUnresolved > 0 ? 2 : 0);
-}
-
-if (require.main === module) {
-  main();
   console.log(lines.join("\n"));
   process.exit(totalUnresolved > 0 ? 2 : 0);
 }

--- a/scripts/checkbox-diff.js
+++ b/scripts/checkbox-diff.js
@@ -1,128 +1,133 @@
+'use strict';
+
 /**
  * checkbox-diff.js
  *
- * Pure utility for detecting newly-checked "Follow-up:" checklist items
- * between two markdown bodies (e.g., PR or issue body before/after edit).
+ * Diffs two markdown bodies (an issue's or PR's `body` before/after an edit)
+ * to find task-list ("- [ ]" / "- [x]") lines that were newly checked in
+ * this edit AND match the `Follow-up:` convention documented in
+ * `.github/workflows/followup-checkbox-router.yml`:
  *
- * Convention:
- *   - [ ] Follow-up: <description>
+ *   - [ ] Follow-up: <free text description of what needs tracking later>
  *
- * When such a line transitions from unchecked to checked, it should be routed
- * to a new tracked WR issue. This module provides the pure detection logic;
- * network/GitHub interactions live in the workflow that consumes it.
+ * When a maintainer/agent edits the body and flips that box from unchecked
+ * to checked, it is the trigger signal to spin the follow-up out into a
+ * tracked WR issue. This module is the pure-logic half of that feature — it
+ * has no GitHub API / network dependency so it can be unit tested directly.
  */
 
-'use strict';
+// Matches a markdown task-list line, e.g.:
+//   - [ ] Follow-up: do the thing
+//   * [x] some other item
+//   +   [X]   spaced out item
+const TASK_LINE_RE = /^[ \t]*[-*+][ \t]+\[([ xX])\][ \t]+(.+?)[ \t]*$/;
 
-// Matches a markdown task-list line. Tolerant of:
-//   - leading whitespace
-//   - optional list marker `-`, `*`, or `+`
-//   - one or more spaces between marker and `[ ]`
-//   - `[ ]`, `[x]`, `[X]` (case-insensitive)
-//   - optional space after the bracket before the content
-const TASK_LINE_RE = /^\s*[-*+]\s+\[([ xX])\]\s?(.*)$/;
-
-// Matches the "Follow-up:" prefix (case-insensitive, tolerant of
-// whitespace around the hyphen and colon).
-const FOLLOW_UP_PREFIX_RE = /^\s*follow\s*-?\s*up\s*:\s*(.*)$/i;
+// Matches the "Follow-up:" prefix (case-insensitive, optional hyphen,
+// optional colon, tolerant of trailing whitespace) that marks a checklist
+// item as a trackable follow-up commitment. Covers "Follow-up:", "Followup:",
+// "FOLLOWUP". (Does not match "Follow up:" with a bare space — the
+// convention documented in followup-checkbox-router.yml is "Follow-up:".)
+const FOLLOWUP_PREFIX_RE = /^follow-?up:?\s*/i;
 
 /**
- * Normalize text for matching lines across an edit. We match by content, not
- * by line index, so reorderings or unrelated edits elsewhere don't break
- * detection.
- *
- * @param {string} s
+ * Parse every markdown task-list line out of a body.
+ * @param {string|null|undefined} body
+ * @returns {Array<{ text: string, checked: boolean }>}
+ */
+function parseTaskItems(body) {
+  if (!body) return [];
+  const items = [];
+  const lines = String(body).split(/\r?\n/);
+  for (const line of lines) {
+    const match = TASK_LINE_RE.exec(line);
+    if (!match) continue;
+    items.push({
+      checked: match[1].toLowerCase() === 'x',
+      text: match[2].trim(),
+    });
+  }
+  return items;
+}
+
+/**
+ * Normalize task-item text into a matching key. Minor whitespace variation
+ * (extra spaces, tabs) should not prevent a line from being matched between
+ * the old and new body; case is folded too since "Follow-up" items are
+ * matched case-insensitively everywhere else in this module.
+ * @param {string} text
  * @returns {string}
  */
-function normalizeText(s) {
-  return String(s || '')
-    .toLowerCase()
-    .replace(/\s+/g, ' ')
-    .trim();
+function normalizeKey(text) {
+  return text.trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
 /**
- * Parse a body into a list of task-list entries.
+ * Find follow-up checklist items that transitioned from unchecked to
+ * checked between `oldBody` and `newBody`.
  *
- * @param {string} body
- * @returns {Array<{checked: boolean, text: string, followUpDescription: string|null, key: string}>}
- */
-function parseTaskLines(body) {
-  if (body === null || body === undefined) return [];
-  const src = String(body);
-  const out = [];
-  const lines = src.split(/\r?\n/);
-  for (const line of lines) {
-    const m = line.match(TASK_LINE_RE);
-    if (!m) continue;
-    const marker = m[1];
-    const text = m[2] || '';
-    const checked = marker === 'x' || marker === 'X';
-    const fu = text.match(FOLLOW_UP_PREFIX_RE);
-    const followUpDescription = fu ? fu[1].trim() : null;
-    // Key by the normalized "content after the checkbox" so we can match
-    // the same logical item across bodies even if reordered.
-    const key = normalizeText(text);
-    out.push({ checked, text: text.trim(), followUpDescription, key });
-  }
-  return out;
-}
-
-/**
- * Find follow-up checklist items that transitioned from unchecked -> checked
- * between oldBody and newBody.
+ * Matching strategy: items are matched by normalized text content (not by
+ * line position), so a line can be correctly identified as "the same item"
+ * even if unrelated lines above/below it were added, removed, or reordered
+ * in the same edit. Only an item that (a) existed in `oldBody` as unchecked
+ * and (b) exists in `newBody` as checked counts as "newly checked" — an
+ * item that is brand new in `newBody` (no matching text in `oldBody` at
+ * all) is not reported, since there is no unchecked->checked transition to
+ * observe for it.
  *
- * Rules:
- *   - Item must exist in both bodies (matched by normalized text). This
- *     avoids over-firing on items added-and-checked in the same edit.
- *   - Item must be unchecked in oldBody and checked in newBody.
- *   - Item's text must match the Follow-up: prefix (case-insensitive,
- *     minor whitespace/hyphen tolerance).
- *   - Non-follow-up checkboxes are ignored.
- *
- * @param {string|null|undefined} oldBody
- * @param {string|null|undefined} newBody
- * @returns {Array<{description: string, text: string}>}
+ * @param {string|null|undefined} oldBody - body before the edit
+ *   (`github.event.changes.body.from`). May be null/undefined, e.g. when
+ *   the issue/PR was just created and there is no prior body to diff
+ *   against, or when the edit didn't touch the body field at all.
+ * @param {string|null|undefined} newBody - body after the edit (current
+ *   `issue.body` / `pull_request.body`).
+ * @returns {string[]} the free-text description of each newly-checked
+ *   follow-up item, with the `Follow-up:` prefix stripped and trimmed. If
+ *   multiple follow-up items were checked in the same edit, all of them are
+ *   returned, in the order they appear in `newBody`.
  */
 function findNewlyCheckedFollowUps(oldBody, newBody) {
-  const oldItems = parseTaskLines(oldBody);
-  const newItems = parseTaskLines(newBody);
+  if (!oldBody || !newBody) return [];
 
+  const oldItems = parseTaskItems(oldBody);
+  const newItems = parseTaskItems(newBody);
   if (oldItems.length === 0 || newItems.length === 0) return [];
 
-  // Build a map of old items keyed by normalized text. If multiple lines
-  // share the same key, prefer the first unchecked occurrence.
+  // Bucket old items by normalized text into per-key queues so duplicate
+  // line text (rare, but possible) is matched one-to-one in document order
+  // rather than every duplicate matching the first old entry.
   const oldByKey = new Map();
-  for (const it of oldItems) {
-    if (!oldByKey.has(it.key)) {
-      oldByKey.set(it.key, it);
-    } else {
-      const prev = oldByKey.get(it.key);
-      if (prev.checked && !it.checked) oldByKey.set(it.key, it);
-    }
+  for (const item of oldItems) {
+    const key = normalizeKey(item.text);
+    if (!oldByKey.has(key)) oldByKey.set(key, []);
+    oldByKey.get(key).push(item);
   }
 
   const results = [];
-  const seenKeys = new Set();
-  for (const it of newItems) {
-    if (!it.checked) continue;
-    if (!it.followUpDescription) continue;
-    if (seenKeys.has(it.key)) continue;
-    const prev = oldByKey.get(it.key);
-    if (!prev) continue; // not present before -> added-and-checked, skip
-    if (prev.checked) continue; // already checked, no transition
-    seenKeys.add(it.key);
-    results.push({
-      description: it.followUpDescription,
-      text: it.text,
-    });
+  for (const newItem of newItems) {
+    if (!newItem.checked) continue;
+
+    const key = normalizeKey(newItem.text);
+    const queue = oldByKey.get(key);
+    if (!queue || queue.length === 0) continue; // no matching prior line found
+    const oldItem = queue.shift();
+    if (oldItem.checked) continue; // already checked before this edit
+
+    const followUpMatch = FOLLOWUP_PREFIX_RE.exec(newItem.text);
+    if (!followUpMatch) continue; // checked, but not a "Follow-up:" item
+
+    const description = newItem.text.slice(followUpMatch[0].length).trim();
+    if (!description) continue; // "Follow-up:" with no description — nothing to track
+
+    results.push(description);
   }
+
   return results;
 }
 
 module.exports = {
   findNewlyCheckedFollowUps,
-  // exported for tests
-  _parseTaskLines: parseTaskLines,
-  _normalizeText: normalizeText,
+  parseTaskItems,
+  normalizeKey,
+  TASK_LINE_RE,
+  FOLLOWUP_PREFIX_RE,
 };

--- a/scripts/daily-diagnostic-audit.js
+++ b/scripts/daily-diagnostic-audit.js
@@ -1,420 +1,712 @@
 #!/usr/bin/env node
-/**
- * Daily Diagnostic Audit
- *
- * Runs once/day. Reads static content of recently-changed workflow YAML
- * and scripts, asks an LLM (via OpenRouter, `review` profile lane) to
- * diagnose a code-level bug, and — only when it can ground a diagnosis at
- * medium+ confidence — files ONE WR issue with an embedded proposed fix
- * plus a coder-facing comment.
- *
- * Fail-open everywhere: missing key, LLM error, parse error, dupe-check
- * failure all log a warning and exit 0.
- *
- * Never auto-fixes, never opens a PR, never auto-merges. Never inspects
- * actions/runs or issue state — only static file content.
- *
- * See standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md for the method and
- * the 8-entry fix-pattern catalog this is grounded in.
- */
-
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
-
-const WINDOW_HOURS = parseInt(process.env.SCOPE_WINDOW_HOURS || '48', 10);
-const MAX_SCOPE_FILES = parseInt(process.env.MAX_SCOPE_FILES || '8', 10);
-const MAX_FILE_BYTES = 20_000;
-const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
-const PRIMARY_MODEL = 'anthropic/claude-3.5-sonnet';
-const FALLBACK_MODEL = 'deepseek/deepseek-r1';
-
-function log(msg) {
-  console.log(`[daily-diagnostic-audit] ${msg}`);
-}
-function warn(msg) {
-  console.warn(`[daily-diagnostic-audit] WARN: ${msg}`);
-}
+"use strict";
 
 /**
- * Return list of in-scope files changed on main in the last WINDOW_HOURS.
- * Restricted to .github/workflows/*.yml and scripts/*.js.
+ * Daily Diagnostic Audit — bounded, code-level bug diagnosis with an
+ * embedded proposed fix, filed as a WR issue for the existing fleet
+ * pipeline to pick up.
+ *
+ * WHAT THIS IS NOT (read before touching this file):
+ * `.github/workflows/self-healing.yml` already scans recent workflow RUNS,
+ * stuck issues, and agent health every 4 hours and files [SELF-HEAL]/
+ * [AGENT-FAILURE] issues for OPERATIONAL failures ("a workflow crashed",
+ * "an issue is stuck"). This script is a DIFFERENT lens: static CODE-LEVEL
+ * bug diagnosis — the kind of thing found in a manual audit pass (missing
+ * `allowError`, unguarded label races, token/permission gaps, exit-code-as-
+ * proxy-metric bugs — see standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md).
+ * It never inspects workflow run history or issue state. If you find
+ * yourself adding run-history/issue-state checks here, that belongs in
+ * self-healing.yml instead — keep the two lenses non-overlapping.
+ *
+ * BOUNDED SCOPE (never a full repo sweep):
+ * Each run only examines files touched on `main` in the last
+ * SCOPE_WINDOW_HOURS hours (default 48), restricted to `.github/workflows/
+ * *.yml` and `scripts/*.js` — this fleet's actual blast radius, and the
+ * same file classes the playbook's pattern catalog was built from. This is
+ * naturally non-repetitive: a file that was flagged but never fixed simply
+ * ages out of the 24-48h window on the next run rather than being
+ * re-diagnosed forever, and a run with a quiet last 48h finds nothing and
+ * files nothing — that is expected and fine (mirrors
+ * scripts/octopus-review-fallback.js's "best-effort, never force it"
+ * philosophy: never manufacture an issue just to have output).
+ *
+ * OUTPUT CAP: at most one WR issue per run (a single LLM call is asked for
+ * a single diagnosis, not a list) plus one follow-up comment addressed to
+ * whichever coding agent picks up the WR. This script NEVER opens a PR,
+ * NEVER pushes a commit, and NEVER applies the fix it proposes — filing a
+ * WR is a request for the existing openrouter-assignee.yml -> wr-pr-
+ * creation.yml -> coding-agent -> review/merge pipeline to act on, not a
+ * bypass of human/AI review (see WR #15833).
+ *
+ * Wiring: .github/workflows/daily-diagnostic-audit.yml
+ * Methodology + pattern catalog: standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md
  */
-function selectScopeFiles() {
-  let out;
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+const { callOpenRouter } = require("./openrouter-routing.js");
+
+const REPO_ROOT = path.join(__dirname, "..");
+const GITHUB_TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || "";
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY || "midnghtsapphire/revvel-standards";
+
+const SCOPE_WINDOW_HOURS = parseInt(process.env.SCOPE_WINDOW_HOURS || "48", 10);
+const MAX_SCOPE_FILES = parseInt(process.env.MAX_SCOPE_FILES || "8", 10);
+const MAX_FILE_CHARS = parseInt(process.env.MAX_FILE_CHARS || "9000", 10);
+const MAX_PROMPT_CHARS = parseInt(process.env.MAX_PROMPT_CHARS || "45000", 10);
+const MAX_PLAYBOOK_CHARS = parseInt(process.env.MAX_PLAYBOOK_CHARS || "12000", 10);
+
+// Only these file classes are in scope — this is the fleet's actual blast
+// radius (workflow YAML + the Node scripts that drive it), and matches the
+// file classes the playbook's pattern catalog (below) was derived from.
+// Markdown/docs/config churn is deliberately excluded: it is not where the
+// established fix-pattern catalog applies, and including it would dilute a
+// single bounded LLM call across unrelated file classes.
+const SCOPE_GLOBS = [
+  { dir: ".github/workflows/", ext: ".yml" },
+  { dir: "scripts/", ext: ".js" },
+];
+
+const WR_LABELS = ["work-request", "auto-diagnosed"];
+const WR_ASSIGNEES = ["oaudrey"];
+
+const PLAYBOOK_PATH = path.join(REPO_ROOT, "standards", "AUDIT_AND_SELF_HEALING_PLAYBOOK.md");
+
+// Fallback summary of the pattern catalog, used only if
+// standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md is unavailable at runtime
+// (e.g. this workflow runs on a commit before that doc merged). Keep this
+// in sync with the "Self-Healing Correction Pattern Catalog" section of the
+// real doc; the real doc is always preferred when present (loadPlaybookContext).
+const EMBEDDED_CATALOG_SUMMARY = `## Self-Healing Correction Pattern Catalog (embedded fallback summary)
+
+1. Unguarded \`removeLabel\`/API race — no try/catch around a removal call that
+   can 404 when a concurrent workflow already removed the same label/item.
+2. Missing \`allowError: true\` (or equivalent try/catch) on internal API
+   helpers — a self-healing/sweep script hard-crashes on one transient error
+   instead of logging a warning and finishing the rest of the sweep.
+3. Default \`GITHUB_TOKEN\` used for agent-created PRs/labels — GitHub blocks
+   the default token from triggering other workflows, so agent-authored PRs
+   silently never cascade into downstream review/CI. Needs the repo's
+   \`ADMIN_GITHUB_TOKEN\`-with-fallback pattern.
+4. Secrets passed via argv instead of stdin — a plaintext secret readable via
+   \`/proc/<pid>/cmdline\` or \`ps aux\` for the life of the process.
+5. Bash bare-array-variable bug — \`"$ARRAY_VAR"\` without \`[@]\`/\`[*]\` only
+   ever expands to the array's first element, so a membership check silently
+   only matches that one element.
+6. Exit code as a proxy metric instead of true resolution state — a script
+   exits 0 based on a counter that can read zero for the WRONG reason (a
+   different, unhandled failure path never increments it), not on an
+   explicit "was this actually fully resolved?" check.
+7. \`nosemgrep\` suppression comment adjacency — the suppression directive
+   only applies when it is the LAST comment line immediately above the
+   flagged code; an explanatory comment inserted between them silently
+   breaks the suppression.
+8. Broken third-party GitHub Action — the same named check fails identically
+   across many unrelated PRs because a pinned third-party Action tag itself
+   is broken (e.g. missing \`dist/index.js\`), not anything in this repo's diff.
+
+Also watch for the CLAUDE.md "Recurring gotchas" #1-#4: missing \`GH_REPO\` on
+checkout-less \`gh\` jobs, missing \`GH_TOKEN\`/\`GITHUB_TOKEN\`, permissions
+narrower than what the job does, and untrusted \`\${{ ... }}\` interpolated
+directly into a \`run:\` shell instead of passed through \`env:\`.`;
+
+/**
+ * Loads the playbook's methodology + pattern catalog for grounding the
+ * diagnostic system prompt. Prefers the live file (kept current as new
+ * patterns are added); falls back to the embedded summary above if the
+ * file is unavailable (e.g. running from a commit before it merged) —
+ * never hard-fails just because a reference doc is missing.
+ */
+function loadPlaybookContext() {
   try {
-    out = execSync(
-      `git log --since="${WINDOW_HOURS} hours ago" --name-only --pretty=format: HEAD`,
-      { encoding: 'utf8' }
+    if (fs.existsSync(PLAYBOOK_PATH)) {
+      const raw = fs.readFileSync(PLAYBOOK_PATH, "utf8");
+      return raw.slice(0, MAX_PLAYBOOK_CHARS);
+    }
+  } catch (err) {
+    console.warn(`Could not read ${PLAYBOOK_PATH}, using embedded catalog summary: ${err.message}`);
+  }
+  return EMBEDDED_CATALOG_SUMMARY;
+}
+
+/**
+ * Parses raw `git log --name-only --pretty=format:` output into a deduped,
+ * order-preserving list of non-empty file paths. Pure function — no I/O —
+ * so it is unit-testable without a real git repo.
+ */
+function parseGitLogNameOnly(rawOutput) {
+  if (!rawOutput) return [];
+  const seen = new Set();
+  const files = [];
+  for (const line of String(rawOutput).split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    files.push(trimmed);
+  }
+  return files;
+}
+
+/**
+ * Filters a file list down to the in-scope glob set (SCOPE_GLOBS), in a
+ * pure/testable way (no filesystem access — existence is checked
+ * separately by the caller since that needs a real checkout).
+ */
+function filterInScope(files) {
+  return files.filter((file) =>
+    SCOPE_GLOBS.some((glob) => file.startsWith(glob.dir) && file.endsWith(glob.ext)),
+  );
+}
+
+/**
+ * Runs `git log --since=<N>.hours.ago --name-only` against the given repo
+ * root and returns the bounded, in-scope, still-existing file list. This is
+ * the only I/O-performing scope function; parseGitLogNameOnly/filterInScope
+ * above carry the testable logic.
+ */
+function selectScopeFiles({ repoRoot = REPO_ROOT, sinceHours = SCOPE_WINDOW_HOURS, maxFiles = MAX_SCOPE_FILES } = {}) {
+  let raw;
+  try {
+    raw = execFileSync(
+      "git",
+      ["log", `--since=${sinceHours}.hours.ago`, "--name-only", "--pretty=format:", "--", ".github/workflows", "scripts"],
+      { cwd: repoRoot, encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
     );
-  } catch (e) {
-    warn(`git log failed: ${e.message}`);
+  } catch (err) {
+    console.warn(`git log scope scan failed, treating as empty scope: ${err.message}`);
     return [];
   }
-  const seen = new Set();
-  for (const raw of out.split('\n')) {
-    const p = raw.trim();
-    if (!p) continue;
-    if (!inScope(p)) continue;
-    if (!fs.existsSync(p)) continue;
-    seen.add(p);
-  }
-  return Array.from(seen).slice(0, MAX_SCOPE_FILES);
+
+  const files = filterInScope(parseGitLogNameOnly(raw))
+    .filter((file) => fs.existsSync(path.join(repoRoot, file))) // skip deleted files
+    .sort();
+
+  return files.slice(0, maxFiles);
 }
 
-function inScope(p) {
-  if (p.startsWith('.github/workflows/') && (p.endsWith('.yml') || p.endsWith('.yaml'))) return true;
-  if (p.startsWith('scripts/') && p.endsWith('.js')) return true;
-  return false;
-}
-
-function readFileClipped(p) {
-  const buf = fs.readFileSync(p, 'utf8');
-  if (buf.length <= MAX_FILE_BYTES) return buf;
-  return buf.slice(0, MAX_FILE_BYTES) + `\n\n/* ...truncated at ${MAX_FILE_BYTES} bytes... */\n`;
-}
-
-function loadPlaybookContext() {
-  const candidate = 'standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md';
-  if (fs.existsSync(candidate)) {
+/**
+ * Reads scope file contents, capping each file and the overall prompt so a
+ * single anomalously large file can't blow the token budget.
+ */
+function readScopeFileContents(files, { repoRoot = REPO_ROOT, maxFileChars = MAX_FILE_CHARS } = {}) {
+  const out = [];
+  for (const file of files) {
     try {
-      const raw = fs.readFileSync(candidate, 'utf8');
-      return raw.slice(0, 8_000);
-    } catch {
-      /* fall through */
+      const content = fs.readFileSync(path.join(repoRoot, file), "utf8");
+      out.push({ path: file, content: content.slice(0, maxFileChars) });
+    } catch (err) {
+      console.warn(`Could not read scope file ${file}, skipping: ${err.message}`);
     }
   }
-  // Embedded fallback: 8-entry fix-pattern catalog summary.
+  return out;
+}
+
+/**
+ * Builds the diagnostic system prompt: explains the task, grounds it in the
+ * playbook's method + pattern catalog, and demands a structured JSON
+ * response. Explicitly instructs the model to say it found nothing / has no
+ * grounded fix rather than guess — a wrong "embedded fix" is worse than no
+ * fix (see standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md step 2: "demand
+ * file:line citations and real code quotes, not summaries").
+ */
+function buildSystemPrompt(playbookContext) {
   return [
-    'Audit fix-pattern catalog (embedded fallback):',
-    '1. Missing `allowError`/`continue-on-error` on non-critical steps that cause whole-workflow failure.',
-    '2. Unguarded label races — two workflows mutating the same label without concurrency: groups.',
-    '3. Token gaps — using default GITHUB_TOKEN where cross-repo/admin scope needed, or vice versa (leaking admin unnecessarily).',
-    '4. Exit-code used as a proxy metric — treating `exit 1` as "nothing to do" causing false failures.',
-    '5. Missing timeout-minutes on long-running or LLM-calling jobs.',
-    '6. Unpinned actions (@main / floating tags) in security-sensitive jobs.',
-    '7. Secrets referenced in `env:` at workflow level rather than step level (broadens exposure).',
-    '8. Cron collisions or thundering-herd (many jobs at :00 of the same hour) causing runner starvation.'
-  ].join('\n');
-}
-
-function buildPrompt(files, playbook) {
-  const fileBlocks = files
-    .map((f) => `----- FILE: ${f.path} -----\n${f.content}\n----- END FILE -----`)
-    .join('\n\n');
-  const system = [
-    'You are a code-level bug diagnostician for a GitHub Actions fleet.',
-    'You will be given the CURRENT content of recently-changed workflow YAML and Node scripts.',
-    'Your job: identify AT MOST ONE concrete code-level bug (not a style nit, not a speculative concern) that you can ground in the file text.',
-    '',
-    'STRICT RULES:',
-    '- If you cannot ground a specific bug in the file text at MEDIUM or HIGH confidence, respond with issueFound=false. Do NOT manufacture findings.',
-    '- If you can identify a bug but cannot ground a fix, set proposedFix to "No clear fix — needs human investigation" rather than guessing.',
-    '- Prefer patterns from the audit playbook catalog below.',
-    '- Output STRICT JSON only, no prose, no markdown fences.',
-    '',
-    'PLAYBOOK CONTEXT:',
-    playbook,
-    '',
-    'RESPONSE SCHEMA (JSON object, single finding, no arrays):',
-    '{',
+    "You are the fleet's daily diagnostic auditor for the revvel-standards repo.",
+    "You run once a day against a SMALL, bounded set of recently-changed files",
+    "(GitHub Actions workflow YAML and Node scripts) and look for a genuine,",
+    "grounded, code-level bug — not an operational failure (a workflow run",
+    "crashing or an issue getting stuck is a DIFFERENT system's job, not yours).",
+    "",
+    "Ground your diagnosis in this repo's established audit methodology and",
+    "fix-pattern catalog (read it before responding):",
+    "",
+    playbookContext,
+    "",
+    "RULES:",
+    "1. Only report an issue you can point to with a specific file and",
+    "   line/location from the content you were actually given below — never",
+    "   invent a file, line, or behavior you were not shown.",
+    "2. Only propose a fix you are genuinely confident about, grounded in the",
+    '   given content. If you found a real issue but cannot ground a concrete',
+    '   fix, set proposedFix to "No clear fix — needs human investigation" and',
+    "   lower confidence accordingly. A wrong proposed fix is worse than none.",
+    "3. If you find nothing worth a human/agent's time in the given files, say",
+    '   so plainly (issueFound: false) — do not manufacture an issue.',
+    "4. Reply with ONLY a single JSON object, no prose before or after it, no",
+    "   markdown code fence, matching exactly this shape:",
+    "{",
     '  "issueFound": boolean,',
-    '  "confidence": "low" | "medium" | "high",',
-    '  "filePath": string | null,',
-    '  "lineHint": string | null,',
-    '  "category": string | null,',
-    '  "title": string | null,',
-    '  "diagnosis": string | null,',
-    '  "proposedFix": string | null,',
-    '  "reasoning": string | null',
-    '}'
-  ].join('\n');
-
-  const user = `Files in scope (changed on main in last ${WINDOW_HOURS}h):\n\n${fileBlocks}`;
-
-  return { system, user };
+    '  "file": string | null,',
+    '  "line": string | null,',
+    '  "patternCategory": string,',
+    '  "diagnosis": string,',
+    '  "proposedFix": string,',
+    '  "confidence": "high" | "medium" | "low",',
+    '  "reasoning": string',
+    "}",
+    "`patternCategory` should name the matching catalog category (or",
+    '"other" if it does not fit one). `reasoning` should explain WHY this',
+    "matters (impact, blast radius) so a reviewer can triage quickly.",
+  ].join("\n");
 }
 
-async function callOpenRouter({ system, user }, model) {
-  const key = process.env.OPENROUTER_API_KEY;
-  if (!key) throw new Error('OPENROUTER_API_KEY missing');
-  const body = {
-    model,
-    messages: [
-      { role: 'system', content: system },
-      { role: 'user', content: user }
-    ],
-    temperature: 0.1,
-    max_tokens: 1500
-  };
-  const res = await fetch(OPENROUTER_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${key}`,
-      'Content-Type': 'application/json',
-      'HTTP-Referer': 'https://github.com/',
-      'X-Title': 'daily-diagnostic-audit'
-    },
-    body: JSON.stringify(body)
-  });
-  if (!res.ok) {
-    const txt = await res.text().catch(() => '');
-    throw new Error(`OpenRouter ${res.status}: ${txt.slice(0, 300)}`);
-  }
-  const json = await res.json();
-  const content = json?.choices?.[0]?.message?.content;
-  if (!content) throw new Error('OpenRouter returned empty content');
-  return content;
-}
+/**
+ * Builds the user message: the actual file contents in scope, capped to
+ * MAX_PROMPT_CHARS overall so the request stays bounded regardless of how
+ * many/large the in-scope files are.
+ */
+function buildUserPrompt(scopeFiles, { sinceHours = SCOPE_WINDOW_HOURS, maxPromptChars = MAX_PROMPT_CHARS } = {}) {
+  const header =
+    `Files changed on main in the last ${sinceHours} hours (in-scope glob: ` +
+    `.github/workflows/*.yml, scripts/*.js), ${scopeFiles.length} file(s):\n` +
+    scopeFiles.map((f) => `- ${f.path}`).join("\n") +
+    "\n\nFull content of each file follows.\n\n";
 
-function parseDiagnosis(raw) {
-  if (!raw) return null;
-  // Strip common code fences if the model ignored the instruction.
-  let s = String(raw).trim();
-  if (s.startsWith('```')) {
-    s = s.replace(/^```(?:json)?\s*/i, '').replace(/```$/, '').trim();
-  }
-  // Extract first {...} object if there's surrounding prose.
-  const first = s.indexOf('{');
-  const last = s.lastIndexOf('}');
-  if (first !== -1 && last !== -1 && last > first) {
-    s = s.slice(first, last + 1);
-  }
-  try {
-    return JSON.parse(s);
-  } catch (e) {
-    warn(`could not parse LLM JSON: ${e.message}`);
-    return null;
-  }
-}
-
-function isActionableDiagnosis(d) {
-  if (!d || typeof d !== 'object') return false;
-  if (d.issueFound !== true) return false;
-  const c = String(d.confidence || '').toLowerCase();
-  if (c !== 'medium' && c !== 'high') return false;
-  if (!d.filePath || typeof d.filePath !== 'string') return false;
-  if (!d.title || !d.diagnosis) return false;
-  return true;
-}
-
-async function hasExistingOpenDiagnosis(repo, filePath, token) {
-  try {
-    const q = encodeURIComponent(
-      `repo:${repo} is:issue is:open label:auto-diagnosed "${filePath}" in:body`
-    );
-    const res = await fetch(`https://api.github.com/search/issues?q=${q}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json'
-      }
-    });
-    if (!res.ok) {
-      warn(`dupe-check search failed: ${res.status}`);
-      return false;
+  let body = header;
+  for (const file of scopeFiles) {
+    const chunk = `--- FILE: ${file.path} ---\n\`\`\`\n${file.content}\n\`\`\`\n\n`;
+    if (body.length + chunk.length > maxPromptChars) {
+      body += `(remaining files omitted — prompt budget reached)\n`;
+      break;
     }
-    const json = await res.json();
-    return (json.total_count || 0) > 0;
-  } catch (e) {
-    warn(`dupe-check error (fail-open): ${e.message}`);
-    return false;
-  }
-}
-
-function renderWrBody(d) {
-  const learnings = [
-    '## Learnings — What & Why',
-    '',
-    `This WR was auto-filed by \`daily-diagnostic-audit.yml\` because a scan of files changed on \`main\` in the last ${WINDOW_HOURS}h flagged **${d.filePath}** with **${d.confidence}** confidence.`,
-    '',
-    'Method and fix-pattern catalog: `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`.',
-    '',
-    '**Implementer:** please *verify* the proposed fix against the current file rather than blindly applying it, and consider whether this represents a new catalog-worthy pattern worth adding to the playbook.'
-  ].join('\n');
-
-  const core = [
-    `## Diagnosis`,
-    '',
-    d.diagnosis || '(none)',
-    '',
-    `**File:** \`${d.filePath}\`` + (d.lineHint ? ` (${d.lineHint})` : ''),
-    d.category ? `**Category:** ${d.category}` : '',
-    '',
-    '## Proposed Fix',
-    '',
-    d.proposedFix || 'No clear fix — needs human investigation',
-    '',
-    '## Reasoning',
-    '',
-    d.reasoning || '(none)',
-    ''
-  ]
-    .filter(Boolean)
-    .join('\n');
-
-  // If the live template exposes a placeholder, substitute; else append.
-  const PLACEHOLDER = '<!-- LEARNINGS_PLACEHOLDER -->';
-  const templatePath = '.github/ISSUE_TEMPLATE/wr.md';
-  let body;
-  if (fs.existsSync(templatePath)) {
-    try {
-      const tmpl = fs.readFileSync(templatePath, 'utf8');
-      if (tmpl.includes(PLACEHOLDER)) {
-        body = tmpl.replace(PLACEHOLDER, `${core}\n${learnings}`);
-      } else {
-        body = `${core}\n\n${learnings}`;
-      }
-    } catch {
-      body = `${core}\n\n${learnings}`;
-    }
-  } else {
-    body = `${core}\n\n${learnings}`;
+    body += chunk;
   }
   return body;
 }
 
-function renderCoderComment(d) {
-  return [
-    '@coding-agent — this WR was auto-filed by the daily diagnostic audit.',
-    '',
-    `Please open **\`${d.filePath}\`**, verify the diagnosis (do not assume it is correct — the model can be wrong), and if confirmed, apply the proposed fix in a PR that closes this issue.`,
-    '',
-    `Confidence: **${d.confidence}**. If your verification lowers this to "low" or "none", close this issue with a comment explaining why rather than filing a speculative PR.`
-  ].join('\n');
-}
-
-async function createWrIssue(repo, token, d) {
-  const title = `[WR] ${d.title}`;
-  const body = renderWrBody(d);
-  const labels = ['WR', 'auto-diagnosed', 'daily-diagnostic-audit'];
-  const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.github+json',
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ title, body, labels })
-  });
-  if (!res.ok) {
-    const txt = await res.text().catch(() => '');
-    throw new Error(`create issue failed ${res.status}: ${txt.slice(0, 300)}`);
+/**
+ * Parses and validates the LLM's structured diagnostic response. Tolerant
+ * of a wrapping ```json fence (models do this even when told not to).
+ * Returns { valid: true, diagnosis } or { valid: false, error }.
+ */
+function parseDiagnosticResponse(text) {
+  if (!text || !String(text).trim()) {
+    return { valid: false, error: "empty response" };
   }
-  return res.json();
+  let jsonText = String(text).trim();
+  const fenceMatch = jsonText.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenceMatch) jsonText = fenceMatch[1].trim();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    return { valid: false, error: `unparseable JSON: ${err.message}` };
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return { valid: false, error: "response is not a JSON object" };
+  }
+  if (typeof parsed.issueFound !== "boolean") {
+    return { valid: false, error: "missing/invalid issueFound boolean" };
+  }
+
+  const confidence = String(parsed.confidence || "low").toLowerCase();
+  const diagnosis = {
+    issueFound: parsed.issueFound,
+    file: parsed.file || null,
+    line: parsed.line != null ? String(parsed.line) : null,
+    patternCategory: parsed.patternCategory || "other",
+    diagnosis: parsed.diagnosis || "",
+    proposedFix: parsed.proposedFix || "",
+    confidence: ["high", "medium", "low"].includes(confidence) ? confidence : "low",
+    reasoning: parsed.reasoning || "",
+  };
+
+  return { valid: true, diagnosis };
 }
 
-async function commentOnIssue(repo, token, number, body) {
-  const res = await fetch(
-    `https://api.github.com/repos/${repo}/issues/${number}/comments`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ body })
-    }
+/**
+ * Gate: is this diagnosis worth filing a WR for? Requires issueFound=true,
+ * at least "medium" confidence, and a non-empty diagnosis string. A "low"
+ * confidence finding is deliberately dropped — see RULES #2/#3 in the
+ * system prompt and constraint #5 in the originating WR: a wrong embedded
+ * fix is worse than no fix, and a low-confidence issue report is not much
+ * better.
+ */
+function isActionableDiagnosis(diagnosis) {
+  if (!diagnosis || !diagnosis.issueFound) return false;
+  if (!["high", "medium"].includes(diagnosis.confidence)) return false;
+  return Boolean(diagnosis.diagnosis && diagnosis.diagnosis.trim());
+}
+
+// Same placeholder text WR_TEMPLATE_BASIC.md/FULL.md ship with (see
+// .github/workflows/followup-checkbox-router.yml LEARNINGS_PLACEHOLDER) —
+// used to swap in real "Learnings — What & Why" content the same way that
+// workflow already does, for consistency between the two WR-generating
+// automations.
+const LEARNINGS_PLACEHOLDER =
+  "_Why this WR exists, and what the assigned agent should know before starting. " +
+  "Populated automatically for follow-up-generated WRs; agents completing other WR " +
+  "types should fill this in themselves once done, summarizing what they did and why, " +
+  "for future audits._";
+
+/**
+ * Renders the WR issue title from a diagnosis.
+ */
+function renderWrTitle(diagnosis) {
+  const short = (diagnosis.diagnosis || "code issue").split(/\r?\n/)[0].slice(0, 80);
+  const location = diagnosis.file ? ` (${diagnosis.file})` : "";
+  return `[WR] Daily Diagnostic Audit: ${short}${location}`.slice(0, 250);
+}
+
+/**
+ * Renders the full WR issue body from wr/WR_TEMPLATE_BASIC.md: a bug/chore
+ * diagnosis has no product/market research surface, so BASIC is always the
+ * right template here (mirrors followup-checkbox-router.yml's
+ * classifyTemplate default for short, single-topic follow-ups).
+ *
+ * Two additions beyond the standard token substitution:
+ *  - A "## Proposed Fix" section is inserted (BASIC has no token for this,
+ *    so it is spliced in structurally rather than by editing the shared
+ *    template file — avoids fighting other in-flight template edits).
+ *  - "## Learnings — What & Why" is populated via LEARNINGS_PLACEHOLDER
+ *    substitution when present; if the checked-out template predates that
+ *    section (it landed in a sibling PR the same day), the section is
+ *    appended instead so the instruction is never silently dropped.
+ */
+function renderWrBody({ template, diagnosis, scopeFiles, sinceHours, repoFull, repoUrl, today, runUrl }) {
+  const issueContext = [
+    "Auto-generated by the daily diagnostic audit cron " +
+      "(`.github/workflows/daily-diagnostic-audit.yml` -> `scripts/daily-diagnostic-audit.js`).",
+    "",
+    `**Scope this run:** files changed on \`main\` in the last ${sinceHours} hours, ` +
+      "restricted to `.github/workflows/*.yml` and `scripts/*.js`:",
+    ...scopeFiles.map((f) => `- \`${f}\``),
+    "",
+    `**Pattern category:** ${diagnosis.patternCategory}`,
+    `**Confidence:** ${diagnosis.confidence}`,
+    diagnosis.file ? `**File:** \`${diagnosis.file}\`${diagnosis.line ? ` (line ${diagnosis.line})` : ""}` : "",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+
+  const proposedFixSection = [
+    "> **Machine-generated starting point — verify before applying, do not apply blindly.**",
+    "> This is the daily diagnostic cron's proposed fix, produced from the file content",
+    "> given to it in this run. It has not been tested and may be wrong or incomplete.",
+    "",
+    "**Diagnosis:**",
+    "",
+    diagnosis.diagnosis,
+    "",
+    "**Proposed fix:**",
+    "",
+    diagnosis.proposedFix || "No clear fix — needs human investigation.",
+    "",
+    "**Why this matters:**",
+    "",
+    diagnosis.reasoning || "(not provided)",
+  ].join("\n");
+
+  const learningsContent = [
+    `**Why this WR exists:** flagged by the daily diagnostic audit cron ` +
+      `(pattern category: ${diagnosis.patternCategory}, confidence: ${diagnosis.confidence}). ` +
+      `See run: ${runUrl}`,
+    "",
+    "**Methodology + pattern catalog:** `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` " +
+      "— read it before starting; it documents the audit method this WR was produced by " +
+      "and a fast-lookup catalog of fix patterns already found more than once in this repo.",
+    "",
+    "**Instructions for the implementing agent:**",
+    "1. Verify the proposed fix above against the *current* code before applying it — " +
+      "line numbers and context can drift between when this WR was filed and when you pick it up.",
+    "2. Do not apply it blindly. If it is wrong, adapt it or take a different approach, and " +
+      "say so (and why) in your PR description.",
+    "3. Once resolved, consider whether this reveals a new recurring pattern worth adding to " +
+      "`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`'s catalog (or whether it matches an " +
+      "existing one, in which case cite it).",
+  ].join("\n");
+
+  let body = template;
+  body = body.split("{TITLE}").join(renderWrTitle(diagnosis).replace(/^\[WR\]\s*/, ""));
+  body = body.split("{ISSUE_REF}").join("N/A — no source issue, auto-diagnosed");
+  body = body.split("{DATE}").join(today);
+  body = body.split("{REPO}").join(repoFull);
+  body = body.split("{STATUS}").join("🟡 In Progress");
+  body = body.split("{ISSUE_BODY}").join(issueContext);
+  body = body.split("{SUMMARY}").join(
+    `The daily diagnostic audit cron flagged a likely code-level bug in ` +
+      `\`${diagnosis.file || "(file not specified)"}\`: ${diagnosis.diagnosis}`,
   );
-  if (!res.ok) {
-    const txt = await res.text().catch(() => '');
-    throw new Error(`comment failed ${res.status}: ${txt.slice(0, 300)}`);
+  body = body.split("{OBJECTIVE}").join(
+    "Verify the diagnosis below and, if correct, apply the proposed fix (or an adapted " +
+      "approach) to resolve it. If the diagnosis turns out to be wrong or not reproducible, " +
+      "comment explaining why and close as invalid rather than force-applying the proposed fix.",
+  );
+  body = body.split("{REQUIRED_BUNDLE}").join(
+    `Fix ${diagnosis.file ? `\`${diagnosis.file}\`` : "the affected file(s)"} per the Proposed ` +
+      "Fix section below (or an adapted approach); add/adjust a regression test where practical; " +
+      "keep `npm test` green.",
+  );
+  body = body.split("{DEFINITION_OF_DONE}").join(
+    `The diagnosed issue is resolved (via the proposed fix or an adapted approach), ` +
+      "`npm ci && npm test` stays green, and the Learnings section below is updated with " +
+      "what was actually done.",
+  );
+  body = body.split("{VALIDATION}").join(
+    "Reproduce/confirm the diagnosed behavior before and after the fix where practical " +
+      "(standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md step 5: reproduce end-to-end, don't just " +
+      "trust a static read). Run `npm ci && npm test` and confirm green.",
+  );
+  body = body.split("{BLOCKERS}").join(
+    "None known at creation time. This is a machine-generated diagnosis from a single bounded " +
+      "LLM call — if it is ungrounded or wrong, that is expected-possible outcome, not a blocker; " +
+      "close as invalid with a short comment explaining why.",
+  );
+
+  // Splice in "## Proposed Fix" ahead of "## Definition of Done" (BASIC has
+  // no token for this section, so this is structural rather than a
+  // template-token substitution — keeps the shared template file untouched).
+  const definitionHeading = "\n## Definition of Done\n";
+  if (body.includes(definitionHeading)) {
+    body = body.replace(definitionHeading, `\n## Proposed Fix\n\n${proposedFixSection}\n${definitionHeading}`);
+  } else {
+    body += `\n\n## Proposed Fix\n\n${proposedFixSection}\n`;
   }
-  return res.json();
+
+  // Learnings — What & Why: substitute the known placeholder if present
+  // (template already has the section, added in a sibling PR the same
+  // day); otherwise append the section so the instruction is never lost
+  // regardless of merge order between the two same-day PRs.
+  if (body.includes(LEARNINGS_PLACEHOLDER)) {
+    body = body.split(LEARNINGS_PLACEHOLDER).join(learningsContent);
+  } else if (!body.includes("## Learnings")) {
+    body += `\n\n## Learnings — What & Why\n\n${learningsContent}\n`;
+  }
+
+  return body;
+}
+
+/**
+ * Renders the separate, coder-addressed comment posted on the new WR.
+ */
+function renderCoderComment() {
+  return [
+    "🔧 **For the implementing agent**",
+    "",
+    "This WR was auto-diagnosed by the daily diagnostic audit cron " +
+      "(`.github/workflows/daily-diagnostic-audit.yml`), not filed by a human.",
+    "",
+    "I'm including a proposed fix and the reasoning behind it above (see the " +
+      "**Proposed Fix** and **Learnings — What & Why** sections) — here's why: a bare " +
+      '"here\'s a bug, go figure it out" report wastes the time you\'d spend re-deriving ' +
+      "context an automated pass already had in front of it. Please:",
+    "- Verify the proposed fix against the current code before applying it — don't apply blindly.",
+    "- Adapt it or take a different approach if it's wrong, and note that (and why) in your PR.",
+    "- Once resolved, check whether this is a new pattern worth adding to " +
+      "`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`, or matches one already there.",
+  ].join("\n");
+}
+
+function splitRepository() {
+  const [owner, repo] = GITHUB_REPOSITORY.split("/");
+  if (!owner || !repo) {
+    throw new Error(`Invalid GITHUB_REPOSITORY format: ${GITHUB_REPOSITORY}`);
+  }
+  return { owner, repo };
+}
+
+async function githubRequest(pathName, { method = "GET", payload } = {}) {
+  const res = await fetch(`https://api.github.com${pathName}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      "User-Agent": "revvel-daily-diagnostic-audit",
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    },
+    body: payload ? JSON.stringify(payload) : undefined,
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`GitHub HTTP ${res.status} for ${pathName}: ${text.slice(0, 400)}`);
+  }
+  return text ? JSON.parse(text) : {};
+}
+
+/**
+ * Best-effort duplicate guard: skip filing a new WR if an open
+ * `auto-diagnosed` issue already mentions the same file — avoids piling up
+ * repeat WRs for a diagnosis that has not been fixed yet but keeps getting
+ * re-touched within the scope window. Never blocks filing on a failed
+ * search (fail open — a missed dedupe is far cheaper than silently never
+ * filing anything again).
+ */
+async function hasExistingOpenDiagnosis(file) {
+  if (!file) return false;
+  const { owner, repo } = splitRepository();
+  const q = encodeURIComponent(`repo:${owner}/${repo} is:issue is:open label:auto-diagnosed "${file}"`);
+  try {
+    const result = await githubRequest(`/search/issues?q=${q}`);
+    return (result.total_count || 0) > 0;
+  } catch (err) {
+    console.warn(`Duplicate check failed (proceeding anyway): ${err.message}`);
+    return false;
+  }
+}
+
+async function createWrIssue({ title, body }) {
+  const { owner, repo } = splitRepository();
+  return githubRequest(`/repos/${owner}/${repo}/issues`, {
+    method: "POST",
+    payload: { title, body, labels: WR_LABELS, assignees: WR_ASSIGNEES },
+  });
+}
+
+async function createComment(issueNumber, body) {
+  const { owner, repo } = splitRepository();
+  return githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+    method: "POST",
+    payload: { body },
+  });
 }
 
 async function main() {
-  const repo = process.env.GITHUB_REPOSITORY;
-  const token = process.env.GITHUB_TOKEN;
-  if (!repo) {
-    warn('GITHUB_REPOSITORY not set — cannot file WR. Exiting 0.');
+  if (!GITHUB_TOKEN) {
+    console.error("GH_TOKEN/GITHUB_TOKEN is required — skipping run.");
     return;
   }
   if (!process.env.OPENROUTER_API_KEY) {
-    warn('OPENROUTER_API_KEY missing — no LLM call possible. Exiting 0 (fail-open).');
-    return;
-  }
-
-  const scope = selectScopeFiles();
-  if (scope.length === 0) {
-    log('quiet 48h window: no in-scope files changed. 0 API calls, 0 WRs.');
-    return;
-  }
-  log(`scope: ${scope.length} file(s) — ${scope.join(', ')}`);
-
-  const files = scope.map((p) => ({ path: p, content: readFileClipped(p) }));
-  const playbook = loadPlaybookContext();
-  const prompt = buildPrompt(files, playbook);
-
-  let raw;
-  try {
-    raw = await callOpenRouter(prompt, PRIMARY_MODEL);
-  } catch (e) {
-    warn(`primary model failed: ${e.message} — trying fallback`);
-    try {
-      raw = await callOpenRouter(prompt, FALLBACK_MODEL);
-    } catch (e2) {
-      warn(`fallback model also failed: ${e2.message} — exiting 0 (fail-open)`);
-      return;
-    }
-  }
-
-  const diagnosis = parseDiagnosis(raw);
-  if (!diagnosis) {
-    warn('unparseable LLM response — exiting 0 (fail-open)');
-    return;
-  }
-  if (!isActionableDiagnosis(diagnosis)) {
-    log(
-      `no actionable diagnosis (issueFound=${diagnosis.issueFound}, confidence=${diagnosis.confidence}). 0 WRs filed — this is expected/common.`
+    // Never hard-fail: a missing/unfunded key is an ops problem, not a bug.
+    // Mirrors scripts/octopus-review-fallback.js's fail-open behavior.
+    console.error(
+      "OPENROUTER_API_KEY is not set — daily diagnostic audit skipped. " +
+        "Check the key AND balance at https://openrouter.ai/credits.",
     );
     return;
   }
 
-  if (!token) {
-    warn('GITHUB_TOKEN missing — cannot file WR. Exiting 0.');
+  const scopePaths = selectScopeFiles();
+  if (scopePaths.length === 0) {
+    console.log(
+      `No .github/workflows/*.yml or scripts/*.js changes on main in the last ${SCOPE_WINDOW_HOURS}h — ` +
+        "nothing to diagnose this run. This is expected and fine.",
+    );
+    return;
+  }
+  console.log(`In-scope files (${scopePaths.length}): ${scopePaths.join(", ")}`);
+
+  const scopeFiles = readScopeFileContents(scopePaths);
+  if (scopeFiles.length === 0) {
+    console.log("Could not read any in-scope files — nothing to diagnose this run.");
     return;
   }
 
-  const dup = await hasExistingOpenDiagnosis(repo, diagnosis.filePath, token);
-  if (dup) {
-    log(`open auto-diagnosed WR already exists for ${diagnosis.filePath} — skipping.`);
-    return;
-  }
+  const playbookContext = loadPlaybookContext();
+  const systemPrompt = buildSystemPrompt(playbookContext);
+  const userPrompt = buildUserPrompt(scopeFiles);
 
-  let issue;
+  let result;
   try {
-    issue = await createWrIssue(repo, token, diagnosis);
-  } catch (e) {
-    warn(`failed to create WR: ${e.message}`);
+    result = await callOpenRouter({
+      // Reuses the fleet's `review` profile from .github/agent-models.yml
+      // (same lane scripts/octopus-review-fallback.js uses) — diagnosis is
+      // close kin to code review, and this avoids adding a new profile.
+      models: loadDiagnosticModels(),
+      max_tokens: 3000,
+      temperature: 0.1,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+    });
+  } catch (err) {
+    // Best-effort by design: an LLM-lane outage must not fail the workflow.
+    console.error(`OpenRouter call failed: ${err.message}`);
     return;
   }
-  log(`filed WR #${issue.number}: ${issue.html_url}`);
 
-  try {
-    await commentOnIssue(repo, token, issue.number, renderCoderComment(diagnosis));
-    log(`posted coder-facing comment on #${issue.number}`);
-  } catch (e) {
-    warn(`failed to post comment (WR was still filed): ${e.message}`);
+  const parsedResult = parseDiagnosticResponse(result.text);
+  if (!parsedResult.valid) {
+    console.log(`Model response was not usable (${parsedResult.error}) — filing nothing this run.`);
+    return;
   }
+
+  const diagnosis = parsedResult.diagnosis;
+  if (!isActionableDiagnosis(diagnosis)) {
+    console.log(
+      `No actionable issue this run (issueFound=${diagnosis.issueFound}, confidence=${diagnosis.confidence}) — ` +
+        "filing nothing. This is expected and fine.",
+    );
+    return;
+  }
+
+  if (await hasExistingOpenDiagnosis(diagnosis.file)) {
+    console.log(`An open auto-diagnosed WR already references ${diagnosis.file} — skipping duplicate.`);
+    return;
+  }
+
+  const template = fs.readFileSync(path.join(REPO_ROOT, "wr", "WR_TEMPLATE_BASIC.md"), "utf8");
+  const { owner, repo } = splitRepository();
+  const runUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID
+    ? `${process.env.GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+    : "(local run, no CI URL)";
+
+  const title = renderWrTitle(diagnosis);
+  const body = renderWrBody({
+    template,
+    diagnosis,
+    scopeFiles: scopePaths,
+    sinceHours: SCOPE_WINDOW_HOURS,
+    repoFull: `${owner}/${repo}`,
+    repoUrl: `https://github.com/${owner}/${repo}`,
+    today: new Date().toISOString().slice(0, 10),
+    runUrl,
+  });
+
+  const issue = await createWrIssue({ title, body });
+  console.log(`Created WR issue #${issue.number}: ${issue.html_url}`);
+
+  await createComment(issue.number, renderCoderComment());
+  console.log(`Posted coder-facing comment on #${issue.number}.`);
+}
+
+/**
+ * Mirrors scripts/octopus-review-fallback.js's loadReviewProfile: reads the
+ * `review` profile (primary + fallback models) from .github/agent-models.yml
+ * so this script follows fleet model policy instead of hardcoding models.
+ * Kept as a local copy (rather than importing octopus-review-fallback.js)
+ * so this script has no dependency on an unrelated fallback-review lane.
+ */
+function loadDiagnosticModels() {
+  const configPath = path.join(REPO_ROOT, ".github", "agent-models.yml");
+  const YAML = require("yaml");
+  const config = YAML.parse(fs.readFileSync(configPath, "utf8"));
+  const review = config?.profiles?.review;
+  if (!review || !review.primary) {
+    throw new Error("No `review` profile with a primary model in agent-models.yml");
+  }
+  return [review.primary, review.fallback].filter(Boolean);
 }
 
 if (require.main === module) {
-  main().catch((e) => {
-    warn(`unhandled error (fail-open): ${e.message}`);
-    process.exit(0);
+  main().catch((err) => {
+    // Final safety net: this cron must never fail the workflow over a bug
+    // in its own diagnosis lane. Log loudly and exit 0.
+    console.error(`daily-diagnostic-audit failed: ${err.message}`);
   });
 }
 
 module.exports = {
+  parseGitLogNameOnly,
+  filterInScope,
   selectScopeFiles,
-  inScope,
-  loadPlaybookContext,
-  buildPrompt,
-  parseDiagnosis,
+  readScopeFileContents,
+  buildSystemPrompt,
+  buildUserPrompt,
+  parseDiagnosticResponse,
   isActionableDiagnosis,
+  renderWrTitle,
   renderWrBody,
-  renderCoderComment
+  renderCoderComment,
+  loadPlaybookContext,
+  loadDiagnosticModels,
+  LEARNINGS_PLACEHOLDER,
+  SCOPE_GLOBS,
+  WR_LABELS,
+  WR_ASSIGNEES,
 };

--- a/scripts/octopus-review-fallback.js
+++ b/scripts/octopus-review-fallback.js
@@ -1,216 +1,171 @@
 #!/usr/bin/env node
-/*
- * Octopus review fallback script.
- *
- * Posts a fallback code review comment on a PR when the primary Octopus
- * reviewer has hit its monthly quota. Designed to never fail loud — a
- * fallback-review outage must not itself go red in CI. However, transient
- * GitHub API rate-limit errors ARE retried (with backoff) before giving up,
- * so that a fan-out burst of concurrent fallback runs sharing one GitHub App
- * installation's rate-limit budget doesn't silently no-op.
- *
- * See issue #15836 for the regression this file's retry logic fixes.
- */
-
-'use strict';
-/**
- * Octopus review fallback
- *
- * When the primary Octopus reviewer cannot post a review (e.g. quota exhausted,
- * transient outage), this script posts a lightweight fallback review comment
- * on open PRs so contributors aren't left waiting.
- *
- * Rate-limit handling notes:
- *   GitHub's REST API has two distinct rate-limit failure modes:
- *     - PRIMARY (shared hourly installation/user budget). Signaled by
- *       `x-ratelimit-remaining: 0` + `x-ratelimit-reset` (Unix seconds).
- *       Does NOT reliably send `Retry-After`. The reset can be up to ~1h out.
- *       See docs/biome/README.md:147-155 (incident #15491).
- *     - SECONDARY / abuse detection. Short-lived. DOES send `Retry-After`.
- *
- *   These need different handling. Primary limits: honor the reset timestamp,
- *   and if that exceeds our in-process wait ceiling (10min, under the 15min
- *   workflow timeout), give up gracefully — the 6-hourly schedule sweep will
- *   pick this PR up on the next cycle because shouldReview()'s dedupe marker
- *   is only set after a review is actually posted.
- */
-
-'use strict';
-
-const RATE_LIMIT_BASE_DELAY_MS = Number(process.env.OCTOPUS_RATE_LIMIT_BASE_DELAY_MS || 1500);
-const RATE_LIMIT_MAX_RETRIES = Number(process.env.OCTOPUS_RATE_LIMIT_MAX_RETRIES || 4);
-// Ceiling for any single in-process sleep. Workflow timeout-minutes is 15, so
-// 10min leaves ~5min headroom for the rest of the job. Any wait longer than
-// this cannot possibly succeed before the runner is killed — bail out instead.
-const RATE_LIMIT_MAX_INPROCESS_WAIT_MS = Number(
-  process.env.OCTOPUS_RATE_LIMIT_MAX_INPROCESS_WAIT_MS || 10 * 60 * 1000,
-);
-
-function lowerHeaders(headers) {
-  const out = {};
-  if (!headers) return out;
-  if (typeof headers.forEach === 'function' && !Array.isArray(headers)) {
-    // Headers-like
-    headers.forEach((value, key) => {
-      out[String(key).toLowerCase()] = value;
-    });
-    return out;
-  }
-  for (const [key, value] of Object.entries(headers)) {
-    out[String(key).toLowerCase()] = value;
-  }
-  return out;
-}
+"use strict";
 
 /**
- * Classify a rate-limited response as `"primary"` or `"secondary"`.
- * Returns `null` if the response does not look rate-limited at all.
+ * Octopus Review Fallback — self-hosted review lane when Octopus is quota-dead
+ *
+ * Octopus Review (octopus-review.ai) runs out of monthly AI quota and posts an
+ * "add your own API keys" comment on every PR instead of a review. External
+ * review apps can't be re-summoned from the WR area when their quota/keys die,
+ * so this script runs the fleet's OWN review lane instead:
+ *
+ *   1. Detect the Octopus quota-death comment (isQuotaDeathComment), OR run in
+ *      sweep mode for PRs where Octopus never showed up after N minutes.
+ *   2. Skip if a healthy Octopus review already exists (no double-review) or
+ *      if this fallback already reviewed the PR (dedupe via HTML marker).
+ *   3. Fetch the PR diff and call OpenRouter with the `review` profile from
+ *      .github/agent-models.yml (Opus 4.7 primary, DeepSeek R1 fallback) —
+ *      no new vendor lock-in; same key/lane as the rest of the fleet.
+ *   4. Post the findings as a formal PR review (COMMENT event).
+ *
+ * Wiring: .github/workflows/octopus-review-fallback.yml
+ * Persona docs: skills/octopus-expert/SKILL.md ("Quota-Death Fallback Lane")
+ *
+ * If reviews "aren't happening": check OPENROUTER_API_KEY funding first
+ * (https://openrouter.ai/credits) — a 401/402/429 here means the key/balance,
+ * not this script. The script is best-effort and never fails the workflow.
  */
-function classifyRateLimit(status, headers, body) {
-  if (status !== 403 && status !== 429) return null;
-  const h = lowerHeaders(headers);
-  const bodyText =
-    typeof body === 'string' ? body : body && typeof body === 'object' ? JSON.stringify(body) : '';
-  const bodyLower = bodyText.toLowerCase();
 
-  const remaining = h['x-ratelimit-remaining'];
-  const reset = h['x-ratelimit-reset'];
-  const retryAfter = h['retry-after'];
-
-  // Secondary rate limit signals
-  const looksSecondary =
-    bodyLower.includes('secondary rate limit') ||
-    bodyLower.includes('abuse detection') ||
-    bodyLower.includes('abuse-detection');
-  if (looksSecondary) return 'secondary';
-
-  // Primary rate limit signals
-  const remainingZero = remaining !== undefined && String(remaining).trim() === '0';
-  const looksPrimaryByHeaders = remainingZero && reset !== undefined;
-  const looksPrimaryByBody =
-    bodyLower.includes('api rate limit exceeded') ||
-    bodyLower.includes('rate limit exceeded for installation');
-  if (looksPrimaryByHeaders || looksPrimaryByBody) return 'primary';
-
-  // A bare Retry-After with no other signal — treat as secondary (short wait).
-  if (retryAfter !== undefined) return 'secondary';
-
-  return null;
 const https = require("https");
 const fs = require("fs");
 const path = require("path");
 const { callOpenRouter } = require("./openrouter-routing.js");
 
-const https = require('https');
+// Environment variables
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN || "";
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY || "midnghtsapphire/revvel-standards";
+const PR_NUMBER = process.env.PR_NUMBER || "";
 
-const DEFAULT_BASE_DELAY_MS = 1500;
-const DEFAULT_MAX_RETRIES = 4;
-const DEFAULT_MAX_DELAY_MS = 20000;
+// Dedupe marker embedded in the review body — presence anywhere on the PR
+// (review or comment) means the fallback already ran; never review twice.
+const FALLBACK_MARKER = "<!-- octopus-review-fallback -->";
 
-function envInt(name, fallback) {
-  const raw = process.env[name];
-  if (raw === undefined || raw === null || raw === '') return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
-  return parsed;
-}
+// The GitHub App login Octopus posts as (see octopus-route.yml).
+const OCTOPUS_BOT_LOGIN = "octopus-review[bot]";
 
-function getRetryConfig() {
-  return {
-    baseDelayMs: envInt('RATE_LIMIT_BASE_DELAY_MS', DEFAULT_BASE_DELAY_MS),
-    maxRetries: envInt('RATE_LIMIT_MAX_RETRIES', DEFAULT_MAX_RETRIES),
-    maxDelayMs: envInt('RATE_LIMIT_MAX_DELAY_MS', DEFAULT_MAX_DELAY_MS),
-  };
-}
+const MAX_DIFF_CHARS = parseInt(process.env.MAX_DIFF_CHARS || "60000", 10);
 
-/**
- * Classify a response as a GitHub rate-limit rejection.
- *
- * - HTTP 429 is always a rate-limit.
- * - HTTP 403 is a rate-limit ONLY if the body carries GitHub's primary or
- *   secondary rate-limit message. A genuine permissions 403 must NOT retry.
- * - Everything else (404, 5xx, etc.) is not classified as rate-limit here.
- */
-function isRateLimitedResponse(status, body) {
-  if (status === 429) return true;
-  if (status !== 403) return false;
-  const text = typeof body === 'string' ? body : (body && typeof body === 'object' ? JSON.stringify(body) : '');
-  if (!text) return false;
-  const lower = text.toLowerCase();
-  return (
-    lower.includes('api rate limit exceeded') ||
-    lower.includes('secondary rate limit') ||
-    lower.includes('you have exceeded a secondary rate limit') ||
-    lower.includes('abuse detection')
-  );
-}
-
-/**
- * Compute a delay before the next retry attempt.
- *
- * Honors the `Retry-After` response header when present (seconds), otherwise
- * falls back to capped exponential backoff: base * 2^attempt, clamped to
- * maxDelayMs.
- */
-function computeRetryDelayMs(headers, attempt, baseDelayMs = DEFAULT_BASE_DELAY_MS, maxDelayMs = DEFAULT_MAX_DELAY_MS) {
-  const h = headers || {};
-  const retryAfterRaw = h['retry-after'] || h['Retry-After'];
-  if (retryAfterRaw !== undefined && retryAfterRaw !== null && retryAfterRaw !== '') {
-    const secs = Number.parseFloat(retryAfterRaw);
-    if (Number.isFinite(secs) && secs >= 0) {
-      return Math.min(Math.round(secs * 1000), maxDelayMs);
-    }
-  }
-  const backoff = baseDelayMs * Math.pow(2, Math.max(0, attempt));
-  return Math.min(backoff, maxDelayMs);
-}
+// Retry policy for GitHub API rate limiting. The issue_comment trigger is
+// unscoped (fires on every comment on every issue/PR in the repo), so a
+// single burst of bot chatter (Vercel pings, CI-status, ship-quality-check,
+// triage bots, plus Octopus itself) can spin up dozens of concurrent
+// fallback-review runs within the same few seconds — all sharing the same
+// GitHub App installation's API rate-limit budget. That burst has been
+// observed tripping GitHub's rate limiting ("API rate limit exceeded for
+// installation", HTTP 403) on the very first REST call of a run that
+// otherwise correctly matched the quota-death comment — and because the
+// whole script runs inside a top-level try/catch that never rethrows (by
+// design: a fallback outage must not go red itself), that 403 was silently
+// swallowed and the job still reported success, with NO review ever posted.
+//
+// GitHub's rate limiting comes in two distinct flavors that need different
+// handling (caught in post-merge review of #15836 by a Copilot comment on
+// this file — the first pass here treated both the same way):
+//
+//   * PRIMARY (the shared installation budget — see docs/biome/README.md's
+//     "PR Lifecycle failing in bulk" field note, incident #15491): the
+//     response carries `x-ratelimit-remaining: 0` and `x-ratelimit-reset`
+//     (a Unix timestamp for when the budget refills — can be up to ~an hour
+//     out) and does NOT reliably carry `Retry-After`. A short exponential
+//     backoff (seconds) can NEVER recover this — the budget simply isn't
+//     there yet — so retrying fast just burns the job's timeout-minutes: 15
+//     without ever succeeding.
+//   * SECONDARY / abuse-detection: short-lived, and GitHub's response
+//     typically DOES carry a `Retry-After` header (seconds) telling you
+//     exactly how long to back off. Waiting that out in-process is the
+//     right move — this is the case the original short-backoff retry was
+//     actually designed for.
+//
+// See classifyRateLimit() for how a response is bucketed into one of these,
+// and computePrimaryResetWaitMs() / computeRetryDelayMs() for how each is
+// waited out.
+const RATE_LIMIT_MAX_RETRIES = parseInt(process.env.RATE_LIMIT_MAX_RETRIES || "4", 10);
+const RATE_LIMIT_BASE_DELAY_MS = parseInt(process.env.RATE_LIMIT_BASE_DELAY_MS || "1500", 10);
+// Cap for the exponential-backoff fallback used when we can't read a
+// specific wait time off the response at all (no Retry-After, no
+// x-ratelimit-reset) — an educated guess, so kept short on purpose.
+const RATE_LIMIT_MAX_DELAY_MS = parseInt(process.env.RATE_LIMIT_MAX_DELAY_MS || "20000", 10);
+// Ceiling on how long we will actually sleep in-process for ANY rate-limit
+// wait we DO have a concrete number for (x-ratelimit-reset, or a
+// server-provided Retry-After) before giving up instead of burning the
+// job's `timeout-minutes: 15` (.github/workflows/octopus-review-fallback.yml)
+// on a wait that can't possibly finish before the job gets killed anyway.
+// Default (10 min) leaves ~5 min of headroom for setup + the actual review
+// call once the wait is over.
+const RATE_LIMIT_MAX_INPROCESS_WAIT_MS = parseInt(
+  process.env.RATE_LIMIT_MAX_INPROCESS_WAIT_MS || String(10 * 60 * 1000),
+  10,
+);
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
- * Perform a single GitHub REST request. Returns {status, headers, data}.
- * `data` is the parsed JSON body when possible, else the raw string.
- * Does NOT throw for non-2xx — callers inspect `status`.
+ * True when a GitHub REST response looks like a rate-limit rejection worth
+ * special-casing (as opposed to a genuine permissions 403, which should
+ * fail fast, not retry): HTTP 429, or HTTP 403 whose body is GitHub's
+ * primary/secondary rate-limit message. Does NOT distinguish primary vs
+ * secondary — see classifyRateLimit() for that.
  */
-function githubRequestOnce(method, pathAndQuery, { token, body, userAgent } = {}) {
-  return new Promise((resolve, reject) => {
-    const payload = body === undefined ? undefined : (typeof body === 'string' ? body : JSON.stringify(body));
-    const options = {
-      hostname: 'api.github.com',
-      path: pathAndQuery,
-      method,
-      headers: {
-        'Accept': 'application/vnd.github+json',
-        'User-Agent': userAgent || 'octopus-review-fallback',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-    };
-    if (token) options.headers['Authorization'] = `Bearer ${token}`;
-    if (payload !== undefined) {
-      options.headers['Content-Type'] = 'application/json';
-      options.headers['Content-Length'] = Buffer.byteLength(payload);
-    }
+function isRateLimitedResponse(status, body) {
+  if (status === 429) return true;
+  if (status !== 403) return false;
+  const text = String(body || "").toLowerCase();
+  return (
+    text.includes("rate limit exceeded") ||
+    text.includes("secondary rate limit") ||
+    text.includes("abuse detection")
+  );
+}
 
-    const req = https.request(options, (res) => {
-      const chunks = [];
-      res.on('data', (c) => chunks.push(c));
-      res.on('end', () => {
-        const raw = Buffer.concat(chunks).toString('utf8');
-        let data = raw;
-        if (raw && res.headers && typeof res.headers['content-type'] === 'string' && res.headers['content-type'].includes('application/json')) {
-          try { data = JSON.parse(raw); } catch (_) { data = raw; }
-        } else if (raw) {
-          try { data = JSON.parse(raw); } catch (_) { data = raw; }
-        }
-        resolve({ status: res.statusCode, headers: res.headers || {}, data, raw });
-      });
-    });
-    req.on('error', reject);
-    if (payload !== undefined) req.write(payload);
-    req.end();
-  });
+/**
+ * Buckets a rate-limited response (isRateLimitedResponse() already true)
+ * into "primary" (shared installation budget exhausted) or "secondary"
+ * (short-lived abuse-detection limit). Header signal wins when present
+ * (most reliable, since Node lowercases response header names); otherwise
+ * falls back to GitHub's documented message wording. Returns null if the
+ * response isn't a rate-limit response at all.
+ */
+function classifyRateLimit(status, headers, body) {
+  if (status !== 403 && status !== 429) return null;
+  const h = headers || {};
+  const text = String(body || "").toLowerCase();
+  const remaining = h["x-ratelimit-remaining"];
+  const reset = h["x-ratelimit-reset"];
+
+  // Most reliable signal: GitHub always sends these on primary-limit
+  // responses. x-ratelimit-remaining arrives as a string ("0") over HTTP.
+  if (remaining === "0" && reset != null && reset !== "") {
+    return "primary";
+  }
+  if (text.includes("secondary rate limit") || text.includes("abuse detection")) {
+    return "secondary";
+  }
+  if (text.includes("api rate limit exceeded") || text.includes("rate limit exceeded")) {
+    // Matches docs/biome/README.md's documented installation-budget-exhaustion
+    // wording (incident #15491) with no header confirmation available (e.g.
+    // headers stripped somewhere upstream) — assume primary. If
+    // x-ratelimit-reset also turns out to be missing, computePrimaryResetWaitMs
+    // returns null and githubRequest() falls back to the short-backoff path
+    // anyway, so this default is safe either way.
+    return "primary";
+  }
+  if (h["retry-after"] != null || h["Retry-After"] != null) {
+    return "secondary";
+  }
+  if (status === 429) return "secondary";
+  return null;
+}
+
+/**
+ * Computes how long (ms) until GitHub's primary rate-limit budget resets,
+ * from the `x-ratelimit-reset` header (Unix seconds). Returns null when the
+ * header is missing/unparseable so the caller can fall back to a generic
+ * backoff instead of guessing.
+ */
+function computePrimaryResetWaitMs(headers) {
+  const h = headers || {};
   const resetHeader = h["x-ratelimit-reset"] || h["X-RateLimit-Reset"];
   const resetEpochSeconds = parseInt(resetHeader, 10);
   if (!Number.isFinite(resetEpochSeconds)) return null;
@@ -237,303 +192,393 @@ function computeRetryDelayMs(headers, attempt, baseDelayMs = RATE_LIMIT_BASE_DEL
   return Math.min(exponential, RATE_LIMIT_MAX_DELAY_MS);
 }
 
-/**
- * For a primary rate-limit response, compute how long to wait for the
- * installation budget to refill, based on `x-ratelimit-reset` (Unix seconds).
- * Returns null if the header is missing/unparseable.
- */
-function computePrimaryResetWaitMs(headers, nowMs = Date.now()) {
-  const h = lowerHeaders(headers);
-  const reset = h['x-ratelimit-reset'];
-  if (reset === undefined || reset === null || reset === '') return null;
-  const resetSeconds = Number(reset);
-  if (!Number.isFinite(resetSeconds)) return null;
-  const resetMs = resetSeconds * 1000;
-  const waitMs = resetMs - nowMs;
-  // Add a small 1s cushion so we don't hit the API right on the boundary,
-  // but never return a negative value.
-  if (waitMs <= 0) return 0;
-  return waitMs + 1000;
-}
+// Phrases Octopus uses when it is out of monthly AI quota. Matching is
+// case-insensitive; keep these lowercase.
+const QUOTA_DEATH_PATTERNS = [
+  "add your own api keys",
+  "out of monthly ai quota",
+  "monthly ai usage limit",
+  "usage limit reached",
+  "usage limit has been reached",
+  "quota exceeded",
+  "out of quota",
+];
 
 /**
- * Compute the sleep duration for a secondary rate-limit retry. Honors
- * server-provided `Retry-After` in full (bounded only by the in-process
- * wait ceiling). Falls back to exponential backoff otherwise.
+ * Returns true when a comment body looks like the Octopus quota-death banner
+ * ("add your own API keys" and friends) rather than a real review.
  */
-function computeRetryDelayMs(headers, attempt, baseDelayMs = RATE_LIMIT_BASE_DELAY_MS) {
-  const h = lowerHeaders(headers);
-  const retryAfter = h['retry-after'];
-  if (retryAfter !== undefined && retryAfter !== null && retryAfter !== '') {
-    const retryAfterSeconds = Number(retryAfter);
-    if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
-      // Honor Retry-After IN FULL. Only bound by the in-process ceiling so a
-      // pathological upstream value can't burn the whole job.
-      return Math.min(retryAfterSeconds * 1000, RATE_LIMIT_MAX_INPROCESS_WAIT_MS);
-    }
-    // Retry-After can also be an HTTP date.
-    const retryAfterDate = Date.parse(retryAfter);
-    if (Number.isFinite(retryAfterDate)) {
-      const deltaMs = retryAfterDate - Date.now();
-      if (deltaMs > 0) {
-        return Math.min(deltaMs, RATE_LIMIT_MAX_INPROCESS_WAIT_MS);
-      }
-      return 0;
-    }
-  }
-  const backoff = baseDelayMs * Math.pow(2, attempt);
-  return Math.min(backoff, RATE_LIMIT_MAX_INPROCESS_WAIT_MS);
+function isQuotaDeathComment(body) {
+  if (!body) return false;
+  const lower = String(body).toLowerCase();
+  return QUOTA_DEATH_PATTERNS.some((pattern) => lower.includes(pattern));
 }
 
-function isRateLimitedResponse(status, headers, body) {
-  return classifyRateLimit(status, headers, body) !== null;
-}
-
-function sleep(ms) {
-  if (ms <= 0) return Promise.resolve();
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function readResponseBody(response) {
-  try {
-    const text = await response.text();
-    try {
-      return { text, json: JSON.parse(text) };
-    } catch {
-      return { text, json: null };
 /**
- * Retrying wrapper around githubRequestOnce.
- *
- * - On rate-limit (429 or 403 w/ rate-limit body): waits per computeRetryDelayMs,
- *   retries up to maxRetries. After exhausting retries, throws.
- * - On any other non-2xx: throws immediately with an HTTP error containing
- *   the status and body preview — matches the pre-existing "never retry
-*    genuine errors" behavior.
- * - On 2xx: resolves with the response's parsed data.
+ * Loads the `review` routing profile (primary + fallback models) from
+ * .github/agent-models.yml so the fallback follows fleet model policy
+ * instead of hardcoding models.
  */
-async function githubRequest(method, pathAndQuery, opts = {}) {
-  const cfg = getRetryConfig();
-  const maxRetries = opts.maxRetries !== undefined ? opts.maxRetries : cfg.maxRetries;
-  const baseDelayMs = opts.baseDelayMs !== undefined ? opts.baseDelayMs : cfg.baseDelayMs;
-  const maxDelayMs = opts.maxDelayMs !== undefined ? opts.maxDelayMs : cfg.maxDelayMs;
-  const sleepFn = opts.sleepFn || sleep;
-
-  let attempt = 0;
-  // total attempts = 1 initial + maxRetries retries
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const res = await githubRequestOnce(method, pathAndQuery, opts);
-    const { status, headers, data, raw } = res;
-    if (status >= 200 && status < 300) {
-      return data;
-    }
-    if (isRateLimitedResponse(status, raw || data)) {
-      if (attempt >= maxRetries) {
-        const preview = typeof raw === 'string' ? raw : JSON.stringify(data);
-        const err = new Error(`GitHub HTTP ${status} for ${pathAndQuery} (rate-limited, exhausted ${maxRetries} retries): ${preview}`);
-        err.status = status;
-        err.rateLimited = true;
-        throw err;
-      }
-      const delay = computeRetryDelayMs(headers, attempt, baseDelayMs, maxDelayMs);
-      attempt += 1;
-      await sleepFn(delay);
-      continue;
-    }
-    const preview = typeof raw === 'string' ? raw : JSON.stringify(data);
-    const err = new Error(`GitHub HTTP ${status} for ${pathAndQuery}: ${preview}`);
-    err.status = status;
-    throw err;
+function loadReviewProfile(configPath) {
+  const resolved = configPath || path.join(__dirname, "../.github/agent-models.yml");
+  const YAML = require("yaml");
+  const config = YAML.parse(fs.readFileSync(resolved, "utf8"));
+  const review = config?.profiles?.review;
+  if (!review || !review.primary) {
+    throw new Error("No `review` profile with a primary model in agent-models.yml");
   }
+  return {
+    models: [review.primary, review.fallback].filter(Boolean),
+    max_tokens: review.max_tokens || 8000,
+    temperature: typeof review.temperature === "number" ? review.temperature : 0.2,
+  };
 }
 
-function commentIndicatesQuota(body) {
-  if (!body || typeof body !== 'string') return false;
-  const lower = body.toLowerCase();
-  return lower.includes('usage limit') || lower.includes('add your own api keys');
-}
-
-async function shouldReview({ owner, repo, prNumber, token }) {
-  const reviews = await githubRequest(
-    'GET',
-    `/repos/${owner}/${repo}/pulls/${prNumber}/reviews?per_page=100&page=1`,
-    { token }
-  );
-  if (!Array.isArray(reviews)) return true;
-  // Skip if we've already posted a fallback review.
-  return !reviews.some((r) => r && r.body && typeof r.body === 'string' && r.body.includes('<!-- octopus-fallback-review -->'));
-}
-
-async function postFallbackReview({ owner, repo, prNumber, token, body }) {
-  return githubRequest(
-    'POST',
-    `/repos/${owner}/${repo}/pulls/${prNumber}/reviews`,
-    { token, body: { body, event: 'COMMENT' } }
-  );
-}
-
-async function main() {
-  const token = process.env.GITHUB_TOKEN;
-  const repoSlug = process.env.GITHUB_REPOSITORY;
-  const prNumber = process.env.PR_NUMBER;
-  if (!token || !repoSlug || !prNumber) {
-    console.log('octopus-review-fallback: missing env (GITHUB_TOKEN/GITHUB_REPOSITORY/PR_NUMBER), skipping');
-    return;
+function splitRepository() {
+  const [owner, repo] = GITHUB_REPOSITORY.split("/");
+  if (!owner || !repo) {
+    throw new Error(`Invalid GITHUB_REPOSITORY format: ${GITHUB_REPOSITORY}`);
   }
-  const [owner, repo] = repoSlug.split('/');
-  const shouldPost = await shouldReview({ owner, repo, prNumber, token });
-  if (!shouldPost) {
-    console.log(`octopus-review-fallback: already posted on #${prNumber}, skipping`);
-    return;
-  }
-  const body = [
-    '<!-- octopus-fallback-review -->',
-    '🐙 **Octopus fallback review**',
-    '',
-    'The primary Octopus reviewer is currently unavailable (monthly usage limit reached).',
-    'This automated fallback acknowledges the PR; a human reviewer will follow up.',
-  ].join('\n');
-  await postFallbackReview({ owner, repo, prNumber, token, body });
-  console.log(`octopus-review-fallback: posted fallback review on #${prNumber}`);
+  return { owner, repo };
 }
 
-if (require.main === module) {
-  main().catch((err) => {
-    // Intentionally do NOT rethrow: a fallback-review outage must not go red.
-    // Rate-limit exhaustion is now surfaced in the log with a clear marker.
-    console.error('octopus-review-fallback failed:', err && err.message ? err.message : err);
+/**
+ * Single GitHub REST attempt — no retry logic. Resolves with
+ * { status, headers, data } so the retry wrapper (githubRequest) can decide
+ * whether to retry, independent of parsing/success handling.
+ */
+function githubRequestOnce({ pathName, method = "GET", payload, accept }) {
+  return new Promise((resolve, reject) => {
+    const body = payload ? JSON.stringify(payload) : "";
+    const req = https.request(
+      {
+        hostname: "api.github.com",
+        path: pathName,
+        method,
+        headers: {
+          Authorization: "Bearer " + GITHUB_TOKEN,
+          "User-Agent": "revvel-octopus-review-fallback",
+          Accept: accept || "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => { data += chunk; });
+        res.on("end", () => {
+          resolve({ status: res.statusCode || 0, headers: res.headers || {}, data });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (body) req.write(body);
+    req.end();
   });
 }
 
-  } catch {
-    return { text: '', json: null };
+/**
+ * Minimal GitHub REST helper (same shape as scripts/pr-auto-review.js).
+ * `accept` overrides the media type so we can fetch raw diffs too.
+ *
+ * Retries rate-limit responses, but PRIMARY (installation budget exhausted)
+ * and SECONDARY (abuse-detection) limits are handled differently — see the
+ * RATE_LIMIT_* doc comment above:
+ *
+ *   - PRIMARY with a usable x-ratelimit-reset: sleep the ACTUAL time until
+ *     reset (not an exponential guess), unless that exceeds
+ *     RATE_LIMIT_MAX_INPROCESS_WAIT_MS — in which case retrying in-process
+ *     cannot possibly succeed before the job's timeout-minutes: 15 kills it,
+ *     so this gives up immediately instead of burning retries that can't
+ *     work. The caller's top-level try/catch (see main()) still turns that
+ *     into a logged warning rather than a red job — same "never fail loud"
+ *     philosophy as before, just an honest one. The 6-hourly `schedule`
+ *     sweep lane in octopus-review-fallback.yml will pick the PR back up
+ *     once the budget resets, PROVIDED shouldReview() doesn't already see a
+ *     fallback marker or healthy Octopus review for it (it won't, since
+ *     this run never got far enough to post one) — flagging as a possible
+ *     follow-up only if that assumption ever needs re-checking, not solving
+ *     it here.
+ *   - SECONDARY (or primary with no reset header to go on): short backoff,
+ *     honoring a server Retry-After when present — this is the case the
+ *     original short-backoff retry was actually designed for.
+ */
+async function githubRequest({ pathName, method = "GET", payload, accept }) {
+  let lastResult;
+  for (let attempt = 1; attempt <= RATE_LIMIT_MAX_RETRIES + 1; attempt++) {
+    lastResult = await githubRequestOnce({ pathName, method, payload, accept });
+    const { status, headers, data } = lastResult;
+
+    if (status >= 200 && status < 300) {
+      if (accept && !accept.includes("json")) return data;
+      try {
+        return data ? JSON.parse(data) : {};
+      } catch (err) {
+        throw new Error(`Failed to parse GitHub response: ${err.message}`);
+      }
+    }
+
+    if (isRateLimitedResponse(status, data)) {
+      const kind = classifyRateLimit(status, headers, data);
+
+      if (kind === "primary") {
+        const waitMs = computePrimaryResetWaitMs(headers);
+        if (waitMs != null) {
+          if (waitMs > RATE_LIMIT_MAX_INPROCESS_WAIT_MS) {
+            console.warn(
+              `GitHub HTTP ${status} (primary rate limit — installation budget exhausted) ` +
+                `for ${pathName}: budget resets in ${Math.ceil(waitMs / 1000)}s, longer than ` +
+                `this job can wait for (cap ${RATE_LIMIT_MAX_INPROCESS_WAIT_MS / 1000}s, given ` +
+                "timeout-minutes: 15). Not retrying in-process — the 6-hourly schedule sweep " +
+                "in octopus-review-fallback.yml will pick this PR back up once the budget " +
+                "resets.",
+            );
+            throw new Error(
+              `GitHub HTTP ${status} for ${pathName}: primary rate limit, reset too far out ` +
+                `to wait for (${Math.ceil(waitMs / 1000)}s) — ${data.slice(0, 200)}`,
+            );
+          }
+          if (attempt <= RATE_LIMIT_MAX_RETRIES) {
+            console.warn(
+              `GitHub HTTP ${status} (primary rate limit) for ${pathName} — waiting ` +
+                `${Math.ceil(waitMs / 1000)}s for x-ratelimit-reset (attempt ${attempt}/${RATE_LIMIT_MAX_RETRIES})`,
+            );
+            await sleep(waitMs);
+            continue;
+          }
+          // Retries exhausted even though the reset was within bounds — fall
+          // through to the final throw below.
+        }
+        // waitMs == null: no x-ratelimit-reset to go on despite the
+        // "primary" classification (e.g. text-matched with no headers) —
+        // fall through to the generic short-backoff path below rather than
+        // guessing a wait time we have no basis for.
+      }
+
+      if (attempt <= RATE_LIMIT_MAX_RETRIES) {
+        const delayMs = computeRetryDelayMs(headers, attempt);
+        console.warn(
+          `GitHub HTTP ${status} (${kind || "rate limited"}) for ${pathName} — retry ` +
+            `${attempt}/${RATE_LIMIT_MAX_RETRIES} in ${delayMs}ms`,
+        );
+        await sleep(delayMs);
+        continue;
+      }
+    }
+
+    throw new Error(`GitHub HTTP ${status} for ${pathName}: ${data.slice(0, 400)}`);
   }
+  // Unreachable in practice (the loop always returns or throws), but keeps
+  // the function's control flow explicit for lint/readability.
+  const { status, data } = lastResult;
+  throw new Error(`GitHub HTTP ${status} for ${pathName}: ${data.slice(0, 400)}`);
+}
+
+async function listAll(pathBase) {
+  const results = [];
+  for (let page = 1; page <= 10; page++) {
+    const sep = pathBase.includes("?") ? "&" : "?";
+    const batch = await githubRequest({ pathName: `${pathBase}${sep}per_page=100&page=${page}` });
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    results.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return results;
 }
 
 /**
- * Fetch wrapper that understands GitHub's two rate-limit modes.
+ * Decides whether the fallback should review a PR. Returns
+ * { review: boolean, reason: string }.
+ *
+ * - Skip if this fallback already posted (FALLBACK_MARKER found) — dedupe.
+ * - Skip if Octopus posted a HEALTHY review (a real review, or any comment
+ *   that is not the quota banner) — no double-review when Octopus works.
  */
-async function githubRequest(url, init = {}, options = {}) {
-  const {
-    fetchImpl = globalThis.fetch,
-    sleepImpl = sleep,
-    nowImpl = () => Date.now(),
-    logger = console,
-    maxRetries = RATE_LIMIT_MAX_RETRIES,
-    baseDelayMs = RATE_LIMIT_BASE_DELAY_MS,
-    maxInProcessWaitMs = RATE_LIMIT_MAX_INPROCESS_WAIT_MS,
-  } = options;
+async function shouldReview(prNumber) {
+  const { owner, repo } = splitRepository();
+  const reviews = await listAll(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`);
+  const comments = await listAll(`/repos/${owner}/${repo}/issues/${prNumber}/comments`);
 
-  if (typeof fetchImpl !== 'function') {
-    throw new Error('githubRequest: no fetch implementation available');
+  const allBodies = [...reviews, ...comments];
+  if (allBodies.some((item) => (item.body || "").includes(FALLBACK_MARKER))) {
+    return { review: false, reason: "fallback review already posted" };
   }
 
-  let attempt = 0;
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const response = await fetchImpl(url, init);
-    if (response.ok) return response;
-
-    const { text, json } = await readResponseBody(response);
-    const kind = classifyRateLimit(response.status, response.headers, json || text);
-
-    if (!kind) {
-      const err = new Error(
-        `githubRequest: ${init.method || 'GET'} ${url} failed with ${response.status}: ${text.slice(0, 200)}`,
-      );
-      err.status = response.status;
-      err.body = text;
-      throw err;
-    }
-
-    if (kind === 'primary') {
-      const waitMs = computePrimaryResetWaitMs(response.headers, nowImpl());
-      if (waitMs !== null) {
-        if (waitMs > maxInProcessWaitMs) {
-          const err = new Error(
-            `githubRequest: primary rate limit exhausted; reset in ${Math.round(
-              waitMs / 1000,
-            )}s exceeds in-process wait ceiling (${Math.round(
-              maxInProcessWaitMs / 1000,
-            )}s). Deferring to the next scheduled sweep.`,
-          );
-          err.status = response.status;
-          err.rateLimit = 'primary';
-          err.resetWaitMs = waitMs;
-          logger.warn?.(err.message);
-          throw err;
-        }
-        logger.warn?.(
-          `githubRequest: primary rate limit hit; sleeping ${Math.round(
-            waitMs / 1000,
-          )}s until x-ratelimit-reset`,
-        );
-        await sleepImpl(waitMs);
-        // After a primary reset wait, retry once — do not consume the backoff
-        // budget for a condition that has now genuinely cleared.
-        continue;
-      }
-      // Primary-looking response with no usable reset header: fall through to
-      // short-backoff retry.
-    }
-
-    if (attempt >= maxRetries) {
-      const err = new Error(
-        `githubRequest: ${kind} rate limit exceeded after ${attempt} retries at ${url}`,
-      );
-      err.status = response.status;
-      err.rateLimit = kind;
-      throw err;
-    }
-
-    const delayMs = computeRetryDelayMs(response.headers, attempt, baseDelayMs);
-    logger.warn?.(
-      `githubRequest: ${kind} rate limit; retry ${attempt + 1}/${maxRetries} in ${Math.round(
-        delayMs / 1000,
-      )}s`,
-    );
-    await sleepImpl(delayMs);
-    attempt += 1;
+  const octopusReviews = reviews.filter((r) => r.user?.login === OCTOPUS_BOT_LOGIN);
+  const octopusComments = comments.filter((c) => c.user?.login === OCTOPUS_BOT_LOGIN);
+  const healthyReview =
+    octopusReviews.some((r) => !isQuotaDeathComment(r.body)) ||
+    octopusComments.some((c) => !isQuotaDeathComment(c.body));
+  if (healthyReview) {
+    return { review: false, reason: "Octopus posted a healthy review — no double-review" };
   }
+
+  const quotaDead =
+    octopusReviews.some((r) => isQuotaDeathComment(r.body)) ||
+    octopusComments.some((c) => isQuotaDeathComment(c.body));
+  if (quotaDead) {
+    return { review: true, reason: "Octopus reported quota-death" };
+  }
+
+  // No Octopus activity at all — the "absence after N minutes" lane
+  // (workflow only invokes this path once the PR is old enough).
+  return { review: true, reason: "no Octopus review found (absence lane)" };
 }
 
-async function shouldReview(_pr) {
-  // Placeholder: real implementation checks for an existing fallback marker
-  // comment on the PR and returns false if one is already present. The
-  // marker is only written AFTER a review is successfully posted, so a run
-  // that bails out on a primary rate limit leaves no marker behind and the
-  // 6-hourly cron sweep (cron: "17 */6 * * *") will retry it next cycle.
+async function getPRDiff(prNumber) {
+  const { owner, repo } = splitRepository();
+  const diff = await githubRequest({
+    pathName: `/repos/${owner}/${repo}/pulls/${prNumber}`,
+    accept: "application/vnd.github.diff",
+  });
+  return String(diff).slice(0, MAX_DIFF_CHARS);
+}
+
+async function postReview(prNumber, body) {
+  const { owner, repo } = splitRepository();
+  return await githubRequest({
+    pathName: `/repos/${owner}/${repo}/pulls/${prNumber}/reviews`,
+    method: "POST",
+    payload: { body, event: "COMMENT" },
+  });
+}
+
+async function reviewPR(prNumber) {
+  const decision = await shouldReview(prNumber);
+  console.log(`PR #${prNumber}: ${decision.reason}`);
+  if (!decision.review) return false;
+
+  const profile = loadReviewProfile();
+  console.log(`Review profile models (fallback order): ${profile.models.join(" → ")}`);
+
+  const pr = await githubRequest({
+    pathName: `/repos/${splitRepository().owner}/${splitRepository().repo}/pulls/${prNumber}`,
+  });
+  const diff = await getPRDiff(prNumber);
+  if (!diff.trim()) {
+    console.log(`PR #${prNumber}: empty diff, nothing to review`);
+    return false;
+  }
+
+  const result = await callOpenRouter({
+    models: profile.models,
+    max_tokens: profile.max_tokens,
+    temperature: profile.temperature,
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are the fleet's FALLBACK code reviewer, stepping in because Octopus Review " +
+          "(the primary external AI reviewer) is out of monthly quota. Review the PR diff " +
+          "for bugs, security issues, logic errors, and correctness regressions. Be concise " +
+          "and concrete: list findings with file/line references and severity " +
+          "(critical/major/minor). If the change looks clean, say so plainly.",
+      },
+      {
+        role: "user",
+        content:
+          `PR #${prNumber}: ${pr.title || ""}\n\n` +
+          `Description:\n${(pr.body || "(none)").slice(0, 2000)}\n\n` +
+          `Diff:\n\`\`\`diff\n${diff}\n\`\`\``,
+      },
+    ],
+  });
+
+  const reviewBody = [
+    FALLBACK_MARKER,
+    "## 🐙➡️🤖 Fleet Review Fallback (Octopus quota-dead)",
+    "",
+    `Octopus Review couldn't review this PR (${decision.reason}), so the fleet's own ` +
+      "`review` profile stepped in via OpenRouter.",
+    "",
+    result.text,
+    "",
+    "---",
+    `_Model used: \`${result.modelUsed || profile.models[0]}\` · profile: \`review\` ` +
+      "(.github/agent-models.yml) · lane: `octopus-review-fallback.yml` · " +
+      "playbook: `skills/octopus-expert/SKILL.md`_",
+  ].join("\n");
+
+  await postReview(prNumber, reviewBody);
+  console.log(`PR #${prNumber}: fallback review posted (model: ${result.modelUsed || "?"})`);
   return true;
 }
 
-async function main() {
-  try {
-    // Real implementation elided for this patch — the important behavior
-    // change is in githubRequest() / classifyRateLimit() /
-    // computePrimaryResetWaitMs() / computeRetryDelayMs().
-  } catch (err) {
-    // Preserve prior "never fail loud" philosophy: log and exit 0 so the
-    // scheduled workflow reports success and the next sweep retries.
-    console.warn(`octopus-review-fallback: ${err.message}`);
+/**
+ * Sweep mode ("absence after N minutes"): scan recently-updated open PRs that
+ * are older than MIN_PR_AGE_MINUTES and have no Octopus review at all, and
+ * review up to MAX_SWEEP_REVIEWS of them. Conservative on purpose — this lane
+ * spends OpenRouter credits.
+ */
+async function sweep() {
+  const { owner, repo } = splitRepository();
+  const minAgeMinutes = parseInt(process.env.MIN_PR_AGE_MINUTES || "30", 10);
+  const maxReviews = parseInt(process.env.MAX_SWEEP_REVIEWS || "3", 10);
+  const prs = await listAll(`/repos/${owner}/${repo}/pulls?state=open&sort=updated&direction=desc`);
+
+  let reviewed = 0;
+  for (const pr of prs) {
+    if (reviewed >= maxReviews) break;
+    if (pr.draft) continue;
+    const ageMinutes = (Date.now() - new Date(pr.created_at).getTime()) / 60000;
+    if (ageMinutes < minAgeMinutes) continue;
+    try {
+      if (await reviewPR(pr.number)) reviewed++;
+    } catch (err) {
+      console.error(`PR #${pr.number}: sweep review failed: ${err.message}`);
+    }
   }
+  console.log(`Sweep complete: ${reviewed} fallback review(s) posted.`);
 }
 
-module.exports = {
-  isRateLimitedResponse,
-  computeRetryDelayMs,
-  isRateLimitedResponse,
-  githubRequest,
-  githubRequestOnce,
-  commentIndicatesQuota,
-  shouldReview,
-  postFallbackReview,
-  shouldReview,
-  RATE_LIMIT_BASE_DELAY_MS,
-  RATE_LIMIT_MAX_RETRIES,
-  RATE_LIMIT_MAX_DELAY_MS,
-  RATE_LIMIT_MAX_INPROCESS_WAIT_MS,
-};
+async function main() {
+  if (!GITHUB_TOKEN) {
+    console.error("GITHUB_TOKEN is required");
+    return;
+  }
+  if (!process.env.OPENROUTER_API_KEY) {
+    // Never hard-fail: a missing/unfunded key is an ops problem, not a bug.
+    console.error(
+      "OPENROUTER_API_KEY is not set — fallback review skipped. " +
+        "Check the key AND balance at https://openrouter.ai/credits.",
+    );
+    return;
+  }
+
+  try {
+    if (process.env.SWEEP === "true") {
+      await sweep();
+    } else if (PR_NUMBER) {
+      await reviewPR(parseInt(PR_NUMBER, 10));
+    } else {
+      console.error("Set PR_NUMBER for single-PR mode or SWEEP=true for sweep mode.");
+    }
+  } catch (err) {
+    // Best-effort by design: a fallback-review outage must not go red itself.
+    console.error(`octopus-review-fallback failed: ${err.message}`);
+  }
+}
 
 if (require.main === module) {
   main();
 }
+
+module.exports = {
+  isQuotaDeathComment,
+  loadReviewProfile,
+  shouldReview,
+  FALLBACK_MARKER,
+  OCTOPUS_BOT_LOGIN,
+  QUOTA_DEATH_PATTERNS,
+  isRateLimitedResponse,
+  classifyRateLimit,
+  computePrimaryResetWaitMs,
+  computeRetryDelayMs,
+  githubRequest,
+  githubRequestOnce,
+  RATE_LIMIT_MAX_RETRIES,
+  RATE_LIMIT_BASE_DELAY_MS,
+  RATE_LIMIT_MAX_DELAY_MS,
+  RATE_LIMIT_MAX_INPROCESS_WAIT_MS,
+};

--- a/tests/auto-resolve-mechanical-conflicts.test.js
+++ b/tests/auto-resolve-mechanical-conflicts.test.js
@@ -1,188 +1,340 @@
-'use strict';
+#!/usr/bin/env node
+"use strict";
 
-const test = require('node:test');
-const assert = require('node:assert');
-const { spawnSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+/**
+ * Unit tests for scripts/auto-resolve-mechanical-conflicts.js
+ * Tests conflict resolution logic for mechanical merge conflicts
+ */
 
-const SCRIPT = path.resolve(
-  __dirname,
-  '..',
-  'scripts',
-  'auto-resolve-mechanical-conflicts.js',
-);
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execSync } = require("child_process");
+const {
+  pickNewerRef,
+  tryVersionBump,
+  tryAdditive,
+} = require("../scripts/auto-resolve-mechanical-conflicts.js");
 
-function sh(cwd, cmd, args, opts = {}) {
-  const r = spawnSync(cmd, args, {
-    cwd,
-    encoding: 'utf8',
-    ...opts,
-  });
-  return r;
+const SCRIPT_PATH = path.join(__dirname, "..", "scripts", "auto-resolve-mechanical-conflicts.js");
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`PASS: ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`FAIL: ${name}\n    ${e.stack || e.message}`);
+    failed++;
+  }
 }
 
-function git(cwd, args, opts = {}) {
-  return sh(cwd, 'git', args, {
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: 'Test',
-      GIT_AUTHOR_EMAIL: 'test@example.com',
-      GIT_COMMITTER_NAME: 'Test',
-      GIT_COMMITTER_EMAIL: 'test@example.com',
-    },
-    ...opts,
-  });
-}
+console.log("Running auto-resolve-mechanical-conflicts.js tests...\n");
 
-function mkRepo() {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'armc-'));
-  git(dir, ['init', '-q', '-b', 'main']);
-  git(dir, ['config', 'commit.gpgsign', 'false']);
-  git(dir, ['config', 'user.email', 'test@example.com']);
-  git(dir, ['config', 'user.name', 'Test']);
-  return dir;
-}
+// ─── pickNewerRef tests ────────────────────────────────────────────────────
 
-test('main() exit code (false-success regression)', async (t) => {
-  await t.test(
-    'binary UU conflict with zero textual hunks exits 2, not 0',
-    () => {
-      const dir = mkRepo();
+console.log("Test Group: pickNewerRef (version comparison)");
 
-      // Seed a binary file on main.
-      const bin0 = Buffer.from([0, 1, 2, 3, 4, 5, 6, 7, 0, 8, 9]);
-      fs.writeFileSync(path.join(dir, 'bin.dat'), bin0);
-      // .gitattributes ensures git treats it as binary (no textual markers).
-      fs.writeFileSync(path.join(dir, '.gitattributes'), 'bin.dat binary\n');
-      git(dir, ['add', '.']);
-      git(dir, ['commit', '-q', '-m', 'seed']);
-
-      // Branch A modifies binary.
-      git(dir, ['checkout', '-q', '-b', 'branchA']);
-      fs.writeFileSync(
-        path.join(dir, 'bin.dat'),
-        Buffer.from([0, 1, 2, 0xaa, 0xaa, 0xaa, 6, 7, 0, 8, 9]),
-      );
-      git(dir, ['commit', '-q', '-am', 'A change']);
-
-      // Branch B modifies binary differently.
-      git(dir, ['checkout', '-q', 'main']);
-      git(dir, ['checkout', '-q', '-b', 'branchB']);
-      fs.writeFileSync(
-        path.join(dir, 'bin.dat'),
-        Buffer.from([0, 1, 2, 0xbb, 0xbb, 0xbb, 6, 7, 0, 8, 9]),
-      );
-      git(dir, ['commit', '-q', '-am', 'B change']);
-
-      // Merge A into B -> conflicted binary (UU) with no textual markers.
-      const mergeRes = git(dir, ['merge', '--no-commit', '--no-ff', 'branchA']);
-      // git returns non-zero on conflict; we just want the working tree state.
-      assert.notStrictEqual(mergeRes.status, 0, 'merge should conflict');
-
-      const status = git(dir, ['diff', '--name-only', '--diff-filter=U']);
-      assert.ok(
-        status.stdout.split('\n').includes('bin.dat'),
-        `expected bin.dat to be UU, got: ${status.stdout}`,
-      );
-
-      // Confirm there are no textual conflict markers in the file.
-      const buf = fs.readFileSync(path.join(dir, 'bin.dat'));
-      assert.ok(
-        !buf.includes(Buffer.from('<<<<<<<')),
-        'binary conflict should not contain textual markers',
-      );
-
-      const run = sh(dir, process.execPath, [SCRIPT]);
-      assert.strictEqual(
-        run.status,
-        2,
-        `expected exit 2 for unresolved binary conflict, got ${run.status}\nstdout:\n${run.stdout}\nstderr:\n${run.stderr}`,
-      );
-      assert.match(
-        run.stdout,
-        /(MANUAL|SKIP)\s+bin\.dat/,
-        `expected bin.dat reported as MANUAL/SKIP, got:\n${run.stdout}`,
-      );
-    },
-  );
-
-  await t.test(
-    'fully mechanically-resolvable conflict still exits 0',
-    () => {
-      const dir = mkRepo();
-
-      const wfPath = path.join(dir, '.github', 'workflows');
-      fs.mkdirSync(wfPath, { recursive: true });
-      const wf = path.join(wfPath, 'ci.yml');
-
-      fs.writeFileSync(
-        wf,
-        [
-          'name: ci',
-          'on: [push]',
-          'jobs:',
-          '  build:',
-          '    runs-on: ubuntu-latest',
-          '    steps:',
-          '      - uses: actions/checkout@v3',
-          '',
-        ].join('\n'),
-      );
-      git(dir, ['add', '.']);
-      git(dir, ['commit', '-q', '-m', 'seed']);
-
-      git(dir, ['checkout', '-q', '-b', 'bumpA']);
-      fs.writeFileSync(
-        wf,
-        [
-          'name: ci',
-          'on: [push]',
-          'jobs:',
-          '  build:',
-          '    runs-on: ubuntu-latest',
-          '    steps:',
-          '      - uses: actions/checkout@v4',
-          '',
-        ].join('\n'),
-      );
-      git(dir, ['commit', '-q', '-am', 'bump to v4']);
-
-      git(dir, ['checkout', '-q', 'main']);
-      git(dir, ['checkout', '-q', '-b', 'bumpB']);
-      fs.writeFileSync(
-        wf,
-        [
-          'name: ci',
-          'on: [push]',
-          'jobs:',
-          '  build:',
-          '    runs-on: ubuntu-latest',
-          '    steps:',
-          '      - uses: actions/checkout@v3.5',
-          '',
-        ].join('\n'),
-      );
-      git(dir, ['commit', '-q', '-am', 'bump to v3.5']);
-
-      const mergeRes = git(dir, ['merge', '--no-commit', '--no-ff', 'bumpA']);
-      assert.notStrictEqual(mergeRes.status, 0, 'merge should conflict');
-
-      const run = sh(dir, process.execPath, [SCRIPT]);
-      assert.strictEqual(
-        run.status,
-        0,
-        `expected exit 0 for fully mechanical resolve, got ${run.status}\nstdout:\n${run.stdout}\nstderr:\n${run.stderr}`,
-      );
-      assert.match(
-        run.stdout,
-        /RESOLVED\s+\.github\/workflows\/ci\.yml/,
-        `expected ci.yml reported RESOLVED, got:\n${run.stdout}`,
-      );
-
-      // And the ambiguous count is 0 in summary.
-      assert.match(run.stdout, /0 ambiguous/);
-    },
-  );
+test("pickNewerRef returns a when equal", () => {
+  assert.strictEqual(pickNewerRef("v1.0.0", "v1.0.0"), "v1.0.0");
 });
+
+test("pickNewerRef picks higher major version", () => {
+  assert.strictEqual(pickNewerRef("v1.0.0", "v2.0.0"), "v2.0.0");
+  assert.strictEqual(pickNewerRef("v2.0.0", "v1.0.0"), "v2.0.0");
+});
+
+test("pickNewerRef picks higher minor version", () => {
+  assert.strictEqual(pickNewerRef("v1.2.0", "v1.3.0"), "v1.3.0");
+  assert.strictEqual(pickNewerRef("v1.3.0", "v1.2.0"), "v1.3.0");
+});
+
+test("pickNewerRef picks higher patch version", () => {
+  assert.strictEqual(pickNewerRef("v1.0.1", "v1.0.2"), "v1.0.2");
+  assert.strictEqual(pickNewerRef("v1.0.2", "v1.0.1"), "v1.0.2");
+});
+
+test("pickNewerRef handles missing v prefix", () => {
+  assert.strictEqual(pickNewerRef("1.0.0", "2.0.0"), "2.0.0");
+});
+
+test("pickNewerRef handles partial semver (no patch)", () => {
+  assert.strictEqual(pickNewerRef("v1.0", "v1.1"), "v1.1");
+});
+
+test("pickNewerRef handles 40-char SHA as newest", () => {
+  const shaA = "a".repeat(40);
+  const shaB = "b".repeat(40);
+  // SHA wins over tag
+  assert.strictEqual(pickNewerRef(shaA, "v1.0.0"), shaA);
+  assert.strictEqual(pickNewerRef("v1.0.0", shaA), shaA);
+  // Both SHAs -> null (undecidable)
+  assert.strictEqual(pickNewerRef(shaA, shaB), null);
+});
+
+test("pickNewerRef returns null for non-comparable strings", () => {
+  assert.strictEqual(pickNewerRef("main", "develop"), null);
+  assert.strictEqual(pickNewerRef("abc", "def"), null);
+});
+
+test("pickNewerRef handles longer SHA prefix", () => {
+  const shaShort = "abc123";
+  const shaLong = "abc123def456789";
+  // Neither is full 40-char, so they're compared as strings
+  // But 40-char SHAs should return null when compared with each other
+  assert.strictEqual(pickNewerRef(shaShort, shaLong), null);
+});
+
+// ─── tryVersionBump tests ──────────────────────────────────────────────────
+
+console.log("\nTest Group: tryVersionBump (GitHub Actions version bump)");
+
+test("tryVersionBump resolves single-line version bump", () => {
+  const current = "    uses: actions/checkout@v4";
+  const incoming = "    uses: actions/checkout@v5";
+  const result = tryVersionBump(current, incoming);
+  assert.strictEqual(result, "    uses: actions/checkout@v5\n");
+});
+
+test("tryVersionBump returns null for multi-line blocks", () => {
+  const current = "    uses: actions/checkout@v4\n    timeout-minutes: 30";
+  const incoming = "    uses: actions/checkout@v5";
+  const result = tryVersionBump(current, incoming);
+  assert.strictEqual(result, null);
+});
+
+test("tryVersionBump returns null for different actions", () => {
+  const current = "    uses: actions/checkout@v4";
+  const incoming = "    uses: actions/setup-node@v5";
+  const result = tryVersionBump(current, incoming);
+  assert.strictEqual(result, null);
+});
+
+test("tryVersionBump returns null for non-uses lines", () => {
+  const current = "    run: npm test";
+  const incoming = "    run: npm run build";
+  const result = tryVersionBump(current, incoming);
+  assert.strictEqual(result, null);
+});
+
+test("tryVersionBump keeps newer SHA when both are SHAs (returns null)", () => {
+  const sha1 = "    uses: owner/repo@abc123def4567890123456789012345678";
+  const sha2 = "    uses: owner/repo@xyz789abc1234567890123456789012345";
+  const result = tryVersionBump(sha1, sha2);
+  // SHA vs SHA is undecidable
+  assert.strictEqual(result, null);
+});
+
+test("tryVersionBump handles whitespace variations", () => {
+  const current = "  - uses: actions/checkout@v4";
+  const incoming = "  - uses: actions/checkout@v5";
+  const result = tryVersionBump(current, incoming);
+  assert.ok(result !== null, "Should handle different indentation");
+});
+
+test("tryVersionBump picks higher semver", () => {
+  const current = "    uses: owner/repo@v1.2.3";
+  const incoming = "    uses: owner/repo@v2.0.0";
+  const result = tryVersionBump(current, incoming);
+  assert.ok(result.includes("v2.0.0"), "Should pick v2.0.0");
+});
+
+test("tryVersionBump handles refs without v prefix", () => {
+  const current = "    uses: owner/repo@1.0.0";
+  const incoming = "    uses: owner/repo@2.0.0";
+  const result = tryVersionBump(current, incoming);
+  assert.ok(result.includes("2.0.0"), "Should pick 2.0.0");
+});
+
+// ─── tryAdditive tests ────────────────────────────────────────────────────
+
+console.log("\nTest Group: tryAdditive (additive line resolution)");
+
+test("tryAdditive resolves markdown table rows (data only)", () => {
+  // Note: When both sides have identical headers/separators, they overlap
+  // and the function returns null (current behavior). This tests data-only rows.
+  const current = "| a    | b    |\n| c    | d    |";
+  const incoming = "| e    | f    |\n| g    | h    |";
+  const result = tryAdditive(current, incoming);
+  assert.ok(result !== null, "Should resolve additive table data rows");
+  assert.ok(result.includes("| a    | b    |"), "Should include current");
+  assert.ok(result.includes("| g    | h    |"), "Should include incoming");
+});
+
+test("tryAdditive resolves markdown list items", () => {
+  const current = "- Item 1\n- Item 2";
+  const incoming = "- Item 3\n- Item 4";
+  const result = tryAdditive(current, incoming);
+  assert.ok(result !== null, "Should resolve additive list items");
+});
+
+test("tryAdditive returns null when blocks are empty", () => {
+  assert.strictEqual(tryAdditive("", ""), null);
+  assert.strictEqual(tryAdditive("  ", "  "), null);
+});
+
+test("tryAdditive returns null for non-additive content", () => {
+  const current = "foo = \"a\"";
+  const incoming = "foo = \"b\"";
+  const result = tryAdditive(current, incoming);
+  assert.strictEqual(result, null, "Value swaps are not additive");
+});
+
+test("tryAdditive returns null when lines overlap", () => {
+  const current = "- Item 1\n- Item 2";
+  const incoming = "- Item 2\n- Item 3";
+  const result = tryAdditive(current, incoming);
+  assert.strictEqual(result, null, "Duplicate lines should not auto-resolve");
+});
+
+test("tryAdditive handles numbered lists", () => {
+  const current = "1. First item\n2. Second item";
+  const incoming = "3. Third item";
+  const result = tryAdditive(current, incoming);
+  assert.ok(result !== null, "Should handle numbered list items");
+});
+
+test("tryAdditive returns null when table headers/separators overlap", () => {
+  // When table headers or separators are identical, they overlap and block auto-resolve
+  const current = "|---|---|\n| a | b |";
+  const incoming = "|---|---|\n| c | d |";
+  const result = tryAdditive(current, incoming);
+  // Headers/separators overlap, so this returns null (correct behavior)
+  assert.strictEqual(result, null, "Identical headers/separators should block auto-resolve");
+});
+
+test("tryAdditive resolves pure data rows without headers", () => {
+  // Tables without header/separator overlap can be resolved
+  const current = "| a | b |\n| c | d |";
+  const incoming = "| e | f |\n| g | h |";
+  const result = tryAdditive(current, incoming);
+  assert.ok(result !== null, "Pure data rows without overlap should resolve");
+});
+
+test("tryAdditive returns null when only one side is additive", () => {
+  const current = "- List item";
+  const incoming = "foo = \"value\"";
+  const result = tryAdditive(current, incoming);
+  assert.strictEqual(result, null, "Mixed content is not purely additive");
+});
+
+test("tryAdditive preserves order (current first, incoming after)", () => {
+  const current = "* A\n* B";
+  const incoming = "* C\n* D";
+  const result = tryAdditive(current, incoming);
+  assert.ok(result !== null);
+  const aIndex = result.indexOf("A");
+  const cIndex = result.indexOf("C");
+  assert.ok(aIndex < cIndex, "Current should come before incoming");
+});
+
+// ─── main() exit code tests ────────────────────────────────────────────────
+//
+// Regression coverage for the false-success bug: a conflicted file with
+// zero recognized conflict-marker hunks (e.g. a binary "both modified"
+// conflict) must NOT let the process exit 0. exit_code == '0' is what
+// conflict-helper.yml treats as "safe to commit + push to the PR branch",
+// so a file that was never actually resolved must still produce a non-zero
+// exit code even though it contributes 0 to the ambiguous-hunk count.
+
+console.log("\nTest Group: main() exit code (false-success regression)");
+
+function withTempGitRepo(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "conflict-resolver-test-"));
+  try {
+    const git = (cmd) => execSync(`git ${cmd}`, { cwd: dir, stdio: "pipe" });
+    git('init -q -b main');
+    git('config user.email test@example.com');
+    git('config user.name test');
+    fn(dir, git);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("main() exits non-zero for a binary conflict with zero marker hunks", () => {
+  withTempGitRepo((dir, git) => {
+    const file = path.join(dir, "bin.dat");
+    // A binary file that both branches change differently: git marks it
+    // conflicted (UU) but does NOT insert <<<<<<< markers into it, since
+    // there is nothing textual to diff. This is exactly the "MANUAL ...
+    // 0 hunk(s) ambiguous" case the bug missed.
+    fs.writeFileSync(file, Buffer.from([0, 1, 65]));
+    git("add bin.dat");
+    git('commit -qm base');
+    git("checkout -q -b feature");
+    fs.writeFileSync(file, Buffer.from([0, 1, 66]));
+    git("add bin.dat");
+    git('commit -qm feature-change');
+    git("checkout -q main");
+    fs.writeFileSync(file, Buffer.from([0, 1, 67]));
+    git("add bin.dat");
+    git('commit -qm main-change');
+
+    let mergeFailed = false;
+    try {
+      git("merge --no-commit --no-ff feature");
+    } catch (e) {
+      mergeFailed = true; // expected: merge conflict
+    }
+    assert.ok(mergeFailed, "merge should conflict");
+
+    let exitCode = 0;
+    let output = "";
+    try {
+      output = execSync(`node "${SCRIPT_PATH}"`, { cwd: dir, encoding: "utf8" });
+    } catch (e) {
+      exitCode = e.status;
+      output = e.stdout || "";
+    }
+    assert.strictEqual(exitCode, 2, "unresolved binary conflict must not exit 0");
+    assert.ok(output.includes("MANUAL"), "should report the file as MANUAL");
+    assert.ok(output.includes("0 hunk(s) ambiguous"), "should show 0 ambiguous hunks");
+  });
+});
+
+test("main() exits 0 when every hunk is cleanly auto-resolved", () => {
+  withTempGitRepo((dir, git) => {
+    const file = path.join(dir, "workflow.yml");
+    fs.writeFileSync(file, "steps:\n  - uses: actions/checkout@v4\n");
+    git("add workflow.yml");
+    git('commit -qm base');
+    git("checkout -q -b feature");
+    fs.writeFileSync(file, "steps:\n  - uses: actions/checkout@v5\n");
+    git("add workflow.yml");
+    git('commit -qm feature-change');
+    git("checkout -q main");
+    fs.writeFileSync(file, "steps:\n  - uses: actions/checkout@v4\n  - run: echo hi\n");
+    git("add workflow.yml");
+    git('commit -qm main-change');
+
+    try {
+      git("merge --no-commit --no-ff feature");
+    } catch (e) {
+      // expected conflict
+    }
+
+    let exitCode = 0;
+    let output = "";
+    try {
+      output = execSync(`node "${SCRIPT_PATH}"`, { cwd: dir, encoding: "utf8" });
+    } catch (e) {
+      exitCode = e.status;
+      output = e.stdout || "";
+    }
+    assert.strictEqual(exitCode, 0, "fully resolved conflicts should exit 0");
+    assert.ok(output.includes("RESOLVED"), "should report the file as RESOLVED");
+  });
+});
+
+// ─── Summary ─────────────────────────────────────────────────────────────
+
+console.log("\n" + "=".repeat(60));
+console.log(`Test Summary: ${passed} passed, ${failed} failed`);
+console.log("=".repeat(60));
+
+if (failed > 0) process.exit(1);

--- a/tests/checkbox-diff.test.js
+++ b/tests/checkbox-diff.test.js
@@ -1,158 +1,185 @@
 'use strict';
 
-const assert = require('assert');
-const { findNewlyCheckedFollowUps } = require('../scripts/checkbox-diff');
+const test = require('node:test');
+const assert = require('node:assert');
 
-function run(name, fn) {
-  try {
-    fn();
-    console.log(`ok - ${name}`);
-  } catch (e) {
-    console.error(`not ok - ${name}`);
-    console.error(e && e.stack ? e.stack : e);
-    process.exitCode = 1;
-  }
-}
+const {
+  findNewlyCheckedFollowUps,
+  parseTaskItems,
+  normalizeKey,
+} = require('../scripts/checkbox-diff');
 
-run('single follow-up item checked', () => {
-  const oldBody = '- [ ] Follow-up: revisit caching layer';
-  const newBody = '- [x] Follow-up: revisit caching layer';
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 1);
-  assert.strictEqual(r[0].description, 'revisit caching layer');
+// ── findNewlyCheckedFollowUps ───────────────────────────────────────────────
+
+test('reports a single follow-up item checked in this edit', () => {
+  const oldBody = [
+    '## Summary',
+    '',
+    '- [ ] Follow-up: circle back on the flaky retry logic',
+  ].join('\n');
+  const newBody = [
+    '## Summary',
+    '',
+    '- [x] Follow-up: circle back on the flaky retry logic',
+  ].join('\n');
+
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, ['circle back on the flaky retry logic']);
 });
 
-run('multiple items checked in one edit', () => {
+test('reports multiple follow-up items checked in the same edit', () => {
   const oldBody = [
     '- [ ] Follow-up: item one',
     '- [ ] Follow-up: item two',
-    '- [ ] Follow-up: item three',
+    '- [ ] some unrelated task',
   ].join('\n');
   const newBody = [
     '- [x] Follow-up: item one',
-    '- [ ] Follow-up: item two',
-    '- [X] Follow-up: item three',
+    '- [x] Follow-up: item two',
+    '- [x] some unrelated task',
   ].join('\n');
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 2);
-  assert.deepStrictEqual(
-    r.map((x) => x.description).sort(),
-    ['item one', 'item three']
-  );
+
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, ['item one', 'item two']);
 });
 
-run('unrelated (non-follow-up) checkbox ignored', () => {
-  const oldBody = '- [ ] some random task';
-  const newBody = '- [x] some random task';
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 0);
+test('does not match a checked box whose text is not a follow-up item', () => {
+  const oldBody = '- [ ] Deploy to staging';
+  const newBody = '- [x] Deploy to staging';
+
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, []);
 });
 
-run('already-checked item not reported', () => {
-  const oldBody = '- [x] Follow-up: already done';
-  const newBody = '- [x] Follow-up: already done';
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 0);
-});
-
-run('null oldBody -> no results', () => {
-  const r = findNewlyCheckedFollowUps(null, '- [x] Follow-up: something');
-  assert.strictEqual(r.length, 0);
-});
-
-run('null newBody -> no results', () => {
-  const r = findNewlyCheckedFollowUps('- [ ] Follow-up: something', null);
-  assert.strictEqual(r.length, 0);
-});
-
-run('undefined bodies -> no results', () => {
-  const r = findNewlyCheckedFollowUps(undefined, undefined);
-  assert.strictEqual(r.length, 0);
-});
-
-run('added-and-checked in same edit is skipped', () => {
-  const oldBody = 'no checkboxes here';
-  const newBody = '- [x] Follow-up: brand new';
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 0);
-});
-
-run('reordered lines still detected', () => {
+test('does not re-report a follow-up that was already checked before this edit', () => {
   const oldBody = [
-    '- [ ] Follow-up: alpha',
-    'some text',
-    '- [ ] Follow-up: beta',
+    '- [x] Follow-up: already tracked, do not refire',
+    '- [ ] Follow-up: newly checked this time',
   ].join('\n');
   const newBody = [
-    '- [ ] Follow-up: beta',
-    'some text',
-    '- [x] Follow-up: alpha',
+    '- [x] Follow-up: already tracked, do not refire',
+    '- [x] Follow-up: newly checked this time',
   ].join('\n');
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 1);
-  assert.strictEqual(r[0].description, 'alpha');
+
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, ['newly checked this time']);
 });
 
-run('prefix casing variant: FOLLOW-UP', () => {
-  const oldBody = '- [ ] FOLLOW-UP: uppercase prefix';
-  const newBody = '- [x] FOLLOW-UP: uppercase prefix';
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 1);
-  assert.strictEqual(r[0].description, 'uppercase prefix');
+test('returns an empty array when oldBody is missing/null (e.g. issue just created)', () => {
+  const newBody = '- [x] Follow-up: brand new item checked on creation';
+  assert.deepStrictEqual(findNewlyCheckedFollowUps(null, newBody), []);
+  assert.deepStrictEqual(findNewlyCheckedFollowUps(undefined, newBody), []);
+  assert.deepStrictEqual(findNewlyCheckedFollowUps('', newBody), []);
 });
 
-run('prefix whitespace variant: "Follow - up:"', () => {
-  const oldBody = '- [ ] Follow - up : spaced prefix';
-  const newBody = '- [x] Follow - up : spaced prefix';
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 1);
-  assert.strictEqual(r[0].description, 'spaced prefix');
+test('returns an empty array when newBody is missing/null', () => {
+  const oldBody = '- [ ] Follow-up: something';
+  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, null), []);
+  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, undefined), []);
 });
 
-run('no description after Follow-up: still recognized as follow-up', () => {
-  const oldBody = '- [ ] Follow-up: ';
-  const newBody = '- [x] Follow-up: ';
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  // Empty description still counts as a transition; description is empty string.
-  assert.strictEqual(r.length, 1);
-  assert.strictEqual(r[0].description, '');
+test('returns an empty array when there are no task-list lines at all', () => {
+  const oldBody = 'Just a plain description with no checkboxes.';
+  const newBody = 'Just a plain description with no checkboxes, edited.';
+  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
 });
 
-run('checked -> unchecked transition not reported', () => {
-  const oldBody = '- [x] Follow-up: was done';
-  const newBody = '- [ ] Follow-up: was done';
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 0);
+test('ignores an item newly added and checked in the same edit (no prior unchecked state to transition from)', () => {
+  const oldBody = '- [ ] Follow-up: existing item';
+  const newBody = [
+    '- [ ] Follow-up: existing item',
+    '- [x] Follow-up: item that appeared already checked',
+  ].join('\n');
+
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, []);
 });
 
-run('star and plus list markers accepted', () => {
-  const oldBody = ['* [ ] Follow-up: star', '+ [ ] Follow-up: plus'].join('\n');
-  const newBody = ['* [x] Follow-up: star', '+ [x] Follow-up: plus'].join('\n');
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 2);
-});
-
-run('indented task line accepted', () => {
-  const oldBody = '  - [ ] Follow-up: indented';
-  const newBody = '  - [x] Follow-up: indented';
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 1);
-  assert.strictEqual(r[0].description, 'indented');
-});
-
-run('duplicate follow-up text only fires once', () => {
+test('matches follow-up items by text even when unrelated lines are reordered', () => {
   const oldBody = [
-    '- [ ] Follow-up: dedupe me',
-    '- [ ] Follow-up: dedupe me',
+    '- [ ] alpha task',
+    '- [ ] Follow-up: track the migration cleanup',
+    '- [ ] beta task',
   ].join('\n');
   const newBody = [
-    '- [x] Follow-up: dedupe me',
-    '- [x] Follow-up: dedupe me',
+    '- [x] beta task',
+    '- [x] Follow-up: track the migration cleanup',
+    '- [ ] alpha task',
   ].join('\n');
-  const r = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.strictEqual(r.length, 1);
+
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, ['track the migration cleanup']);
 });
 
-if (!process.exitCode) {
-  console.log('# checkbox-diff.test.js: all cases passed');
-}
+test('handles case-insensitive and hyphen/colon variations of the Follow-up prefix', () => {
+  const oldBody = [
+    '- [ ] FOLLOWUP no colon or hyphen',
+    '- [ ] followup: no hyphen, with colon',
+    '- [ ] Follow-Up:  extra   spacing',
+  ].join('\n');
+  const newBody = [
+    '- [x] FOLLOWUP no colon or hyphen',
+    '- [x] followup: no hyphen, with colon',
+    '- [x] Follow-Up:  extra   spacing',
+  ].join('\n');
+
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, [
+    'no colon or hyphen',
+    'no hyphen, with colon',
+    'extra   spacing',
+  ]);
+});
+
+test('does not match "Follow up:" with a bare space (convention requires the hyphenated form)', () => {
+  const oldBody = '- [ ] Follow up: with a bare space';
+  const newBody = '- [x] Follow up: with a bare space';
+  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
+});
+
+test('tolerates minor whitespace differences between old and new line text when matching', () => {
+  const oldBody = '- [ ]   Follow-up:   trim me   ';
+  const newBody = '- [x] Follow-up:   trim me';
+
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, ['trim me']);
+});
+
+test('drops a Follow-up item with no description text', () => {
+  const oldBody = '- [ ] Follow-up:';
+  const newBody = '- [x] Follow-up:';
+  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
+});
+
+// ── parseTaskItems ───────────────────────────────────────────────────────
+
+test('parseTaskItems parses checked/unchecked markers and strips marker syntax', () => {
+  const body = [
+    '- [ ] unchecked item',
+    '- [x] checked lowercase',
+    '- [X] checked uppercase',
+    '* [x] asterisk bullet',
+    '+ [x] plus bullet',
+    'not a task line',
+  ].join('\n');
+
+  assert.deepStrictEqual(parseTaskItems(body), [
+    { checked: false, text: 'unchecked item' },
+    { checked: true, text: 'checked lowercase' },
+    { checked: true, text: 'checked uppercase' },
+    { checked: true, text: 'asterisk bullet' },
+    { checked: true, text: 'plus bullet' },
+  ]);
+});
+
+test('parseTaskItems returns an empty array for null/undefined/empty input', () => {
+  assert.deepStrictEqual(parseTaskItems(null), []);
+  assert.deepStrictEqual(parseTaskItems(undefined), []);
+  assert.deepStrictEqual(parseTaskItems(''), []);
+});
+
+// ── normalizeKey ─────────────────────────────────────────────────────────
+
+test('normalizeKey folds case and collapses whitespace', () => {
+  assert.strictEqual(normalizeKey('  Follow-Up:   Do The Thing  '), 'follow-up: do the thing');
+});

--- a/tests/octopus-review-fallback.test.js
+++ b/tests/octopus-review-fallback.test.js
@@ -1,82 +1,63 @@
 'use strict';
 
-const test = require('node:test');
-const assert = require('node:assert/strict');
+// Tests for the Octopus quota-death review fallback lane:
+// scripts/octopus-review-fallback.js + .github/workflows/octopus-review-fallback.yml
+// (see wr/pending/07-review-fallback-when-octopus-quota-dead.md).
 
-const {
+const test = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
 const https = require('node:https');
 const { EventEmitter } = require('node:events');
-const https = require('node:https');
+const yaml = require('yaml');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const workflowPath = path.join(REPO_ROOT, '.github', 'workflows', 'octopus-review-fallback.yml');
+
+// Keep the retry-regression tests fast: override before require() since the
+// script reads these as module-load-time constants. RATE_LIMIT_MAX_INPROCESS_WAIT_MS
+// is kept small (3s) so the "primary limit exceeds the wait ceiling" test
+// doesn't need a multi-minute reset to prove the give-up path, and the
+// "waits out the real reset" test can use a sub-3s reset and still finish
+// quickly.
+process.env.RATE_LIMIT_BASE_DELAY_MS = process.env.RATE_LIMIT_BASE_DELAY_MS || '5';
+process.env.RATE_LIMIT_MAX_RETRIES = process.env.RATE_LIMIT_MAX_RETRIES || '3';
+process.env.RATE_LIMIT_MAX_INPROCESS_WAIT_MS = process.env.RATE_LIMIT_MAX_INPROCESS_WAIT_MS || '3000';
 
 const {
+  isQuotaDeathComment,
+  loadReviewProfile,
+  FALLBACK_MARKER,
+  OCTOPUS_BOT_LOGIN,
   isRateLimitedResponse,
+  classifyRateLimit,
+  computePrimaryResetWaitMs,
   computeRetryDelayMs,
-  isRateLimitedResponse,
   githubRequest,
-  commentIndicatesQuota,
 } = require('../scripts/octopus-review-fallback.js');
 
-// -----------------------------------------------------------------------------
-// isRateLimitedResponse
-// -----------------------------------------------------------------------------
-
-test('isRateLimitedResponse: 429 is always rate-limited', () => {
-  assert.equal(isRateLimitedResponse(429, ''), true);
-  assert.equal(isRateLimitedResponse(429, 'anything'), true);
+test('isQuotaDeathComment matches known Octopus quota banners (case-insensitive)', () => {
+  assert.strictEqual(isQuotaDeathComment('Please Add Your Own API Keys to continue reviews'), true);
+  assert.strictEqual(isQuotaDeathComment('Your monthly AI usage limit was hit.'), true);
+  assert.strictEqual(isQuotaDeathComment('quota exceeded for this billing period'), true);
 });
 
-test('isRateLimitedResponse: 403 with rate-limit body is rate-limited', () => {
-  const body = '{"message":"API rate limit exceeded for installation."}';
-  assert.equal(isRateLimitedResponse(403, body), true);
-  assert.equal(
-    isRateLimitedResponse(403, '{"message":"You have exceeded a secondary rate limit"}'),
-    true
+test('isQuotaDeathComment does NOT match healthy reviews or empty bodies', () => {
+  assert.strictEqual(isQuotaDeathComment('Found a null-pointer bug in scripts/foo.js line 12'), false);
+  assert.strictEqual(isQuotaDeathComment(''), false);
+  assert.strictEqual(isQuotaDeathComment(null), false);
+  assert.strictEqual(isQuotaDeathComment(undefined), false);
+});
+
+test('loadReviewProfile resolves the review profile from agent-models.yml', () => {
+  const profile = loadReviewProfile();
+  // Per agent-models.yml: Opus 4.7 primary, DeepSeek R1 fallback — but assert
+  // structure (drift-proof), not exact model slugs.
+  assert.ok(Array.isArray(profile.models) && profile.models.length >= 1);
+  const config = yaml.parse(
+    fs.readFileSync(path.join(REPO_ROOT, '.github', 'agent-models.yml'), 'utf8')
   );
-function makeResponse({ status, headers = {}, body = '' }) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    headers,
-    async text() {
-      return typeof body === 'string' ? body : JSON.stringify(body);
-    },
-  };
-}
-
-test('classifyRateLimit: primary via header signal', () => {
-  const kind = classifyRateLimit(
-    403,
-    { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1700000000' },
-    { message: 'API rate limit exceeded for installation ID 12345.' },
-  );
-  assert.equal(kind, 'primary');
-});
-
-test('classifyRateLimit: primary via body wording only', () => {
-  const kind = classifyRateLimit(
-    403,
-    {},
-    { message: 'API rate limit exceeded for installation ID 12345.' },
-  );
-  assert.equal(kind, 'primary');
-});
-
-test('classifyRateLimit: secondary via explicit wording', () => {
-  const kind = classifyRateLimit(
-    403,
-    { 'retry-after': '30' },
-    { message: 'You have exceeded a secondary rate limit.' },
-  );
-  assert.equal(kind, 'secondary');
-});
-
-test('classifyRateLimit: secondary via bare Retry-After', () => {
-  const kind = classifyRateLimit(429, { 'retry-after': '5' }, '');
-  assert.equal(kind, 'secondary');
-});
   assert.strictEqual(profile.models[0], config.profiles.review.primary);
   if (config.profiles.review.fallback) {
     assert.strictEqual(profile.models[1], config.profiles.review.fallback);
@@ -84,234 +65,109 @@ test('classifyRateLimit: secondary via bare Retry-After', () => {
   assert.strictEqual(config.profiles.review.provider, 'openrouter');
 });
 
-test('isRateLimitedResponse: 403 permissions error is NOT rate-limited', () => {
-  const body = '{"message":"Resource not accessible by integration"}';
-  assert.equal(isRateLimitedResponse(403, body), false);
+test('dedupe marker and bot login are stable identifiers', () => {
+  assert.strictEqual(FALLBACK_MARKER, '<!-- octopus-review-fallback -->');
+  assert.strictEqual(OCTOPUS_BOT_LOGIN, 'octopus-review[bot]');
 });
 
-test('isRateLimitedResponse: 404 is NOT rate-limited', () => {
-  assert.equal(isRateLimitedResponse(404, '{"message":"Not Found"}'), false);
+test('workflow guards the issue_comment lane to octopus-review[bot] quota banners', () => {
+  const workflow = yaml.parse(fs.readFileSync(workflowPath, 'utf8'));
+  const job = workflow.jobs['fallback-review'];
+  assert.ok(job, 'fallback-review job exists');
+  assert.match(job.if, /octopus-review\[bot\]/);
+  assert.match(job.if, /add your own API keys/);
+  assert.strictEqual(workflow.permissions['pull-requests'], 'write');
 });
 
-// -----------------------------------------------------------------------------
-// computeRetryDelayMs
-// -----------------------------------------------------------------------------
-
-test('computeRetryDelayMs: honors Retry-After header (seconds)', () => {
-  const d = computeRetryDelayMs({ 'retry-after': '3' }, 0, 1500, 20000);
-  assert.equal(d, 3000);
+test('workflow covers all three lanes: quota comment, sweep schedule, manual dispatch', () => {
+  const workflow = yaml.parse(fs.readFileSync(workflowPath, 'utf8'));
+  const triggers = workflow.on || workflow[true]; // yaml parses bare `on:` as boolean true
+  assert.ok(triggers.issue_comment, 'issue_comment trigger present');
+  assert.ok(triggers.schedule, 'schedule trigger present');
+  assert.ok(triggers.workflow_dispatch, 'workflow_dispatch trigger present');
 });
 
-test('computeRetryDelayMs: exponential backoff when no header', () => {
-  assert.equal(computeRetryDelayMs({}, 0, 1000, 20000), 1000);
-  assert.equal(computeRetryDelayMs({}, 1, 1000, 20000), 2000);
-  assert.equal(computeRetryDelayMs({}, 2, 1000, 20000), 4000);
-});
+// --- Rate-limit retry regression tests -------------------------------------
+//
+// Root cause (2026-07-13 fallback-review audit): the issue_comment trigger is
+// unscoped, so a burst of bot comments (Vercel, CI-status, ship-quality-check,
+// Octopus itself, ...) on several PRs in the same few seconds spins up many
+// concurrent fallback-review runs sharing one GitHub App installation's rate
+// limit. Confirmed live in job logs for PR #15821 and #15822: the very first
+// GitHub REST call (`GET /pulls/{n}/reviews`) came back
+// `403 "API rate limit exceeded for installation"`, and because the whole
+// script runs inside a top-level try/catch that never rethrows, the job
+// still reported conclusion "success" with zero review posted — a silent
+// no-op indistinguishable from "nothing to do here" in monitoring. These
+// tests pin the fix: githubRequest() must retry transient rate-limit
+// responses instead of surfacing them as an immediate failure.
+//
+// Follow-up (post-merge review of #15836, Copilot comment on
+// scripts/octopus-review-fallback.js:98): the first pass of the fix above
+// treated ALL rate-limit-flavored 403/429s the same way (short exponential
+// backoff, capped at 20s even when GitHub sent an explicit Retry-After).
+// That's correct for a SECONDARY/abuse-detection limit (short-lived, and
+// GitHub tells you exactly how long via Retry-After) but wrong for a
+// PRIMARY limit — the shared installation budget documented in
+// docs/biome/README.md's "PR Lifecycle failing in bulk" field note
+// (incident #15491): that budget resets via `x-ratelimit-reset` (a Unix
+// timestamp that can be up to ~an hour out), doesn't reliably send
+// Retry-After, and cannot be recovered by ANY amount of fast retrying. The
+// tests below cover both the classification (classifyRateLimit) and the
+// two different wait strategies (computePrimaryResetWaitMs vs
+// computeRetryDelayMs) that githubRequest() now picks between.
 
-test('computeRetryDelayMs: caps at maxDelayMs', () => {
-  assert.equal(computeRetryDelayMs({}, 10, 1000, 5000), 5000);
-  assert.equal(computeRetryDelayMs({ 'retry-after': '9999' }, 0, 1000, 5000), 5000);
-});
-
-// -----------------------------------------------------------------------------
-// commentIndicatesQuota
-// -----------------------------------------------------------------------------
-
-test('commentIndicatesQuota: matches quota comment text', () => {
-  assert.equal(
-    commentIndicatesQuota('This app has reached its monthly AI usage limit. Please add your own API keys in Settings...'),
-    true
-  );
-  assert.equal(commentIndicatesQuota('LGTM 👍'), false);
-  assert.equal(commentIndicatesQuota(''), false);
-  assert.equal(commentIndicatesQuota(null), false);
-});
-
-// -----------------------------------------------------------------------------
-// githubRequest — integration with mocked https.request
-// -----------------------------------------------------------------------------
-
+/**
+ * Replaces https.request with a stub that answers a fixed sequence of
+ * { status, headers, data } responses (last one repeats if exhausted), and
+ * returns a restore() to put the real implementation back.
+ */
 function mockHttpsResponses(responses) {
-  const calls = [];
   const original = https.request;
-  let i = 0;
-  https.request = function (options, cb) {
-    calls.push({ method: options.method, path: options.path });
-    const spec = responses[Math.min(i, responses.length - 1)];
-    i += 1;
+  let callIndex = 0;
+  https.request = (_options, callback) => {
+    const spec = responses[Math.min(callIndex, responses.length - 1)];
+    callIndex += 1;
     const res = new EventEmitter();
     res.statusCode = spec.status;
-    res.headers = Object.assign({ 'content-type': 'application/json' }, spec.headers || {});
-    // Fire cb async so req.end() has been called first, mirroring real https.
-    setImmediate(() => {
-      cb(res);
-      setImmediate(() => {
-        if (spec.body) res.emit('data', Buffer.from(spec.body));
-        res.emit('end');
-      });
-    });
+    res.headers = spec.headers || {};
     const req = new EventEmitter();
     req.write = () => {};
-    req.end = () => {};
+    req.end = () => {
+      process.nextTick(() => {
+        callback(res);
+        process.nextTick(() => {
+          res.emit('data', Buffer.from(spec.data || ''));
+          res.emit('end');
+        });
+      });
+    };
     return req;
   };
   return {
-    calls,
-    restore() { https.request = original; },
+    restore: () => { https.request = original; },
+    callCount: () => callIndex,
   };
 }
 
-test('githubRequest: retries after rate-limit 403 and eventually succeeds', async () => {
-  const mock = mockHttpsResponses([
-    { status: 403, body: '{"message":"API rate limit exceeded for installation."}' },
-    { status: 200, body: '[]' },
-test('classifyRateLimit: null for a plain permission 403', () => {
-  const kind = classifyRateLimit(
-    403,
-    {},
-    { message: 'Resource not accessible by integration' },
+test('isRateLimitedResponse matches 429 and GitHub rate-limit 403 bodies, not permission 403s', () => {
+  assert.strictEqual(isRateLimitedResponse(429, ''), true);
+  assert.strictEqual(
+    isRateLimitedResponse(403, JSON.stringify({ message: 'API rate limit exceeded for installation.' })),
+    true
   );
-  assert.equal(kind, null);
-});
-
-test('classifyRateLimit: null for non-4xx', () => {
-  assert.equal(classifyRateLimit(500, {}, ''), null);
-});
-
-test('computePrimaryResetWaitMs: computes future wait with cushion', () => {
-  const now = 1_700_000_000_000;
-  const resetSec = 1_700_000_060; // 60s in the future
-  const wait = computePrimaryResetWaitMs({ 'x-ratelimit-reset': String(resetSec) }, now);
-  assert.equal(wait, 60_000 + 1000);
-});
-
-test('computePrimaryResetWaitMs: returns 0 for a past reset', () => {
-  const now = 1_700_000_000_000;
-  const wait = computePrimaryResetWaitMs({ 'x-ratelimit-reset': '1699999000' }, now);
-  assert.equal(wait, 0);
-});
-
-test('computePrimaryResetWaitMs: null when header is absent', () => {
-  assert.equal(computePrimaryResetWaitMs({}), null);
-});
-
-test('computeRetryDelayMs: honors Retry-After in full (not capped at 20s)', () => {
-  // 45s Retry-After should not be clamped to 20s (that was the bug).
-  const delay = computeRetryDelayMs({ 'retry-after': '45' }, 0, 1500);
-  assert.equal(delay, 45_000);
-});
-
-test('computeRetryDelayMs: exponential backoff when no Retry-After', () => {
-  assert.equal(computeRetryDelayMs({}, 0, 1500), 1500);
-  assert.equal(computeRetryDelayMs({}, 1, 1500), 3000);
-  assert.equal(computeRetryDelayMs({}, 2, 1500), 6000);
-  assert.equal(computeRetryDelayMs({}, 3, 1500), 12000);
-});
-
-test('isRateLimitedResponse: covers both flavors', () => {
-  assert.equal(
-    isRateLimitedResponse(403, { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1' }, ''),
-    true,
+  assert.strictEqual(
+    isRateLimitedResponse(403, JSON.stringify({ message: 'You have exceeded a secondary rate limit.' })),
+    true
   );
-  assert.equal(isRateLimitedResponse(429, { 'retry-after': '5' }, ''), true);
-  assert.equal(isRateLimitedResponse(403, {}, { message: 'Not accessible' }), false);
-});
-
-test('githubRequest: primary limit sleeps the ACTUAL reset time, not exponential guess', async () => {
-  const now = 1_700_000_000_000;
-  const resetSec = 1_700_000_120; // ~120s in the future
-  let call = 0;
-  const sleeps = [];
-  const fetchImpl = async () => {
-    call += 1;
-    if (call === 1) {
-      return makeResponse({
-        status: 403,
-        headers: {
-          'x-ratelimit-remaining': '0',
-          'x-ratelimit-reset': String(resetSec),
-        },
-        body: { message: 'API rate limit exceeded for installation ID 12345.' },
-      });
-    }
-    return makeResponse({ status: 200, body: 'ok' });
-  };
-  const res = await githubRequest(
-    'https://api.github.com/foo',
-    {},
-    {
-      fetchImpl,
-      sleepImpl: async (ms) => {
-        sleeps.push(ms);
-      },
-      nowImpl: () => now,
-      logger: { warn() {} },
-      maxInProcessWaitMs: 15 * 60 * 1000,
-    },
+  // A genuine permissions error must NOT be treated as retryable.
+  assert.strictEqual(
+    isRateLimitedResponse(403, JSON.stringify({ message: 'Resource not accessible by integration' })),
+    false
   );
-  assert.equal(res.ok, true);
-  assert.equal(sleeps.length, 1);
-  // Should be ~120s + 1s cushion — NOT 1.5s / 3s / 6s / 12s exponential.
-  assert.equal(sleeps[0], 121_000);
+  assert.strictEqual(isRateLimitedResponse(404, 'not found'), false);
 });
 
-test('githubRequest: primary limit whose reset exceeds ceiling gives up immediately (no burn-loop)', async () => {
-  const now = 1_700_000_000_000;
-  const resetSec = 1_700_000_000 + 30 * 60; // 30min in the future
-  let call = 0;
-  const sleeps = [];
-  const fetchImpl = async () => {
-    call += 1;
-    return makeResponse({
-      status: 403,
-      headers: {
-        'x-ratelimit-remaining': '0',
-        'x-ratelimit-reset': String(resetSec),
-      },
-      body: { message: 'API rate limit exceeded for installation ID 12345.' },
-    });
-  };
-  await assert.rejects(
-    githubRequest(
-      'https://api.github.com/foo',
-      {},
-      {
-        fetchImpl,
-        sleepImpl: async (ms) => {
-          sleeps.push(ms);
-        },
-        nowImpl: () => now,
-        logger: { warn() {} },
-        maxInProcessWaitMs: 10 * 60 * 1000,
-      },
-    ),
-    (err) => {
-      assert.equal(err.rateLimit, 'primary');
-      assert.ok(err.message.includes('exceeds in-process wait ceiling'));
-      return true;
-    },
-  );
-  assert.equal(call, 1, 'must not retry when reset exceeds the ceiling');
-  assert.equal(sleeps.length, 0, 'must not sleep before giving up');
-});
-
-test('githubRequest: secondary limit retries with short backoff, honoring Retry-After in full', async () => {
-  let call = 0;
-  const sleeps = [];
-  const fetchImpl = async () => {
-    call += 1;
-    if (call <= 2) {
-      return makeResponse({
-        status: 403,
-        headers: { 'retry-after': '45' },
-        body: { message: 'You have exceeded a secondary rate limit.' },
-      });
-    }
-    return makeResponse({ status: 200, body: 'ok' });
-  };
-  const res = await githubRequest(
-    'https://api.github.com/foo',
-    {},
 test('classifyRateLimit distinguishes PRIMARY (installation budget) from SECONDARY (abuse) limits', () => {
   const nowSeconds = Math.floor(Date.now() / 1000);
 
@@ -385,44 +241,11 @@ test('githubRequest falls back to short backoff for a primary-worded 403 with NO
   // the real-reset-wait or the give-up path.
   const mock = mockHttpsResponses([
     {
-      fetchImpl,
-      sleepImpl: async (ms) => {
-        sleeps.push(ms);
-      },
-      logger: { warn() {} },
-      maxInProcessWaitMs: 60 * 1000,
-    },
-  );
-  assert.equal(res.ok, true);
-  assert.equal(call, 3);
-  // Both sleeps should honor the 45s Retry-After (bounded to the 60s ceiling).
-  assert.deepEqual(sleeps, [45_000, 45_000]);
-});
-
-test('githubRequest: genuine permission 403 fails fast (regression)', async () => {
-  let call = 0;
-  const fetchImpl = async () => {
-    call += 1;
-    return makeResponse({
       status: 403,
-      headers: {},
-      body: { message: 'Resource not accessible by integration' },
-    });
-  };
-  await assert.rejects(
-    githubRequest(
-      'https://api.github.com/foo',
-      {},
-      { fetchImpl, sleepImpl: async () => {}, logger: { warn() {} } },
-    ),
-    (err) => {
-      assert.equal(err.status, 403);
-      // Must NOT be marked as a rate-limit error, and must NOT have retried.
-      assert.equal(err.rateLimit, undefined);
-      return true;
+      data: JSON.stringify({
+        message: 'API rate limit exceeded for installation. If you reach out to GitHub Support...',
+      }),
     },
-  );
-  assert.equal(call, 1, 'permission 403 must not trigger rate-limit retry loop');
     { status: 200, data: JSON.stringify([{ id: 1 }]) },
   ]);
   try {
@@ -462,69 +285,98 @@ test('githubRequest waits out the ACTUAL x-ratelimit-reset time for a real PRIMA
     },
     { status: 200, data: JSON.stringify([{ id: 1 }]) },
   ]);
+  const start = Date.now();
   try {
-    const data = await githubRequest('GET', '/repos/o/r/pulls/1/reviews', {
-      token: 't',
-      maxRetries: 3,
-      baseDelayMs: 1,
-      maxDelayMs: 5,
-      sleepFn: async () => {},
-    });
-    assert.deepEqual(data, []);
-    assert.equal(mock.calls.length, 2);
+    const result = await githubRequest({ pathName: '/repos/midnghtsapphire/revvel-standards/pulls/2/reviews' });
+    const elapsedMs = Date.now() - start;
+    assert.deepStrictEqual(result, [{ id: 1 }]);
+    assert.strictEqual(mock.callCount(), 2, 'expected exactly one retry before success');
+    // Must wait close to the REAL reset time, not a tiny exponential guess
+    // (RATE_LIMIT_BASE_DELAY_MS is overridden to 5ms for the rest of this
+    // file — finishing in a few ms here would mean the fix regressed to
+    // guessing instead of reading x-ratelimit-reset).
+    assert.ok(elapsedMs >= 500, `expected a real wait close to ${resetInSeconds}s, only waited ${elapsedMs}ms`);
   } finally {
     mock.restore();
   }
 });
 
-test('githubRequest: gives up after exhausting retries on persistent rate-limit', async () => {
+test('githubRequest gives up immediately (no wasted retries) when a PRIMARY limit reset exceeds the in-process wait ceiling', async () => {
+  const resetEpoch = Math.floor(Date.now() / 1000) + 3600; // an hour out — far beyond the 3s test ceiling
   const mock = mockHttpsResponses([
-    { status: 403, body: '{"message":"API rate limit exceeded for installation."}' },
+    {
+      status: 403,
+      headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': String(resetEpoch) },
+      data: JSON.stringify({ message: 'API rate limit exceeded for installation.' }),
+    },
   ]);
+  const start = Date.now();
   try {
     await assert.rejects(
-      () => githubRequest('GET', '/repos/o/r/pulls/1/reviews', {
-        token: 't',
-        maxRetries: 2,
-        baseDelayMs: 1,
-        maxDelayMs: 5,
-        sleepFn: async () => {},
-      }),
-      (err) => {
-        assert.equal(err.status, 403);
-        assert.equal(err.rateLimited, true);
-        assert.match(err.message, /exhausted 2 retries/);
-        return true;
-      }
+      () => githubRequest({ pathName: '/repos/midnghtsapphire/revvel-standards/pulls/3/reviews' }),
+      /primary rate limit, reset too far out/
     );
-    // 1 initial + 2 retries = 3 total calls
-    assert.equal(mock.calls.length, 3);
+    const elapsedMs = Date.now() - start;
+    assert.strictEqual(
+      mock.callCount(),
+      1,
+      'must not retry a primary limit that cannot recover before the job times out'
+    );
+    assert.ok(elapsedMs < 500, `expected an immediate give-up, took ${elapsedMs}ms`);
   } finally {
     mock.restore();
   }
 });
 
-test('githubRequest: does NOT retry a genuine (non-rate-limit) error', async () => {
+test('githubRequest retries a SECONDARY (abuse-detection) limit with short backoff, honoring Retry-After', async () => {
   const mock = mockHttpsResponses([
-    { status: 404, body: '{"message":"Not Found"}' },
-    { status: 200, body: '[]' }, // should never be reached
+    {
+      status: 403,
+      headers: { 'retry-after': '1' },
+      data: JSON.stringify({
+        message: 'You have exceeded a secondary rate limit. Please retry your request again later.',
+      }),
+    },
+    { status: 200, data: JSON.stringify([{ id: 2 }]) },
+  ]);
+  const start = Date.now();
+  try {
+    const result = await githubRequest({ pathName: '/repos/midnghtsapphire/revvel-standards/pulls/4/reviews' });
+    const elapsedMs = Date.now() - start;
+    assert.deepStrictEqual(result, [{ id: 2 }]);
+    assert.strictEqual(mock.callCount(), 2, 'expected exactly one retry before success');
+    // Retry-After (1s) should be honored close to in full, same as before
+    // this fix — this is the case the original short-backoff retry was
+    // actually designed for and must keep working.
+    assert.ok(elapsedMs >= 800, `expected to honor Retry-After (~1s), only waited ${elapsedMs}ms`);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('githubRequest does not retry a non-rate-limit error (fails fast)', async () => {
+  const mock = mockHttpsResponses([{ status: 404, data: JSON.stringify({ message: 'Not Found' }) }]);
+  try {
+    await assert.rejects(
+      () => githubRequest({ pathName: '/repos/midnghtsapphire/revvel-standards/pulls/999999/reviews' }),
+      /GitHub HTTP 404/
+    );
+    assert.strictEqual(mock.callCount(), 1, 'a genuine 404 must not be retried');
+  } finally {
+    mock.restore();
+  }
+});
+
+test('githubRequest does not retry a genuine permissions 403 (fails fast, still confirms real permission errors are never mistaken for rate limits)', async () => {
+  const mock = mockHttpsResponses([
+    { status: 403, data: JSON.stringify({ message: 'Resource not accessible by integration' }) },
   ]);
   try {
     await assert.rejects(
-      () => githubRequest('GET', '/repos/o/r/pulls/1/reviews', {
-        token: 't',
-        maxRetries: 3,
-        baseDelayMs: 1,
-        maxDelayMs: 5,
-        sleepFn: async () => {},
-      }),
-      (err) => {
-        assert.equal(err.status, 404);
-        assert.notEqual(err.rateLimited, true);
-        return true;
-      }
+      () => githubRequest({ pathName: '/repos/midnghtsapphire/revvel-standards/pulls/5/reviews' }),
+      /GitHub HTTP 403/
     );
-    assert.equal(mock.calls.length, 1);
+    assert.strictEqual(mock.callCount(), 1, 'a genuine permissions 403 must not be retried');
   } finally {
     mock.restore();
   }

--- a/tests/work-request-form-sync.test.js
+++ b/tests/work-request-form-sync.test.js
@@ -1,89 +1,749 @@
-// Sync-audit test for the WR auto-classify workflow.
-//
-// History: on 2026-07-08 an interleave-damage incident (see CLAUDE.md gotcha #5)
-// duplicated function definitions and left a body-less `def` in the embedded
-// Python payload of .github/workflows/wr-auto-classify.yml. This test file
-// previously pinned assertions to the *broken* duplicate strings; those 4
-// assertions have been updated to check the reconciled implementation instead.
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Keeps Work Request issue template dropdowns aligned with wr-auto-classify
+ * allowed values so QA / contractors do not see spurious doc-vs-automation drift.
+ *
+ * Pure fs + regex — no npm deps required for this file.
+ */
 
 const fs = require('fs');
 const path = require('path');
 
-const WORKFLOW_PATH = path.join(
-  __dirname,
-  '..',
-  '.github',
-  'workflows',
-  'wr-auto-classify.yml'
-);
+const REPO_ROOT = path.resolve(__dirname, '..');
 
-function readWorkflow() {
-  return fs.readFileSync(WORKFLOW_PATH, 'utf8');
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`PASS: ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`FAIL: ${name}\n    ${e.stack || e.message}`);
+    failed++;
+  }
 }
 
-describe('wr-auto-classify.yml embedded Python payload', () => {
-  const content = readWorkflow();
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assertion failed');
+}
 
-  test('defines exactly one infer_output_type_from_title_tags', () => {
-    const matches = content.match(/def\s+infer_output_type_from_title_tags\s*\(/g) || [];
-    expect(matches.length).toBe(1);
-  });
+function sortedEq(a, b, label) {
+  const as = [...a].sort();
+  const bs = [...b].sort();
+  assert(
+    JSON.stringify(as) === JSON.stringify(bs),
+    `${label}: expected ${JSON.stringify(bs)}, got ${JSON.stringify(as)}`
+  );
+}
 
-  test('does not redeclare deprecated title-inference helpers', () => {
-    // These duplicate/dead functions were removed as part of the interleave reconcile.
-    expect(content).not.toMatch(/def\s+infer_output_type_from_title\s*\(/);
-    expect(content).not.toMatch(/def\s+infer_title_output_type\s*\(/);
-  });
-
-  test('defines exactly one fields_needing_classification with explicit second parameter', () => {
-    const matches =
-      content.match(/def\s+fields_needing_classification\s*\([^)]*\)/g) || [];
-    expect(matches.length).toBe(1);
-    expect(matches[0]).toMatch(/fields_needing_classification\(parsed,\s*title_output_type\)/);
-  });
-
-  test('uses the reconciled single-variable name in the main flow', () => {
-    // The reconciled main() uses `title_output_type` end-to-end; the drifting
-    // shadowing variants from the interleave incident must not reappear.
-    expect(content).toMatch(/title_output_type\s*=\s*infer_output_type_from_title_tags\(title\)/);
-    expect(content).not.toMatch(/title_inferred_output_type\s*=/);
-    expect(content).not.toMatch(/title_hint_used/);
-  });
-
-  test('merge precedence chain has an owning if (no stray elif)', () => {
-    // The pre-fix payload had a bare `elif field == "Output Type" and title_output_type in allowed:`
-    // with no owning if. The reconciled chain must lead with `if explicit:`.
-    expect(content).toMatch(/if\s+explicit\s*:/);
-    expect(content).toMatch(/elif\s+field\s*==\s*"Output Type"\s+and\s+title_output_type\s+in\s+ALLOWED_OUTPUT_TYPES\s*:/);
-  });
-
-  test('source-legend comment reflects reconciled tier names', () => {
-    // The now-nonexistent `title-hint` tier (a duplicate of `title-tag`) must not appear.
-    expect(content).not.toMatch(/title-hint\s*=\s*inferred from title tags/);
-    expect(content).toMatch(/title-tag\s*=\s*inferred from `#tag` in title/);
-    expect(content).toMatch(/classifier\s*=\s*OpenRouter classifier output/);
-    expect(content).toMatch(/fallback\s*=\s*opinionated default/);
-  });
-
-  test('title-tag output-type mapping stays in sync with the documented full set', () => {
-    // Sanity check that the 13-tag mapping from openrouter-auto-route.yml is present.
-    const requiredTags = [
-      '#research',
-      '#report',
-      '#brief',
-      '#tool',
-      '#cli',
-      '#lib',
-      '#library',
-      '#doc',
-      '#docs',
-      '#spec',
-      '#api',
-      '#service',
-      '#dataset',
-    ];
-    for (const tag of requiredTags) {
-      expect(content).toContain(`"${tag}"`);
+/**
+ * Parse GitHub issue form YAML dropdown options for a given field id.
+ * Indentation-stable (does not rely on a single giant regex).
+ */
+function dropdownOptionsFromTemplate(content, id) {
+  const marker = `id: ${id}`;
+  const start = content.indexOf(marker);
+  if (start < 0) {
+    throw new Error(`dropdown id "${id}" not found in Work Request template`);
+  }
+  const slice = content.slice(start);
+  const optHead = slice.indexOf('\n      options:');
+  if (optHead < 0) {
+    throw new Error(`"options:" block not found after id "${id}"`);
+  }
+  const afterOpts = slice.slice(optHead + '\n      options:'.length);
+  const lines = afterOpts.split(/\r?\n/);
+  const opts = [];
+  for (const line of lines) {
+    const om = line.match(/^\s{8}-\s+(.+)$/);
+    if (om) {
+      opts.push(om[1].trim());
+      continue;
     }
-  });
+    if (/^\s{4}validations:/.test(line)) break;
+    if (/^\s{4}\w/.test(line) && !line.includes('-')) break;
+  }
+  if (opts.length === 0) {
+    throw new Error(`No options parsed for id "${id}"`);
+  }
+  return opts;
+}
+
+function requiredFlagFromTemplate(content, id) {
+  const marker = `id: ${id}`;
+  const start = content.indexOf(marker);
+  if (start < 0) {
+    throw new Error(`field id "${id}" not found in template`);
+  }
+  const slice = content.slice(start);
+  const match = slice.match(/\n\s{4}validations:\n\s{6}required:\s*(true|false)\b/);
+  if (!match) {
+    throw new Error(`required validation flag not found for "${id}"`);
+  }
+  return match[1] === 'true';
+}
+
+function labelsFromTemplate(content) {
+  const start = content.indexOf('\nlabels:\n');
+  if (start < 0) {
+    throw new Error('labels block not found in template');
+  }
+
+  const lines = content.slice(start + '\nlabels:\n'.length).split(/\r?\n/);
+  const labels = [];
+  for (const line of lines) {
+    const match = line.match(/^\s{2}-\s+(.+)$/);
+    if (match) {
+      labels.push(match[1].trim().replace(/^['"]|['"]$/g, ''));
+      continue;
+    }
+    if (line.trim()) break;
+  }
+  return labels;
+}
+
+function assertLabelDefinition(labelsYaml, label) {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`- name: (?:"${escaped}"|'${escaped}'|${escaped})\\n`);
+  assert(pattern.test(labelsYaml), `.github/labels.yml missing canonical label definition for "${label}"`);
+}
+
+test('active Work Request templates stay in sync with portable template copies', () => {
+  const pairs = [
+    ['00-work-request.yml', '00-work-request.yml'],
+    ['10-openhands-system-wr.yml', '10-openhands-system-wr.yml'],
+  ];
+
+  for (const [activeName, portableName] of pairs) {
+    const active = fs.readFileSync(
+      path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', activeName),
+      'utf8'
+    );
+    const portable = fs.readFileSync(
+      path.join(REPO_ROOT, 'templates', 'issue-template', portableName),
+      'utf8'
+    );
+    assert(active === portable, `${activeName} must match templates/issue-template/${portableName}`);
+  }
 });
+
+test('Work Request templates apply canonical WR routing labels', () => {
+  const primary = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', '00-work-request.yml'),
+    'utf8'
+  );
+  const quick = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', '10-openhands-system-wr.yml'),
+    'utf8'
+  );
+  const labelsYaml = fs.readFileSync(path.join(REPO_ROOT, '.github', 'labels.yml'), 'utf8');
+
+  const canonicalWrLabels = [
+    'work-request',
+    'weekly-research',
+    'wr:in-progress',
+    'deep-research',
+    'openrouter',
+    'role:orchestrator',
+  ];
+
+  for (const label of canonicalWrLabels) {
+    assert(labelsFromTemplate(primary).includes(label), `primary WR template missing ${label}`);
+    assert(labelsFromTemplate(quick).includes(label), `quick WR template missing ${label}`);
+    assertLabelDefinition(labelsYaml, label);
+  }
+
+  for (const label of ['quick', 'OpenHands']) {
+    assert(labelsFromTemplate(quick).includes(label), `quick WR template missing ${label}`);
+    assertLabelDefinition(labelsYaml, label);
+  }
+});
+
+test('WR templates allow title-only intake for orchestrator-filled routing', () => {
+  const templates = [
+    fs.readFileSync(
+      path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', '00-work-request.yml'),
+      'utf8'
+    ),
+    fs.readFileSync(
+      path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', '10-openhands-system-wr.yml'),
+      'utf8'
+    ),
+  ];
+
+  for (const template of templates) {
+    assert(
+      template.includes('Title-only intake is allowed.'),
+      'WR template must document title-only intake'
+    );
+    // 2026-05-21 (Claude): title-only intake allows the orchestrator to fill the
+    // rest, but Output Type stays required (you must declare what to build).
+    // So at most one field — output_type — may be required; no other body field.
+    const requiredCount = (template.match(/required:\s*true/g) || []).length;
+    assert(
+      requiredCount <= 1,
+      'WR templates must not require body fields beyond Output Type'
+    );
+    if (requiredCount === 1) {
+      assert(
+        requiredFlagFromTemplate(template, 'output_type'),
+        'the only required WR field may be output_type'
+      );
+    }
+  }
+});
+
+test('WR workflows accept BASIC WR issue type, work-request label, and title route tags', () => {
+  const wrPrCreation = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-pr-creation.yml'),
+    'utf8'
+  );
+  const weeklyResearch = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'weekly-research.yml'),
+    'utf8'
+  );
+
+  for (const workflow of [wrPrCreation, weeklyResearch]) {
+    assert(workflow.includes("labelSet.has('work-request')"), 'WR workflow must accept work-request label');
+    assert(workflow.includes("labelSet.has('wr:new') && hasTitleRouteTag"), 'WR workflow must accept title-only wr:new route-tag intake');
+    assert(workflow.includes("'basic wr'"), 'WR workflow must accept BASIC WR issue type');
+    assert(workflow.includes('hasWrRouteTag'), 'WR workflow must detect title-only route tags');
+    assert(workflow.includes('tool|tools'), 'WR workflow must accept #tool title route tags');
+    assert(workflow.includes('app|apps'), 'WR workflow must accept #app title route tags');
+    assert(
+      workflow.includes('hasTitleRouteTag') &&
+        workflow.includes('#(?:app|apps|tool|tools'),
+      'WR workflow must accept title route tags'
+    );
+    assert(workflow.includes('#(app|web-app|tool|tools|pdf|docs?|documentation|api|cli|mcp|video|skill|skills|website)'),
+      'WR workflow must accept title route tags like #app/#tools');
+    // 2026-07-08: was pinned to `titleHasRouteTags`, an identifier that only
+    // existed in a mangled duplicate block; the surviving extended-alias tier
+    // is named `hasRouteTag`.
+    assert(workflow.includes('const hasRouteTag ='), 'WR workflow must accept title-only route tags');
+    assert(workflow.includes("'weekly-research'"), 'WR workflow must apply weekly-research label');
+    assert(workflow.includes("'deep-research'"), 'WR workflow must apply deep-research label');
+    assert(workflow.includes("'openrouter'"), 'WR workflow must apply openrouter label');
+    assert(workflow.includes("'role:orchestrator'"), 'WR workflow must apply role:orchestrator label');
+  }
+});
+
+test('WR auto-classify accepts title signals and infers output type from route tags', () => {
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'wr-auto-classify.yml'), 'utf8');
+  assert(
+    wf.includes("contains(github.event.issue.labels.*.name, 'weekly-research')"),
+    'wr-auto-classify must accept weekly-research label'
+  );
+  assert(
+    wf.includes("startsWith(github.event.issue.title, '[WR]')"),
+    'wr-auto-classify must accept [WR] title prefix'
+  );
+  assert(
+    wf.includes("contains(format(' {0} ', github.event.issue.title), ' #app ')"),
+    'wr-auto-classify must accept #app title route tags'
+  );
+  assert(
+    wf.includes("contains(format(' {0} ', github.event.issue.title), ' #tool ')"),
+    'wr-auto-classify must accept #tool title route tags'
+  );
+  assert(
+    wf.includes('def infer_output_type_from_title_tags(title):'),
+    'wr-auto-classify must infer Output Type from title route tags when the issue body is blank'
+  );
+});
+
+test('OpenRouter auto-route accepts title-only route tags and infers Output Type from them', () => {
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'openrouter-auto-route.yml'), 'utf8');
+  assert(
+    wf.includes("contains(github.event.issue.labels.*.name, 'work-request')"),
+    'openrouter-auto-route must accept work-request labels'
+  );
+  assert(
+    wf.includes("contains(format(' {0} ', github.event.issue.title), ' #app ')"),
+    'openrouter-auto-route must accept #app title route tags'
+  );
+  assert(
+    wf.includes("contains(format(' {0} ', github.event.issue.title), ' #tool ')"),
+    'openrouter-auto-route must accept #tool title route tags'
+  );
+  assert(
+    wf.includes("contains(format(' {0} ', github.event.issue.title), ' #skill ')"),
+    'openrouter-auto-route must accept #skill title route tags'
+  );
+  assert(
+    wf.includes('const titleTagOutputTypeMap = ['),
+    'openrouter-auto-route must infer Output Type from title route tags when the issue body is blank'
+  );
+});
+
+// Reconstructed 2026-07-08: this test's assertions were spliced into the one
+// above (against the wrong workflow file) by an overlapping merge — the file
+// did not parse and the gate sat red. See standards/GREEN_MAIN_STANDARD.md.
+test('wr-auto-classify accepts title route tags and infers Output Type', () => {
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'wr-auto-classify.yml'), 'utf8');
+  assert(
+    wf.includes("contains(format(' {0} ', github.event.issue.title), ' #app ')") &&
+      wf.includes("contains(format(' {0} ', github.event.issue.title), ' #tool ')"),
+    'wr-auto-classify must accept title route tags'
+  );
+  assert(
+    wf.includes('TITLE_ROUTE_OUTPUT_TYPES') &&
+      wf.includes('title-tag = inferred from a route tag in the issue title'),
+    'wr-auto-classify must infer Output Type from title route tags'
+  );
+});
+
+test('openrouter auto-route accepts WR labels and title route tags', () => {
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'openrouter-auto-route.yml'), 'utf8');
+  assert(
+    wf.includes("contains(github.event.issue.labels.*.name, 'weekly-research')") &&
+      wf.includes("contains(github.event.issue.labels.*.name, 'work-request')"),
+    'openrouter-auto-route must accept WR labels'
+  );
+  assert(
+    wf.includes("contains(format(' {0} ', github.event.issue.title), ' #app ')") &&
+      wf.includes("contains(format(' {0} ', github.event.issue.title), ' #tool ')"),
+    'openrouter-auto-route must accept title route tags'
+  );
+  assert(
+    wf.includes("startsWith(github.event.label.name, 'output-type:')") &&
+      wf.includes('inferOutputTypeFromTitle'),
+    'openrouter-auto-route must route from output-type labels or title tags when body is blank'
+  );
+});
+
+// CONSOLIDATED 2026-07-08 (see standards/GREEN_MAIN_STANDARD.md): this span
+// held six+ generations of the same title-route-tag tests, each generation
+// spliced into the previous one by overlapping merges until the file no
+// longer parsed. The tests below are the survivors, re-verified line by line
+// against the CURRENT workflow implementations.
+
+test('weekly-research accepts route-tagged title-only source intake', () => {
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'weekly-research.yml'), 'utf8');
+  assert(
+    wf.includes('looksLikeTaggedSourceIntake') &&
+      wf.includes('hasSourceUrl'),
+    'weekly-research must detect route-tagged source-link intake as WR work'
+  );
+});
+
+test('OpenRouter auto-route accepts normalized WR labels and output-type fallbacks', () => {
+  const wf = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'openrouter-auto-route.yml'),
+    'utf8'
+  );
+
+  assert(
+    wf.includes("contains(github.event.issue.labels.*.name, 'work-request')"),
+    'openrouter-auto-route must run after WR labels are normalized'
+  );
+  assert(
+    wf.includes("contains(github.event.issue.labels.*.name, 'weekly-research')"),
+    'openrouter-auto-route must accept weekly-research-labeled issues'
+  );
+  assert(
+    wf.includes("label.startsWith('output-type:')"),
+    'openrouter-auto-route must fall back to output-type:* labels'
+  );
+  assert(
+    wf.includes('inferTitleOutputType'),
+    'openrouter-auto-route must support title-tag Output Type inference for title-only intake'
+  );
+});
+
+test('WR workflows infer routing from title tags for title-only intake', () => {
+  const weeklyResearch = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'weekly-research.yml'),
+    'utf8'
+  );
+  const wrPrCreation = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-pr-creation.yml'),
+    'utf8'
+  );
+  const wrAutoClassify = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-auto-classify.yml'),
+    'utf8'
+  );
+  const openrouterAutoRoute = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'openrouter-auto-route.yml'),
+    'utf8'
+  );
+
+  assert(
+    weeklyResearch.includes('const hasRouteTag ='),
+    'weekly-research should treat title route tags as WR intake signals'
+  );
+  assert(
+    wrPrCreation.includes('const hasRouteTag ='),
+    'wr-pr-creation should treat title route tags as WR intake signals'
+  );
+  assert(
+    wrAutoClassify.includes('infer_output_type_from_title') &&
+      wrAutoClassify.includes('Title route tag inferred Output Type'),
+    'wr-auto-classify should infer Output Type from title route tags when body is blank'
+  );
+  assert(
+    openrouterAutoRoute.includes('inferOutputTypeFromTitle') &&
+      openrouterAutoRoute.includes('No Output Type section or route tags found'),
+    'openrouter-auto-route should infer Output Type from title route tags'
+  );
+});
+
+test('WR auto-classify infers Output Type from title app/tool hints', () => {
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'wr-auto-classify.yml'), 'utf8');
+  assert(
+    wf.includes('def infer_output_type_from_title_tags(title):'),
+    'wr-auto-classify should infer output type from title hints when Output Type is missing'
+  );
+  assert(
+    wf.includes('title_output_type = infer_output_type_from_title_tags(ISSUE_TITLE)'),
+    'wr-auto-classify should compute a title-based Output Type hint'
+  );
+  assert(
+    wf.includes('elif field == "Output Type" and title_output_type in allowed:'),
+    'wr-auto-classify should use the title Output Type hint before fallback defaults'
+  );
+  assert(
+    wf.includes('title-tag = inferred from a route tag in the issue title'),
+    'wr-auto-classify should document title-tag as a classification source'
+  );
+});
+
+
+test('Title route tags act as WR intake and Output Type signals for title-only issues', () => {
+  const weeklyResearch = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'weekly-research.yml'),
+    'utf8'
+  );
+  const autoClassify = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-auto-classify.yml'),
+    'utf8'
+  );
+  const autoRoute = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'openrouter-auto-route.yml'),
+    'utf8'
+  );
+
+  assert(
+    weeklyResearch.includes('const hasTitleRouteTag =') &&
+      weeklyResearch.includes('#(?:app|apps|tool|tools'),
+    'weekly-research must recognize #app/#tool title tags as WR intake signals'
+  );
+  // The trigger uses word-boundary matching — format(' {0} ', title) — so a
+  // route tag only counts as a whole word. (A bare contains(title, '#app')
+  // variant existed only in the mangled duplicate blocks removed 2026-07-08.)
+  assert(
+    autoClassify.includes("contains(format(' {0} ', github.event.issue.title), ' #app ')") &&
+      autoClassify.includes("contains(format(' {0} ', github.event.issue.title), ' #tool ')"),
+    'wr-auto-classify must run for title-only route tags'
+  );
+  assert(
+    autoClassify.includes('def infer_output_type_from_title_tags(title):') &&
+      autoClassify.includes('TITLE_TAG_OUTPUT_TYPE.get(f"#{tag}")') &&
+      autoClassify.includes('"production-app"') &&
+      autoClassify.includes('"desktop-tool"'),
+    'wr-auto-classify must infer Output Type from #app/#tool title tags when the body is blank'
+  );
+  assert(
+    autoRoute.includes("contains(github.event.issue.labels.*.name, 'work-request')") &&
+      autoRoute.includes("contains(format(' {0} ', github.event.issue.title), ' #app ')") &&
+      autoRoute.includes("label.startsWith('output-type:')") &&
+      autoRoute.includes('inferOutputTypeFromTitle(title)'),
+    'openrouter-auto-route must accept title-tag WR intake and route from title/body/output-type label signals'
+  );
+});
+
+test('WR routing workflows infer Output Type from title route tags', () => {
+  const classify = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-auto-classify.yml'),
+    'utf8'
+  );
+  const route = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'openrouter-auto-route.yml'),
+    'utf8'
+  );
+  const wrPr = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-pr-creation.yml'),
+    'utf8'
+  );
+
+  for (const workflow of [classify, route, wrPr]) {
+    assert(workflow.includes('#tool') && workflow.includes('#tools'), 'must recognize #tool/#tools route tags');
+    assert(workflow.includes('#app') && workflow.includes('#apps'), 'must recognize #app/#apps route tags');
+    assert(
+      workflow.includes('desktop-tool') && workflow.includes('production-app'),
+      'must map tool/app title tags to canonical Output Type values'
+    );
+  }
+});
+
+test('WR PR creation waits for research completion and ignores PR comments', () => {
+  const wrPrCreation = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-pr-creation.yml'),
+    'utf8'
+  );
+
+  assert(
+    wrPrCreation.includes("!(github.event_name == 'issue_comment' &&"),
+    'WR PR creation must negate pull-request issue_comment events at the workflow gate'
+  );
+  assert(
+    wrPrCreation.includes("github.event.issue.pull_request"),
+    'WR PR creation must ignore pull-request issue_comment events'
+  );
+  assert(
+    wrPrCreation.includes("labelSet.has('research:complete')"),
+    'WR PR creation must treat research:complete as a creation signal'
+  );
+  assert(
+    wrPrCreation.includes("commentBody.includes('Research packet:')"),
+    'WR PR creation must treat research packet comments as research-ready signals'
+  );
+});
+
+test('WR PR creation mirrors deep research labels onto the generated PR', () => {
+  const wrPrCreation = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-pr-creation.yml'),
+    'utf8'
+  );
+
+  assert(
+    wrPrCreation.includes("label === 'deep-research'"),
+    'Generated WR PRs must inherit the deep-research label'
+  );
+  assert(
+    wrPrCreation.includes("label.startsWith('research:')"),
+    'Generated WR PRs must inherit research lane labels'
+  );
+});
+
+test('WR PR creation uses an existing template and clears recovered stuck labels', () => {
+  const wrPrCreation = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-pr-creation.yml'),
+    'utf8'
+  );
+  const labelsYaml = fs.readFileSync(path.join(REPO_ROOT, '.github', 'labels.yml'), 'utf8');
+
+  assert(
+    fs.statSync(path.join(REPO_ROOT, 'wr', 'WR_TEMPLATE_FULL.md')).isFile(),
+    'Canonical full WR template must exist'
+  );
+  assert(
+    wrPrCreation.includes('wr/WR_TEMPLATE_FULL.md') &&
+      wrPrCreation.includes('wr/WR_TEMPLATE_BASIC.md'),
+    'WR PR creation must use existing WR template paths'
+  );
+  assert(
+    wrPrCreation.includes('ISSUE_BODY: ${{ needs.detect-completion.outputs.issue_body }}'),
+    'WR PR creation must pass the issue body into document generation'
+  );
+  assert(
+    wrPrCreation.includes("name.startsWith('wr:retrigger-attempts-')") &&
+      wrPrCreation.includes("name === 'lifecycle:stuck'") &&
+      wrPrCreation.includes("name === 'wr-stuck'"),
+    'WR PR creation must clear auto-healer stuck labels after a PR is created'
+  );
+
+  // wr:reset must be stripped after success (one-shot signal)
+  assert(
+    wrPrCreation.includes("name === 'wr:reset'"),
+    'WR PR creation must remove wr:reset label after successful PR generation'
+  );
+
+  for (const label of [
+    'wr:retrigger-attempts-1',
+    'wr:retrigger-attempts-2',
+    'wr:retrigger-attempts-3',
+    'wr-stuck',
+    'wr:reset',
+  ]) {
+    assertLabelDefinition(labelsYaml, label);
+  }
+});
+
+test('wr:reset bypasses existing-PR guard and is allowed as a trigger label', () => {
+  const wrPrCreation = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-pr-creation.yml'),
+    'utf8'
+  );
+
+  // wr:reset must appear in the COMPLETION_LABELS allowlist so labeled events
+  // carrying it are not dropped as label noise before the check runs.
+  assert(
+    wrPrCreation.includes("'wr:reset'") &&
+      wrPrCreation.includes('COMPLETION_LABELS'),
+    'wr:reset must be included in the COMPLETION_LABELS trigger allowlist'
+  );
+
+  // The bypass block must reference wr:reset and the existing-PR variable
+  // so operators can force a fresh PR even when a skeleton already exists.
+  assert(
+    wrPrCreation.includes("labelSet.has('wr:reset')") &&
+      wrPrCreation.includes('wr:reset detected'),
+    'wr:reset must bypass the existing-PR guard with a clear log message'
+  );
+
+  // wr:reset must count as a completion signal so should_create_pr becomes true
+  // even when no other completion label is present.
+  assert(
+    wrPrCreation.includes("labelSet.has('wr:reset')"),
+    'wr:reset must be treated as a completion signal in the isComplete check'
+  );
+});
+
+test('Work Request Output Type options match wr-auto-classify DROPDOWN_FIELDS', () => {
+  const tmplPath = path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', '00-work-request.yml');
+  const tmpl = fs.readFileSync(tmplPath, 'utf8');
+  const templateOpts = dropdownOptionsFromTemplate(tmpl, 'output_type');
+
+  const wfPath = path.join(REPO_ROOT, '.github', 'workflows', 'wr-auto-classify.yml');
+  const wf = fs.readFileSync(wfPath, 'utf8');
+  const m = wf.match(/"Output Type":\s*\[([\s\S]*?)\]\s*,\s*\n\s*"Research Mode":/);
+  assert(m, 'Could not extract Output Type list from wr-auto-classify.yml');
+  const inner = m[1];
+  const classifyOpts = [...inner.matchAll(/"([^"]+)"/g)].map((x) => x[1]);
+
+  sortedEq(templateOpts, classifyOpts, 'Output Type option mismatch');
+});
+
+test('WR PR creation maps current WR output types to ship-to-market labels', () => {
+  const wrPrCreation = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'workflows', 'wr-pr-creation.yml'),
+    'utf8'
+  );
+
+  const expectedMappings = {
+    'production-app': 'deliver:app',
+    'desktop-tool': 'deliver:app',
+    'sellable-pdf': 'deliver:pdf',
+    'technical-documentation': 'deliver:docs',
+    'project-management-doc': 'deliver:docs',
+    'internal-script-automation': 'deliver:cli',
+    'cli-product': 'deliver:cli',
+    'mcp-product': 'deliver:mcp',
+    'api-product': 'deliver:api',
+    'client-code-task': 'deliver:package',
+    'invention-flow': 'deliver:docs',
+  };
+
+  for (const [outputType, deliverLabel] of Object.entries(expectedMappings)) {
+    assert(
+      wrPrCreation.includes(`'${outputType}': '${deliverLabel}'`),
+      `WR PR creation must map ${outputType} to ${deliverLabel}`
+    );
+  }
+  // 2026-07-08: the surviving title-tag fallback helper is named
+  // `inferTitleOutputType` (the `inferOutputTypeFromTitle` arrow variant
+  // lived only in the mangled duplicate blocks that were removed).
+  assert(
+    wrPrCreation.includes('const inferTitleOutputType = (title) => {') &&
+      wrPrCreation.includes("inferTitleOutputType(issue.title || '')"),
+    'WR PR creation must fall back to title route tags for deliver label inference'
+  );
+});
+
+test('PDF pipeline batch dropdown exists with expected options', () => {
+  const tmplPath = path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', '00-work-request.yml');
+  const tmpl = fs.readFileSync(tmplPath, 'utf8');
+  assert(tmpl.includes('id: pdf_pipeline_batch'), 'pdf_pipeline_batch id missing');
+  const opts = dropdownOptionsFromTemplate(tmpl, 'pdf_pipeline_batch');
+  sortedEq(opts, ['Autocreate 20', 'Autocreate 3', 'Not applicable'], 'PDF pipeline batch options');
+
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'wr-auto-classify.yml'), 'utf8');
+  assert(
+    wf.includes('"Not applicable", "Autocreate 3", "Autocreate 20"'),
+    'wr-auto-classify playbook guard missing pdf_batch_allowed set'
+  );
+  assert(
+    /if\s+final\.get\("Output Type"\)\s*==\s*"sellable-pdf"\s*:\s*\n\s*pdf_batch_raw\s*=\s*parse_form_section\(/.test(wf),
+    'wr-auto-classify should only parse PDF pipeline batch for sellable-pdf requests'
+  );
+  assert(
+    /if\s+final\.get\("Output Type"\)\s*==\s*"sellable-pdf"\s+and\s+pdf_batch_raw\s*:/.test(wf),
+    'wr-auto-classify should only evaluate PDF pipeline batch values for sellable-pdf requests'
+  );
+  assert(
+    fs.existsSync(path.join(REPO_ROOT, 'workflows', 'PDF_WR_PLAYBOOK.md')),
+    'workflows/PDF_WR_PLAYBOOK.md missing'
+  );
+});
+
+test('Work Request heavy template keeps only Output Type required', () => {
+  const tmplPath = path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', '00-work-request.yml');
+  const tmpl = fs.readFileSync(tmplPath, 'utf8');
+
+  assert(requiredFlagFromTemplate(tmpl, 'output_type'), 'output_type should remain required');
+
+  for (const id of [
+    'pdf_pipeline_batch',
+    'research_mode',
+    'delivery_mode',
+    'lifecycle_mode',
+    'commercial_mode',
+    'summary',
+    'objective',
+    'required_bundle',
+    'definition_of_done',
+    'do_not_under_scope',
+    'delivery_shape',
+    'sellable_artifact_bundle',
+    'purchase_validation',
+    'blocker_rule',
+  ]) {
+    assert(!requiredFlagFromTemplate(tmpl, id), `${id} should be optional`);
+  }
+});
+
+test('Work Request heavy template exposes sellable-artifact bundle and purchase validation fields', () => {
+  const active = fs.readFileSync(
+    path.join(REPO_ROOT, '.github', 'ISSUE_TEMPLATE', '00-work-request.yml'),
+    'utf8'
+  );
+
+  // Explodable sellable ZIP delivery shape (unpacks into repo folders).
+  assert(
+    dropdownOptionsFromTemplate(active, 'delivery_shape').includes(
+      'Explodable sellable ZIP (unpacks into repo folders)'
+    ),
+    'Delivery Shape must offer the explodable sellable ZIP option'
+  );
+
+  // Sellable Artifact Bundle field for the ZIP contents (files/prompts/skills/etc.).
+  assert(
+    active.includes('id: sellable_artifact_bundle') &&
+      active.includes('label: Sellable Artifact Bundle'),
+    'heavy WR template must expose a Sellable Artifact Bundle field'
+  );
+
+  // Purchase Validation field to rigorously prove it functions as purchased.
+  assert(
+    active.includes('id: purchase_validation') &&
+      active.includes('label: Purchase Validation (functions-as-purchased)'),
+    'heavy WR template must expose a Purchase Validation field'
+  );
+
+  // wr-preprocess must keep these canonical fields in sync so Jules parses them.
+  const preprocess = fs.readFileSync(
+    path.join(REPO_ROOT, 'scripts', 'wr-preprocess.js'),
+    'utf8'
+  );
+  assert(
+    preprocess.includes('"Sellable Artifact Bundle"') &&
+      preprocess.includes('"Purchase Validation"'),
+    'scripts/wr-preprocess.js CANONICAL_WR_FIELDS must include the new sellable-artifact fields'
+  );
+});
+
+test('PDF_WR_PLAYBOOK links AUTOMATED_PRODUCT_PIPELINE and PDF shape', () => {
+  const pb = fs.readFileSync(path.join(REPO_ROOT, 'workflows', 'PDF_WR_PLAYBOOK.md'), 'utf8');
+  assert(pb.includes('AUTOMATED_PRODUCT_PIPELINE.md'), 'playbook should reference pipeline standard');
+  assert(pb.includes('standards/shapes/PDF.md'), 'playbook should reference PDF shape');
+});
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Third occurrence **today** of the interleave-collision incident (CLAUDE.md gotcha #5). A router bug re-dispatched already-merged PRs/issues as if open, mistaking PR numbers for open issues, and coding agents pasted **regressive duplicate copies** of already-merged work on top of the clean versions. This reddened `main` again (`npm test` → 34 failures) after round 1 (#15910) had restored it to 619/619.

The **root cause was fixed forward in #15914** (guards `openrouter-coder.yml` against dispatching on merged PRs / closed issues), which should prevent a round 4. But several duplicate commits had **already landed** and were never part of #15910's reconciliation — and #15910 itself left three workflow files with duplicate-key / spliced-literal YAML damage. This PR reconciles all of it.

Methodology matches #15910: **one implementation per behavior, delete the losers, verify by execution.** Each file restored to its last known-green committed version (biased toward the original merged PR, verified by reading both sides — not blind reverts).

## Changes

Per-file reconciliation (duplicate → restored-to):

| File(s) | Restored to | Corrupting dup(s) | Damage signature |
|---|---|---|---|
| `scripts/octopus-review-fallback.js` + test | `dd2e3f51` (keeps #15887 `classifyRateLimit`/`computePrimaryResetWaitMs` + #15836 retry) | `a5ea140e` (#15894), `79da6363` (#15897) | redeclared `const https` / `const assert` |
| `.github/workflows/issue-state-machine.yml` | `ba750728` (#15887; keeps #15821 `removeLabel` 404 try/catch) | `09903ba4` (#15890), `a71686dd` (#15909) + botched round-1 | duplicate top-level `jobs:`/`permissions:` keys; `timeout-minutes:` spliced into a `script:` literal |
| `scripts/auto-resolve-mechanical-conflicts.js` + test | `5658c962` (#15826, canonical exit-code fix per gotcha #6) | `64c0787e` (#15881), `9ab2fcaf` (#15900) | redeclared `const execSync` |
| `.github/workflows/wr-auto-classify.yml` + `tests/work-request-form-sync.test.js` | `708ffc83` (#15846) | `bc364f82` (#15889), `dd2e3f51` (#15908) | duplicate job keys; sync test gutted → `describe is not defined` |
| `.github/workflows/saml-sso-registration.yml` | `7fff18fc` (#15871; already has the inline GitHub-API replacement for the removed `gagoar` action) | `7609170e` (#15885, 13×`[openrouter]` prefix), `f76f3569` (#15907) | unrecoverable interleave soup (competing run-scripts spliced together) |
| `scripts/daily-diagnostic-audit.js` (+ workflow → `39fb109b`) | `609c7f4c` (#15844) | `c12bf976` (#15899) | rewrite dropped the module exports the test imports (`parseGitLogNameOnly`, `buildSystemPrompt`, … → "not a function") |
| `scripts/checkbox-diff.js` + test | `39fb109b` (round-1 clean) | `9cc674f3` (#15898) | reintroduced a follow-up-detection assertion regression |

## Validation

- `npm ci && npm test` → **619/619 passing, exit 0** (baseline before this PR: 34 failing). Confirms parity with the #15910 green baseline; no unexplained failures.
- Every touched workflow YAML validates with `python3 -c "import yaml; yaml.safe_load(...)"` **and** is duplicate-key-free (the stricter check `automation-doctor` enforces). The `Workflow YAML Parsing`, `AutomationDoctor`, and `daily-diagnostic-audit` suites are green again.
- No changed Markdown, so the changed-Markdown lint gate is a no-op.
- No new `|| echo` shims; gates stay real.

## Root-cause status

The dispatch bug that generated these duplicates is fixed forward in **#15914**. Combined with this restoration, `main` is green and a round 4 should not recur. If the SAML inline-GraphQL rework (#15885/#15907 intent) is still wanted, it must be re-attempted cleanly on top of `7fff18fc` — its previous attempts were corrupt on arrival.

## Checklist

- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format
- [x] WR/issue scope is delivered in full
- [ ] Closes #N — this is an incident restoration (round 3), not a single tracked issue; references #15910 (round 1) and #15914 (root-cause fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK

---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR reconciles *round-3* duplicate code that re-corrupted `main` after router bugs mistakenly re-dispatched already-merged PRs/issues. The corruption manifested as redeclared constants, spliced YAML keys, and gutted test files, causing **34 test failures**. Each affected file is restored to its last known-green committed version (biased toward the original merged PR, verified by reading both conflict sides). The root-cause dispatch bug was already fixed in #15914; this PR cleans up the duplicate commits that had already landed but were never part of round-1's reconciliation (#15910), which itself left three workflow files with YAML damage. Methodology matches #15910: one implementation per behavior, delete the losers, verify by execution. After this PR, `npm test` returns **619/619 passing**.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/checkbox-diff.js` |
| 2 | `scripts/auto-resolve-mechanical-conflicts.js` |
| 3 | `scripts/octopus-review-fallback.js` |
| 4 | `scripts/daily-diagnostic-audit.js` |
| 5 | `.github/workflows/issue-state-machine.yml` |
| 6 | `.github/workflows/wr-auto-classify.yml` |
| 7 | `.github/workflows/saml-sso-registration.yml` |
| 8 | `.github/workflows/daily-diagnostic-audit.yml` |
| 9 | `tests/checkbox-diff.test.js` |
| 10 | `tests/auto-resolve-mechanical-conflicts.test.js` |
| 11 | `tests/octopus-review-fallback.test.js` |
| 12 | `tests/work-request-form-sync.test.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores workflows and scripts after a third OpenRouter interleave incident, removing duplicate/garbled changes and making main green again (619/619 tests). Tightens WR auto-classify logic and expands sync checks to prevent drift.

- **Bug Fixes**
  - Workflows: cleaned duplicate keys and spliced YAML in `issue-state-machine.yml` and `wr-auto-classify.yml`; reverted `saml-sso-registration.yml` to the stable inline GraphQL path and simplified conditions; clarified the scope and bounds in `daily-diagnostic-audit.yml`. All YAML validates and is duplicate-key free.
  - Scripts: restored canonical versions of `octopus-review-fallback.js` (keeps rate-limit classification and retry), `auto-resolve-mechanical-conflicts.js` (correct exit-code contract), `daily-diagnostic-audit.js` (restores exports and bounded scan), and `checkbox-diff.js` (follow-up detection with small helper exports).
  - Tests: repaired and aligned `octopus-review-fallback.test.js`, `checkbox-diff.test.js`, and `auto-resolve-mechanical-conflicts.test.js`; expanded `work-request-form-sync.test.js` to enforce template dropdowns match the classifier.  
  - Outcome: `npm test` passes 619/619; main is green. Upstream dispatch guard remains in place to prevent a repeat.

<sup>Written for commit 304a23746715d42b553283a55fcdee76b71cd601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

