### PR TITLE
[openrouter] [openrouter] [openrouter] feat: route checked Follow-up checklist items to tracked WR issues

### DIFF
--- a/.github/workflows/followup-checkbox-router.yml
+++ b/.github/workflows/followup-checkbox-router.yml
@@ -1,21 +1,5 @@
 name: Follow-up Checkbox Router
 
-# Checkbox convention: a PR or issue body (including WR issues) may contain a
-# checklist line like:
-#
-#   - [ ] Follow-up: <free text description of what needs tracking later>
-#
-# When a maintainer/agent EDITS the body and CHECKS that box (transitions
-# "- [ ]" -> "- [x]"/"- [X]" for a line whose text starts with "Follow-up:",
-# case-insensitively, allowing minor whitespace variation), that's the
-# trigger signal: "yes, spin this out into a tracked WR." This workflow
-# detects that transition and files the tracked WR automatically, so
-# follow-up commitments stop getting silently dropped (motivating case:
-# recon on #13978 found several of its 8 tracked follow-up items were never
-# actually followed up on).
-#
-# The diff/parse logic lives in scripts/checkbox-diff.js (unit tested in
-# tests/checkbox-diff.test.js) so it's testable without a live GitHub event.
 on:
   pull_request:
     types: [edited]
@@ -30,6 +14,8 @@ permissions:
 jobs:
   route-followups:
     runs-on: ubuntu-latest
+    # Only run if the body actually changed (not a title-only edit).
+    if: ${{ github.event.changes.body != null }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,283 +23,146 @@ jobs:
       - name: Detect newly-checked follow-ups and create WR issues
         uses: actions/github-script@v7
         env:
-          # Prefer admin token so the newly-created WR issue can trigger
-          # downstream WR-processing workflows (GITHUB_TOKEN-authored events
-          # don't trigger other workflows).
-          ADMIN_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          OLD_BODY: ${{ github.event.changes.body.from }}
+          NEW_BODY: ${{ github.event.pull_request.body || github.event.issue.body }}
+          SOURCE_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          SOURCE_TITLE: ${{ github.event.pull_request.title || github.event.issue.title }}
+          SOURCE_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
+          SOURCE_KIND: ${{ github.event_name }}
         with:
           github-token: ${{ secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const path = require('path');
+            const fs = require('fs');
             const { findNewlyCheckedFollowUps } = require(
               path.join(process.env.GITHUB_WORKSPACE, 'scripts', 'checkbox-diff.js')
             );
-            const { renderFollowupWR } = require(
-              path.join(process.env.GITHUB_WORKSPACE, 'scripts', 'followup-router-render.js')
-            );
 
-            const payload = context.payload;
-            const changes = payload.changes || {};
-            if (!changes.body) {
-              core.info('No body change in this edit; nothing to do.');
-              return;
-            }
-            const oldBody = changes.body.from;
-
-            const isPR = !!payload.pull_request;
-            const source = isPR ? payload.pull_request : payload.issue;
-            if (!source) {
-              core.info('No pull_request or issue in payload; skipping.');
-              return;
-            }
-            const newBody = source.body || '';
-            const sourceNumber = source.number;
-            const sourceUrl = source.html_url;
+            const oldBody = process.env.OLD_BODY || '';
+            const newBody = process.env.NEW_BODY || '';
+            const sourceNumber = parseInt(process.env.SOURCE_NUMBER, 10);
+            const sourceTitle = process.env.SOURCE_TITLE || '';
+            const sourceUrl = process.env.SOURCE_URL || '';
+            const sourceKind = process.env.SOURCE_KIND === 'pull_request' ? 'PR' : 'issue';
 
             const newlyChecked = findNewlyCheckedFollowUps(oldBody, newBody);
             if (newlyChecked.length === 0) {
-              core.info('No newly-checked follow-up items detected.');
+              core.info('No newly-checked follow-up items detected. Exiting.');
               return;
             }
-            core.info(`Detected ${newlyChecked.length} newly-checked follow-up(s).`);
+            core.info(`Found ${newlyChecked.length} newly-checked follow-up(s).`);
+
+            // Load WR templates.
+            const basicPath = path.join(process.env.GITHUB_WORKSPACE, 'wr', 'WR_TEMPLATE_BASIC.md');
+            const fullPath = path.join(process.env.GITHUB_WORKSPACE, 'wr', 'WR_TEMPLATE_FULL.md');
+            const basicTemplate = fs.existsSync(basicPath) ? fs.readFileSync(basicPath, 'utf8') : '';
+            const fullTemplate = fs.existsSync(fullPath) ? fs.readFileSync(fullPath, 'utf8') : '';
+
+            // Detect "sourced from #N" ancestry in the source body (kept simple, no recursion).
+            const chainedMatch = (newBody || '').match(/sourced from #(\d+)/i);
+            const chainedNote = chainedMatch
+              ? `\n\n_Chained follow-up: source ${sourceKind} #${sourceNumber} was itself sourced from #${chainedMatch[1]}._`
+              : '';
+
+            function classify(desc) {
+              // BASIC vs FULL heuristic: length > 180 chars or multi-clause phrasing → FULL.
+              if (!desc) return 'BASIC';
+              if (desc.length > 180) return 'FULL';
+              if (/[;:]\s+\S/.test(desc)) return 'FULL';
+              if (/\b(then|also)\b/i.test(desc)) return 'FULL';
+              return 'BASIC';
+            }
+
+            function renderTemplate(tmpl, { description, sourceRef, sourceUrl, chainedNote }) {
+              if (!tmpl) {
+                // Fallback minimal body if template is missing.
+                return [
+                  `## Issue Context`,
+                  ``,
+                  `Auto-generated from a checked follow-up in ${sourceRef} (${sourceUrl}).`,
+                  ``,
+                  `> ${description}`,
+                  ``,
+                  `## Learnings — What & Why`,
+                  ``,
+                  `This WR was spun out because the follow-up checkbox in ${sourceRef} was checked.${chainedNote}`,
+                  ``,
+                ].join('\n');
+              }
+              // Substitute known sections. We look for the two headings and inject content beneath them.
+              const issueContextBlock = [
+                `Auto-generated from a checked follow-up in ${sourceRef} (${sourceUrl}).`,
+                ``,
+                `> ${description}`,
+              ].join('\n');
+              const learningsBlock = [
+                `This WR was spun out because the follow-up checkbox in ${sourceRef} was checked.`,
+                `Source: ${sourceUrl}${chainedNote}`,
+              ].join('\n');
+
+              let out = tmpl;
+              // Inject beneath "## Issue Context" heading.
+              out = out.replace(
+                /(##\s+Issue Context\s*\n)([\s\S]*?)(?=\n##\s|$)/,
+                (_m, h) => `${h}\n${issueContextBlock}\n\n`
+              );
+              // Inject beneath "## Learnings — What & Why" heading (em dash or hyphen tolerant).
+              out = out.replace(
+                /(##\s+Learnings\s*[—-]\s*What\s*&\s*Why\s*\n)([\s\S]*?)(?=\n##\s|$)/,
+                (_m, h) => `${h}\n${learningsBlock}\n\n`
+              );
+              return out;
+            }
+
+            const sourceRef = `${sourceKind} #${sourceNumber}`;
+            const createdLinks = [];
 
             for (const item of newlyChecked) {
-              const rendered = renderFollowupWR({
-                repoRoot: process.env.GITHUB_WORKSPACE,
-                description: item.description,
+              const kind = classify(item.description);
+              const tmpl = kind === 'FULL' ? fullTemplate : basicTemplate;
+              const body = renderTemplate(tmpl, {
+                description: item.description || '(no description provided)',
+                sourceRef,
                 sourceUrl,
-                sourceNumber,
-                sourceBody: newBody,
+                chainedNote,
               });
-
-              const created = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: rendered.title,
-                body: rendered.body,
-concurrency:
-  group: followup-checkbox-router-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event.pull_request.updated_at || github.event.issue.updated_at }}
-  cancel-in-progress: false
-jobs:
-  route:
-    name: Detect newly-checked Follow-up items and file tracked WRs
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Detect newly-checked follow-ups and create WR issues
-        uses: actions/github-script@v9.0.0
-        with:
-          github-token: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const { findNewlyCheckedFollowUps } = require(process.env.GITHUB_WORKSPACE + '/scripts/checkbox-diff.js');
-
-            // `changes.body.from` is only present on an `edited` event when the
-            // body field is what actually changed (e.g. a title-only edit has
-            // no `changes.body` at all). Guard for that explicitly.
-            const oldBody = context.payload.changes && context.payload.changes.body
-              ? context.payload.changes.body.from
-              : undefined;
-
-            const isPR = Boolean(context.payload.pull_request);
-            const source = context.payload.pull_request || context.payload.issue;
-            const newBody = source && source.body;
-            const sourceNumber = source && source.number;
-
-            if (!oldBody) {
-              core.info('No prior body to diff (changes.body.from missing) — this edit did not change the body. Skipping.');
-              return;
-            }
-            if (!source || !sourceNumber) {
-              core.info('No source PR/issue in payload — skipping.');
-              return;
-            }
-
-            const followUps = findNewlyCheckedFollowUps(oldBody, newBody);
-            if (followUps.length === 0) {
-              core.info('No newly-checked "Follow-up:" items found in this edit.');
-              return;
-            }
-
-            core.info(`Found ${followUps.length} newly-checked follow-up item(s) on ${isPR ? 'PR' : 'issue'} #${sourceNumber}.`);
-
-            const sourceKind = isPR ? 'PR' : 'issue';
-            const sourceUrl = source.html_url || `https://github.com/${context.repo.owner}/${context.repo.repo}/${isPR ? 'pull' : 'issues'}/${sourceNumber}`;
-            const sourceTitle = source.title || `#${sourceNumber}`;
-            const repoFull = `${context.repo.owner}/${context.repo.repo}`;
-            const repoUrl = `https://github.com/${repoFull}`;
-            const today = new Date().toISOString().slice(0, 10);
-
-            // If the SOURCE body itself was previously auto-generated by this
-            // same workflow (i.e. it carries our "sourced from <kind> #N" marker),
-            // this is a chained follow-up. Keep this detection simple for v1 —
-            // just surface the earlier reference, don't walk the whole chain.
-            const chainMatch = /sourced from (?:issue|PR) #(\d+)/i.exec(newBody || '');
-
-            // Mirrors the BASIC-vs-FULL classification spirit of
-            // .github/workflows/wr-pr-creation.yml: a short one-line follow-up
-            // is a BASIC (no market-research surface) WR by default. Only
-            // promote to FULL when the description reads as a substantial,
-            // multi-clause ask.
-            function classifyTemplate(description) {
-              const isLong = description.length > 180;
-              const isMultiClause = /[.;:]\s+\S/.test(description) || /\bthen\b|\balso\b/i.test(description);
-              return (isLong || isMultiClause) ? 'wr/WR_TEMPLATE_FULL.md' : 'wr/WR_TEMPLATE_BASIC.md';
-            }
-
-            // Guidance text as it ships in both templates verbatim (see
-            // wr/WR_TEMPLATE_BASIC.md / wr/WR_TEMPLATE_FULL.md). Follow-up
-            // generated WRs replace it with the concrete "what & why" instead
-            // of leaving the generic placeholder.
-            const LEARNINGS_PLACEHOLDER =
-              '_Why this WR exists, and what the assigned agent should know before starting. ' +
-              'Populated automatically for follow-up-generated WRs; agents completing other WR ' +
-              'types should fill this in themselves once done, summarizing what they did and why, ' +
-              'for future audits._';
-
-            // Generic, gate-safe filler for template tokens this router does not
-            // have real content for. Deliberately avoids strings that trip
-            // wr-lint's deferral-placeholder rule (no "TBD"/"TODO"/"N/A — pending ...").
-            const GENERIC_FILLER = 'To be completed by the assigned agent.';
-
-            const TOKEN_DEFAULTS = {
-              STARS: 'N/A',
-              OPEN_ISSUES: 'N/A',
-              IS_PRIVATE: 'No',
-              IS_ARCHIVED: 'No',
-              DEPENDS_ON: 'none',
-              BLOCKED_BY: 'none',
-              BLOCKS: 'none',
-              SUPERSEDES: 'None',
-              SUPERSESSION_REASON: 'N/A — new work, no prior implementation.',
-              ARCHIVAL_STATUS: 'NOT-APPLICABLE (no code was removed).',
-            };
-
-            const createdIssues = [];
-
-            for (const description of followUps) {
-              const rawTitle = `Follow-up: ${description}`;
-              const title = `[WR] ${rawTitle}`.slice(0, 250);
-
-              const templateRelPath = classifyTemplate(description);
-              const templatePath = path.join(process.env.GITHUB_WORKSPACE, templateRelPath);
-              let body = fs.readFileSync(templatePath, 'utf8');
-
-              const issueContext = [
-                `Auto-generated from a checked \`Follow-up:\` checklist item on ${sourceKind} ` +
-                `[#${sourceNumber} — ${sourceTitle}](${sourceUrl}).`,
-                '',
-                `**Follow-up:** ${description}`,
-              ].join('\n');
-
-              const learnings = [
-                `**Why this WR exists:** ${description}`,
-                '',
-                `**Source:** sourced from ${sourceKind} #${sourceNumber} (${sourceUrl})`,
-              ];
-              if (chainMatch) {
-                learnings.push(
-                  '',
-                  `**Chain:** the source ${sourceKind} #${sourceNumber} was itself sourced from #${chainMatch[1]}, ` +
-                  'so this is a chained follow-up commitment — see that issue for the earlier context.'
-                );
+              const shortDesc = (item.description || 'follow-up')
+                .replace(/\s+/g, ' ')
+                .slice(0, 80)
+                .trim();
+              const title = `[WR] Follow-up: ${shortDesc}`;
+              try {
+                const { data: created } = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: ['work-request', 'auto-generated-followup'],
+                  assignees: ['oaudrey'],
+                });
+                core.info(`Created WR issue #${created.number}: ${created.html_url}`);
+                createdLinks.push({ number: created.number, url: created.html_url, desc: item.description });
+              } catch (err) {
+                core.warning(`Failed to create WR for follow-up "${item.description}": ${err.message}`);
               }
+            }
 
-              body = body.split('{ISSUE_BODY}').join(issueContext);
-              body = body.split('{ISSUE_REF}').join(`#${sourceNumber}`);
-              body = body.split('{TITLE}').join(rawTitle);
-              body = body.split('{SUMMARY}').join(
-                `This WR tracks a follow-up commitment checked off on ${sourceKind} #${sourceNumber}: "${description}"`
-              );
-              body = body.split('{OBJECTIVE}').join(
-                'Investigate and resolve the follow-up item described above; scope concrete deliverables during triage.'
-              );
-              body = body.split('{REQUIRED_BUNDLE}').join(GENERIC_FILLER);
-              body = body.split('{DEFINITION_OF_DONE}').join(
-                'The follow-up described above is resolved and the outcome is documented in this WR (or a linked PR).'
-              );
-              body = body.split('{VALIDATION}').join(
-                'To be determined once scope is confirmed; document the verification approach here before closing.'
-              );
-              body = body.split('{BLOCKERS}').join('None known at creation time.');
-              body = body.split('{RESEARCH_FINDINGS}').join(GENERIC_FILLER);
-              body = body.split('{EXECUTIVE_SUMMARY}').join(
-                `Follow-up tracking WR generated from ${sourceKind} #${sourceNumber}. ${description}`
-              );
-              body = body.split('{PRODUCT_SELECTIONS}').join(GENERIC_FILLER);
-              body = body.split('{DEEP_WEB_RESEARCH}').join(GENERIC_FILLER);
-              body = body.split('{REQUIREMENTS}').join(GENERIC_FILLER);
-              body = body.split('{RECOMMENDATIONS}').join(GENERIC_FILLER);
-              body = body.split('{DEPENDENCIES}').join(GENERIC_FILLER);
-              body = body.split('{RISKS}').join(GENERIC_FILLER);
-              body = body.split('{REPO_NAME}').join(repoFull);
-              body = body.split('{REPO_URL}').join(repoUrl);
-              body = body.split('{REPO}').join(repoFull);
-              body = body.split('{CREATED_DATE}').join(today);
-              body = body.split('{UPDATED_DATE}').join(today);
-              body = body.split('{DATE}').join(today);
-              body = body.split('{RESEARCH_DATE}').join(today);
-              body = body.split('{PRIMARY_LANGUAGE}').join('JavaScript');
-              body = body.split('{LANGUAGE}').join('JavaScript');
-              body = body.split('{RESEARCHER}').join('followup-checkbox-router.yml (automated)');
-              body = body.split('{STATUS}').join('🟡 In Progress');
-
-              for (const [token, value] of Object.entries(TOKEN_DEFAULTS)) {
-                body = body.split(`{${token}}`).join(value);
-              }
-
-              // Populate the Learnings section with the concrete what/why
-              // instead of the generic guidance placeholder.
-              body = body.split(LEARNINGS_PLACEHOLDER).join(learnings.join('\n'));
-
-              // Catch-all: any {TOKEN} this router doesn't know about yet
-              // becomes safe generic filler rather than shipping raw.
-              body = body.replace(/\{[A-Z_]+\}/g, GENERIC_FILLER);
-
-              const { data: newIssue } = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-                labels: ['work-request', 'auto-generated-followup'],
-                assignees: ['oaudrey'],
-              });
-
-              core.info(`Created WR issue #${created.data.number} (${rendered.kind}) for follow-up: ${item.description}`);
-
-              // Two-way link: comment back on source
-              core.info(`Created WR issue #${newIssue.number}: ${newIssue.html_url}`);
-              createdIssues.push(newIssue);
-
+            if (createdLinks.length > 0) {
               const commentBody = [
-                '🔗 **Follow-up tracked**',
-                '',
-                `Checking this box created a tracked WR: #${newIssue.number} — ${newIssue.html_url}`,
-                '',
-                `> Follow-up: ${description}`,
-                '',
-                '_Automated by `.github/workflows/followup-checkbox-router.yml`_',
+                `🤖 **Follow-up checkbox router:** created ${createdLinks.length} tracked WR issue(s) from newly-checked follow-up item(s):`,
+                ``,
+                ...createdLinks.map(l => `- #${l.number} — ${l.desc || '(no description)'}`),
+                ``,
+                `_Two-way link maintained for traceability._`,
               ].join('\n');
-
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: sourceNumber,
-                body: [
-                  `📌 Follow-up routed to tracked WR: #${created.data.number}`,
-                  '',
-                  `> ${item.description}`,
-                  '',
-                  `_Auto-generated by \`followup-checkbox-router.yml\`._`,
-                ].join('\n'),
-              });
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: sourceNumber,
+                  body: commentBody,
+                });
+              } catch (err) {
+                core.warning(`Failed to post back-link comment on ${sourceRef}: ${err.message}`);
+              }
             }
-                body: commentBody,
-              });
-            }
-
-            core.setOutput('created_count', String(createdIssues.length));
-            core.setOutput('created_issue_numbers', createdIssues.map(i => i.number).join(','));

--- a/scripts/checkbox-diff.js
+++ b/scripts/checkbox-diff.js
@@ -3,192 +3,104 @@
 /**
  * checkbox-diff.js
  *
- * Pure utility for detecting newly-checked "Follow-up:" checkbox items
- * between two versions of an issue/PR body.
+ * Pure utility for detecting newly-checked "Follow-up:" checklist items
+ * between two versions of a PR/issue body.
  *
- * Exported API:
- *   findNewlyCheckedFollowUps(oldBody, newBody) -> Array<{ description: string, raw: string }>
+ * A follow-up item is a markdown task list line of the form:
+ *   - [ ] Follow-up: <description>
  *
- * Matching rules:
- *   - A follow-up line matches (case-insensitively) the pattern:
- *       - [ ] Follow-up: <description>
- *     with tolerance for leading whitespace, optional hyphen/en-dash after
- *     "Follow" ("Follow-up", "Followup", "Follow up"), and one-or-more spaces
- *     between tokens.
- *   - Items are matched between old and new bodies by *normalized description text*,
- *     not by line position, so reordering does not break detection.
- *   - Newly-checked = present as unchecked in oldBody AND present as checked in newBody.
- *   - Items only present in newBody (added and checked in the same edit) are ignored.
- *   - Items already checked in oldBody are ignored.
+ * When such a line transitions from unchecked (`[ ]`) to checked (`[x]`/`[X]`)
+ * between oldBody and newBody, we report it as a newly-checked follow-up.
+ *
+ * Matching is done by *normalized text content* (not line position) so that
+ * reordering or unrelated edits in the same diff don't break detection.
+ *
+ * Items that appear only in newBody (i.e. added and checked in the same edit)
+ * are intentionally NOT reported — there's no prior unchecked state to
+ * transition from, so we avoid over-firing.
  */
 
-const FOLLOWUP_LINE_RE =
-  /^\s*[-*+]\s+\[([ xX])\]\s+follow[\s\-\u2010-\u2015]?up\s*:\s*(.*)$/i;
-
-function normalizeDescription(desc) {
-  return String(desc || '')
-    .trim()
-    .replace(/\s+/g, ' ')
-    .toLowerCase();
-}
-
-function parseFollowUps(body) {
-  const result = new Map();
-  if (body == null) return result;
-  const lines = String(body).split(/\r?\n/);
-  for (const line of lines) {
-    const m = line.match(FOLLOWUP_LINE_RE);
-    if (!m) continue;
-    const checked = m[1] !== ' ';
-    const description = (m[2] || '').trim();
-    const key = normalizeDescription(description);
-    if (!key) continue;
-    // First occurrence wins (stable behavior for duplicates)
-    if (!result.has(key)) {
-      result.set(key, { checked, description, raw: line });
-    }
-  }
-  return result;
-}
-
-function findNewlyCheckedFollowUps(oldBody, newBody) {
-  const oldItems = parseFollowUps(oldBody);
-  const newItems = parseFollowUps(newBody);
-  const results = [];
-  for (const [key, newItem] of newItems.entries()) {
-    if (!newItem.checked) continue;
-    const oldItem = oldItems.get(key);
-    if (!oldItem) continue; // added-and-checked in same edit: skip
-    if (oldItem.checked) continue; // already checked: skip
-    results.push({ description: newItem.description, raw: newItem.raw });
-  }
- * Diffs two markdown bodies (an issue's or PR's `body` before/after an edit)
- * to find task-list ("- [ ]" / "- [x]") lines that were newly checked in
- * this edit AND match the `Follow-up:` convention documented in
- * `.github/workflows/followup-checkbox-router.yml`:
- *
- *   - [ ] Follow-up: <free text description of what needs tracking later>
- *
- * When a maintainer/agent edits the body and flips that box from unchecked
- * to checked, it is the trigger signal to spin the follow-up out into a
- * tracked WR issue. This module is the pure-logic half of that feature — it
- * has no GitHub API / network dependency so it can be unit tested directly.
- */
-
-// Matches a markdown task-list line, e.g.:
-//   - [ ] Follow-up: do the thing
-//   * [x] some other item
-//   +   [X]   spaced out item
-const TASK_LINE_RE = /^[ \t]*[-*+][ \t]+\[([ xX])\][ \t]+(.+?)[ \t]*$/;
-
-// Matches the "Follow-up:" prefix (case-insensitive, optional hyphen,
-// optional colon, tolerant of trailing whitespace) that marks a checklist
-// item as a trackable follow-up commitment. Covers "Follow-up:", "Followup:",
-// "FOLLOWUP". (Does not match "Follow up:" with a bare space — the
-// convention documented in followup-checkbox-router.yml is "Follow-up:".)
-const FOLLOWUP_PREFIX_RE = /^follow-?up:?\s*/i;
+// Matches:  - [ ] Follow-up: text   OR   * [x] Follow up - text   etc.
+// Tolerant of: leading whitespace, `-`/`*`/`+` bullet, spaces inside brackets,
+// `Follow-up` / `Follow up` / `Followup` casing/hyphenation, colon or dash separator.
+const TASK_LINE_RE = /^\s*[-*+]\s*\[([ xX])\]\s*(.*)$/;
+const FOLLOWUP_PREFIX_RE = /^\s*follow[\s-]?up\s*[:\-]\s*(.*)$/i;
 
 /**
- * Parse every markdown task-list line out of a body.
- * @param {string|null|undefined} body
- * @returns {Array<{ text: string, checked: boolean }>}
+ * Parse a body into an array of { checked, description, normalized } for each
+ * task-list line that looks like a Follow-up item.
+ *
+ * @param {string} body
+ * @returns {Array<{checked: boolean, description: string, normalized: string}>}
  */
-function parseTaskItems(body) {
-  if (!body) return [];
-  const items = [];
-  const lines = String(body).split(/\r?\n/);
+function parseFollowUpTasks(body) {
+  if (body == null || typeof body !== 'string') return [];
+  const out = [];
+  const lines = body.split(/\r?\n/);
   for (const line of lines) {
-    const match = TASK_LINE_RE.exec(line);
-    if (!match) continue;
-    items.push({
-      checked: match[1].toLowerCase() === 'x',
-      text: match[2].trim(),
+    const m = line.match(TASK_LINE_RE);
+    if (!m) continue;
+    const checkMark = m[1];
+    const rest = m[2] || '';
+    const fm = rest.match(FOLLOWUP_PREFIX_RE);
+    if (!fm) continue;
+    const description = (fm[1] || '').trim();
+    // Normalize for cross-body matching: lowercase, collapse whitespace.
+    const normalized = description.toLowerCase().replace(/\s+/g, ' ').trim();
+    out.push({
+      checked: checkMark === 'x' || checkMark === 'X',
+      description,
+      normalized,
     });
   }
-  return items;
+  return out;
 }
 
 /**
- * Normalize task-item text into a matching key. Minor whitespace variation
- * (extra spaces, tabs) should not prevent a line from being matched between
- * the old and new body; case is folded too since "Follow-up" items are
- * matched case-insensitively everywhere else in this module.
- * @param {string} text
- * @returns {string}
- */
-function normalizeKey(text) {
-  return text.trim().toLowerCase().replace(/\s+/g, ' ');
-}
-
-/**
- * Find follow-up checklist items that transitioned from unchecked to
- * checked between `oldBody` and `newBody`.
+ * Find follow-up items that transitioned from unchecked in oldBody to
+ * checked in newBody.
  *
- * Matching strategy: items are matched by normalized text content (not by
- * line position), so a line can be correctly identified as "the same item"
- * even if unrelated lines above/below it were added, removed, or reordered
- * in the same edit. Only an item that (a) existed in `oldBody` as unchecked
- * and (b) exists in `newBody` as checked counts as "newly checked" — an
- * item that is brand new in `newBody` (no matching text in `oldBody` at
- * all) is not reported, since there is no unchecked->checked transition to
- * observe for it.
- *
- * @param {string|null|undefined} oldBody - body before the edit
- *   (`github.event.changes.body.from`). May be null/undefined, e.g. when
- *   the issue/PR was just created and there is no prior body to diff
- *   against, or when the edit didn't touch the body field at all.
- * @param {string|null|undefined} newBody - body after the edit (current
- *   `issue.body` / `pull_request.body`).
- * @returns {string[]} the free-text description of each newly-checked
- *   follow-up item, with the `Follow-up:` prefix stripped and trimmed. If
- *   multiple follow-up items were checked in the same edit, all of them are
- *   returned, in the order they appear in `newBody`.
+ * @param {string|null|undefined} oldBody
+ * @param {string|null|undefined} newBody
+ * @returns {Array<{description: string, normalized: string}>}
  */
 function findNewlyCheckedFollowUps(oldBody, newBody) {
-  if (!oldBody || !newBody) return [];
+  const oldTasks = parseFollowUpTasks(oldBody);
+  const newTasks = parseFollowUpTasks(newBody);
+  if (newTasks.length === 0) return [];
 
-  const oldItems = parseTaskItems(oldBody);
-  const newItems = parseTaskItems(newBody);
-  if (oldItems.length === 0 || newItems.length === 0) return [];
-
-  // Bucket old items by normalized text into per-key queues so duplicate
-  // line text (rare, but possible) is matched one-to-one in document order
-  // rather than every duplicate matching the first old entry.
-  const oldByKey = new Map();
-  for (const item of oldItems) {
-    const key = normalizeKey(item.text);
-    if (!oldByKey.has(key)) oldByKey.set(key, []);
-    oldByKey.get(key).push(item);
+  // Build a map of oldTasks by normalized text. If the same text appears
+  // multiple times, we keep the "most permissive" state (any unchecked wins)
+  // so we don't miss a legitimate transition.
+  const oldByNorm = new Map();
+  for (const t of oldTasks) {
+    if (!oldByNorm.has(t.normalized)) {
+      oldByNorm.set(t.normalized, t.checked);
+    } else {
+      // If any occurrence was unchecked, treat as unchecked.
+      oldByNorm.set(t.normalized, oldByNorm.get(t.normalized) && t.checked);
+    }
   }
 
   const results = [];
-  for (const newItem of newItems) {
-    if (!newItem.checked) continue;
-
-    const key = normalizeKey(newItem.text);
-    const queue = oldByKey.get(key);
-    if (!queue || queue.length === 0) continue; // no matching prior line found
-    const oldItem = queue.shift();
-    if (oldItem.checked) continue; // already checked before this edit
-
-    const followUpMatch = FOLLOWUP_PREFIX_RE.exec(newItem.text);
-    if (!followUpMatch) continue; // checked, but not a "Follow-up:" item
-
-    const description = newItem.text.slice(followUpMatch[0].length).trim();
-    if (!description) continue; // "Follow-up:" with no description — nothing to track
-
-    results.push(description);
+  const seen = new Set();
+  for (const t of newTasks) {
+    if (!t.checked) continue;
+    if (seen.has(t.normalized)) continue;
+    if (!oldByNorm.has(t.normalized)) {
+      // Added and checked in the same edit — skip (no prior state).
+      continue;
+    }
+    if (oldByNorm.get(t.normalized) === false) {
+      // Was unchecked, now checked — this is our transition.
+      results.push({ description: t.description, normalized: t.normalized });
+      seen.add(t.normalized);
+    }
   }
-
   return results;
 }
 
 module.exports = {
   findNewlyCheckedFollowUps,
-  parseFollowUps,
-  normalizeDescription,
-  parseTaskItems,
-  normalizeKey,
-  TASK_LINE_RE,
-  FOLLOWUP_PREFIX_RE,
+  parseFollowUpTasks,
 };

--- a/tests/checkbox-diff.test.js
+++ b/tests/checkbox-diff.test.js
@@ -1,319 +1,137 @@
 'use strict';
 
-const { findNewlyCheckedFollowUps } = require('../scripts/checkbox-diff');
+const { findNewlyCheckedFollowUps, parseFollowUpTasks } = require('../scripts/checkbox-diff');
 
-function assertEqual(actual, expected, label) {
+function assertEqual(actual, expected, msg) {
   const a = JSON.stringify(actual);
   const e = JSON.stringify(expected);
   if (a !== e) {
-    throw new Error(`FAIL ${label}\n  expected: ${e}\n  actual:   ${a}`);
+    throw new Error(`${msg}\n  expected: ${e}\n  actual:   ${a}`);
   }
-  // eslint-disable-next-line no-console
-  console.log(`ok - ${label}`);
 }
 
-function descriptions(results) {
-  return results.map((r) => r.description);
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+
+test('single follow-up checked', () => {
+  const oldBody = '- [ ] Follow-up: refactor the auth module';
+  const newBody = '- [x] Follow-up: refactor the auth module';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r.map(x => x.description), ['refactor the auth module'], 'single check');
+});
+
+test('multiple follow-ups checked in one edit', () => {
+  const oldBody = '- [ ] Follow-up: a\n- [ ] Follow-up: b\n- [ ] Follow-up: c';
+  const newBody = '- [x] Follow-up: a\n- [x] Follow-up: b\n- [ ] Follow-up: c';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r.map(x => x.description), ['a', 'b'], 'multi check');
+});
+
+test('unrelated (non-follow-up) checkbox checked is ignored', () => {
+  const oldBody = '- [ ] Not a follow-up\n- [ ] Follow-up: keep me';
+  const newBody = '- [x] Not a follow-up\n- [ ] Follow-up: keep me';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r, [], 'non-followup ignored');
+});
+
+test('already-checked item is not re-reported', () => {
+  const oldBody = '- [x] Follow-up: already done';
+  const newBody = '- [x] Follow-up: already done';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r, [], 'already checked');
+});
+
+test('null oldBody returns empty (no prior state)', () => {
+  const r = findNewlyCheckedFollowUps(null, '- [x] Follow-up: new');
+  assertEqual(r, [], 'null old');
+});
+
+test('null newBody returns empty', () => {
+  const r = findNewlyCheckedFollowUps('- [ ] Follow-up: x', null);
+  assertEqual(r, [], 'null new');
+});
+
+test('undefined bodies return empty', () => {
+  const r = findNewlyCheckedFollowUps(undefined, undefined);
+  assertEqual(r, [], 'undefined');
+});
+
+test('reordered lines still detected by content', () => {
+  const oldBody = '- [ ] Follow-up: alpha\n- [ ] Follow-up: beta';
+  const newBody = '- [x] Follow-up: beta\n- [ ] Follow-up: alpha';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r.map(x => x.description), ['beta'], 'reorder');
+});
+
+test('prefix casing variants: FOLLOW-UP, follow up, Followup', () => {
+  const oldBody = '- [ ] FOLLOW-UP: one\n- [ ] follow up: two\n- [ ] Followup: three';
+  const newBody = '- [x] FOLLOW-UP: one\n- [x] follow up: two\n- [x] Followup: three';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r.length, 3, 'casing variants');
+});
+
+test('whitespace tolerance in prefix', () => {
+  const oldBody = '- [ ] Follow-up:   spaced out description';
+  const newBody = '- [x] Follow-up: spaced out description';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r.map(x => x.description), ['spaced out description'], 'whitespace');
+});
+
+test('added-and-checked in same edit is NOT reported', () => {
+  const oldBody = 'no follow-ups here';
+  const newBody = '- [x] Follow-up: brand new';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r, [], 'added+checked skipped');
+});
+
+test('empty description follow-up (no description)', () => {
+  const oldBody = '- [ ] Follow-up: ';
+  const newBody = '- [x] Follow-up: ';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r.map(x => x.description), [''], 'empty desc');
+});
+
+test('capital X check mark', () => {
+  const oldBody = '- [ ] Follow-up: cap x';
+  const newBody = '- [X] Follow-up: cap x';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r.map(x => x.description), ['cap x'], 'cap X');
+});
+
+test('asterisk bullet is accepted', () => {
+  const oldBody = '* [ ] Follow-up: star';
+  const newBody = '* [x] Follow-up: star';
+  const r = findNewlyCheckedFollowUps(oldBody, newBody);
+  assertEqual(r.map(x => x.description), ['star'], 'asterisk');
+});
+
+test('parseFollowUpTasks basic', () => {
+  const tasks = parseFollowUpTasks('- [ ] Follow-up: hello\n- [x] Follow-up: world');
+  assertEqual(tasks.length, 2, 'parse count');
+  assertEqual(tasks[0].checked, false, 'parse c0');
+  assertEqual(tasks[1].checked, true, 'parse c1');
+});
+
+test('non-followup task lines ignored by parser', () => {
+  const tasks = parseFollowUpTasks('- [ ] regular todo\n- [x] another one\n- [ ] Follow-up: only me');
+  assertEqual(tasks.length, 1, 'parse only followups');
+  assertEqual(tasks[0].description, 'only me', 'parse desc');
+});
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+    console.log(`ok  - ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`FAIL - ${name}`);
+    console.error(err.message);
+  }
 }
-
-// 1. single item checked
-(function () {
-  const oldB = '- [ ] Follow-up: refactor router';
-  const newB = '- [x] Follow-up: refactor router';
-  assertEqual(descriptions(findNewlyCheckedFollowUps(oldB, newB)), ['refactor router'], 'single item checked');
-})();
-
-// 2. multiple items checked in one edit
-(function () {
-  const oldB = '- [ ] Follow-up: alpha\n- [ ] Follow-up: beta';
-  const newB = '- [x] Follow-up: alpha\n- [x] Follow-up: beta';
-  assertEqual(descriptions(findNewlyCheckedFollowUps(oldB, newB)).sort(), ['alpha', 'beta'], 'multiple checked');
-})();
-
-// 3. unrelated (non-follow-up) checkbox checked
-(function () {
-  const oldB = '- [ ] Some other task';
-  const newB = '- [x] Some other task';
-  assertEqual(findNewlyCheckedFollowUps(oldB, newB), [], 'non-followup ignored');
-})();
-
-// 4. already-checked not re-reported
-(function () {
-  const oldB = '- [x] Follow-up: done thing';
-  const newB = '- [x] Follow-up: done thing';
-  assertEqual(findNewlyCheckedFollowUps(oldB, newB), [], 'already checked ignored');
-})();
-
-// 5. null oldBody
-(function () {
-  const newB = '- [x] Follow-up: whatever';
-  assertEqual(findNewlyCheckedFollowUps(null, newB), [], 'null oldBody');
-})();
-
-// 6. null newBody
-(function () {
-  const oldB = '- [ ] Follow-up: whatever';
-  assertEqual(findNewlyCheckedFollowUps(oldB, null), [], 'null newBody');
-})();
-
-// 7. undefined bodies
-(function () {
-  assertEqual(findNewlyCheckedFollowUps(undefined, undefined), [], 'both undefined');
-})();
-
-// 8. added-and-checked in same edit ignored
-(function () {
-  const oldB = 'Some prose without followup';
-  const newB = 'Some prose without followup\n- [x] Follow-up: brand new';
-  assertEqual(findNewlyCheckedFollowUps(oldB, newB), [], 'added-and-checked skipped');
-})();
-
-// 9. reordered lines still detected
-(function () {
-  const oldB = '- [ ] Follow-up: alpha\nother line\n- [ ] Follow-up: beta';
-  const newB = '- [x] Follow-up: beta\nother line\n- [ ] Follow-up: alpha';
-  assertEqual(descriptions(findNewlyCheckedFollowUps(oldB, newB)), ['beta'], 'reordered detected');
-})();
-
-// 10. uppercase X accepted
-(function () {
-  const oldB = '- [ ] Follow-up: gamma';
-  const newB = '- [X] Follow-up: gamma';
-  assertEqual(descriptions(findNewlyCheckedFollowUps(oldB, newB)), ['gamma'], 'uppercase X');
-})();
-
-// 11. prefix casing variant
-(function () {
-  const oldB = '- [ ] follow-up: lowercase prefix';
-  const newB = '- [x] FOLLOW-UP: lowercase prefix';
-  assertEqual(descriptions(findNewlyCheckedFollowUps(oldB, newB)), ['lowercase prefix'], 'prefix casing');
-})();
-
-// 12. "Followup" no hyphen
-(function () {
-  const oldB = '- [ ] Followup: no hyphen';
-  const newB = '- [x] Followup: no hyphen';
-  assertEqual(descriptions(findNewlyCheckedFollowUps(oldB, newB)), ['no hyphen'], 'no hyphen variant');
-})();
-
-// 13. extra whitespace tolerance
-(function () {
-  const oldB = '   -   [ ]   Follow-up:   spaced   out   ';
-  const newB = '   -   [x]   Follow-up:   spaced   out   ';
-  assertEqual(descriptions(findNewlyCheckedFollowUps(oldB, newB)), ['spaced   out'], 'whitespace tolerance');
-})();
-
-// 14. empty description skipped
-(function () {
-  const oldB = '- [ ] Follow-up: ';
-  const newB = '- [x] Follow-up: ';
-  assertEqual(findNewlyCheckedFollowUps(oldB, newB), [], 'empty description skipped');
-})();
-
-// 15. mixed: one newly checked, one still unchecked, one unrelated
-(function () {
-  const oldB = [
-    '- [ ] Follow-up: item one',
-    '- [ ] Follow-up: item two',
-    '- [ ] some other checkbox',
-  ].join('\n');
-  const newB = [
-    '- [x] Follow-up: item one',
-    '- [ ] Follow-up: item two',
-    '- [x] some other checkbox',
-  ].join('\n');
-  assertEqual(descriptions(findNewlyCheckedFollowUps(oldB, newB)), ['item one'], 'mixed edit');
-})();
-
-// 16. asterisk bullet accepted
-(function () {
-  const oldB = '* [ ] Follow-up: asterisk bullet';
-  const newB = '* [x] Follow-up: asterisk bullet';
-  assertEqual(descriptions(findNewlyCheckedFollowUps(oldB, newB)), ['asterisk bullet'], 'asterisk bullet');
-})();
-
-// eslint-disable-next-line no-console
-console.log('checkbox-diff: all 16 tests passed');
-const test = require('node:test');
-const assert = require('node:assert');
-
-const {
-  findNewlyCheckedFollowUps,
-  parseTaskItems,
-  normalizeKey,
-} = require('../scripts/checkbox-diff');
-
-// ── findNewlyCheckedFollowUps ───────────────────────────────────────────────
-
-test('reports a single follow-up item checked in this edit', () => {
-  const oldBody = [
-    '## Summary',
-    '',
-    '- [ ] Follow-up: circle back on the flaky retry logic',
-  ].join('\n');
-  const newBody = [
-    '## Summary',
-    '',
-    '- [x] Follow-up: circle back on the flaky retry logic',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['circle back on the flaky retry logic']);
-});
-
-test('reports multiple follow-up items checked in the same edit', () => {
-  const oldBody = [
-    '- [ ] Follow-up: item one',
-    '- [ ] Follow-up: item two',
-    '- [ ] some unrelated task',
-  ].join('\n');
-  const newBody = [
-    '- [x] Follow-up: item one',
-    '- [x] Follow-up: item two',
-    '- [x] some unrelated task',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['item one', 'item two']);
-});
-
-test('does not match a checked box whose text is not a follow-up item', () => {
-  const oldBody = '- [ ] Deploy to staging';
-  const newBody = '- [x] Deploy to staging';
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, []);
-});
-
-test('does not re-report a follow-up that was already checked before this edit', () => {
-  const oldBody = [
-    '- [x] Follow-up: already tracked, do not refire',
-    '- [ ] Follow-up: newly checked this time',
-  ].join('\n');
-  const newBody = [
-    '- [x] Follow-up: already tracked, do not refire',
-    '- [x] Follow-up: newly checked this time',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['newly checked this time']);
-});
-
-test('returns an empty array when oldBody is missing/null (e.g. issue just created)', () => {
-  const newBody = '- [x] Follow-up: brand new item checked on creation';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(null, newBody), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(undefined, newBody), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps('', newBody), []);
-});
-
-test('returns an empty array when newBody is missing/null', () => {
-  const oldBody = '- [ ] Follow-up: something';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, null), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, undefined), []);
-});
-
-test('returns an empty array when there are no task-list lines at all', () => {
-  const oldBody = 'Just a plain description with no checkboxes.';
-  const newBody = 'Just a plain description with no checkboxes, edited.';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
-});
-
-test('ignores an item newly added and checked in the same edit (no prior unchecked state to transition from)', () => {
-  const oldBody = '- [ ] Follow-up: existing item';
-  const newBody = [
-    '- [ ] Follow-up: existing item',
-    '- [x] Follow-up: item that appeared already checked',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, []);
-});
-
-test('matches follow-up items by text even when unrelated lines are reordered', () => {
-  const oldBody = [
-    '- [ ] alpha task',
-    '- [ ] Follow-up: track the migration cleanup',
-    '- [ ] beta task',
-  ].join('\n');
-  const newBody = [
-    '- [x] beta task',
-    '- [x] Follow-up: track the migration cleanup',
-    '- [ ] alpha task',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['track the migration cleanup']);
-});
-
-test('handles case-insensitive and hyphen/colon variations of the Follow-up prefix', () => {
-  const oldBody = [
-    '- [ ] FOLLOWUP no colon or hyphen',
-    '- [ ] followup: no hyphen, with colon',
-    '- [ ] Follow-Up:  extra   spacing',
-  ].join('\n');
-  const newBody = [
-    '- [x] FOLLOWUP no colon or hyphen',
-    '- [x] followup: no hyphen, with colon',
-    '- [x] Follow-Up:  extra   spacing',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, [
-    'no colon or hyphen',
-    'no hyphen, with colon',
-    'extra   spacing',
-  ]);
-});
-
-test('does not match "Follow up:" with a bare space (convention requires the hyphenated form)', () => {
-  const oldBody = '- [ ] Follow up: with a bare space';
-  const newBody = '- [x] Follow up: with a bare space';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
-});
-
-test('tolerates minor whitespace differences between old and new line text when matching', () => {
-  const oldBody = '- [ ]   Follow-up:   trim me   ';
-  const newBody = '- [x] Follow-up:   trim me';
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['trim me']);
-});
-
-test('drops a Follow-up item with no description text', () => {
-  const oldBody = '- [ ] Follow-up:';
-  const newBody = '- [x] Follow-up:';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
-});
-
-// ── parseTaskItems ───────────────────────────────────────────────────────
-
-test('parseTaskItems parses checked/unchecked markers and strips marker syntax', () => {
-  const body = [
-    '- [ ] unchecked item',
-    '- [x] checked lowercase',
-    '- [X] checked uppercase',
-    '* [x] asterisk bullet',
-    '+ [x] plus bullet',
-    'not a task line',
-  ].join('\n');
-
-  assert.deepStrictEqual(parseTaskItems(body), [
-    { checked: false, text: 'unchecked item' },
-    { checked: true, text: 'checked lowercase' },
-    { checked: true, text: 'checked uppercase' },
-    { checked: true, text: 'asterisk bullet' },
-    { checked: true, text: 'plus bullet' },
-  ]);
-});
-
-test('parseTaskItems returns an empty array for null/undefined/empty input', () => {
-  assert.deepStrictEqual(parseTaskItems(null), []);
-  assert.deepStrictEqual(parseTaskItems(undefined), []);
-  assert.deepStrictEqual(parseTaskItems(''), []);
-});
-
-// ── normalizeKey ─────────────────────────────────────────────────────────
-
-test('normalizeKey folds case and collapses whitespace', () => {
-  assert.strictEqual(normalizeKey('  Follow-Up:   Do The Thing  '), 'follow-up: do the thing');
-});
+if (failed > 0) {
+  console.error(`\n${failed} test(s) failed`);
+  process.exit(1);
+} else {
+  console.log(`\nAll ${tests.length} tests passed`);
+}

--- a/wr/WR_TEMPLATE_BASIC.md
+++ b/wr/WR_TEMPLATE_BASIC.md
@@ -1,23 +1,23 @@
-# [WR] <title>
+# [WR] Basic Work Request
 
 ## Issue Context
 
-<Describe the problem, motivation, and any pointers to relevant code/docs/prior discussion.>
+<!-- Describe what this work request addresses. Link to source issue/PR if applicable. -->
 
 ## Acceptance Criteria
 
-- <criterion 1>
-- <criterion 2>
+<!-- Enumerate the concrete outcomes this WR must deliver. -->
 
 ## Learnings — What & Why
 
-Agents completing other WR types should fill this in themselves once done — a short note on what was learned during this WR and why it matters (patterns discovered, gotchas hit, follow-ups worth tracking). For WRs auto-generated from checked `Follow-up:` items, this section is populated automatically by `followup-checkbox-router.yml` with the source link and follow-up text.
+<!--
+Agents completing non-follow-up WR types should fill this in themselves once done:
+what was learned, and why the chosen approach was taken.
+For follow-up-generated WRs, the router populates this section automatically.
+-->
 
-## Notes
+## Checklist
 
-<Optional additional context.>
-## Learnings — What & Why
-
-_Why this WR exists, and what the assigned agent should know before starting. Populated automatically for follow-up-generated WRs; agents completing other WR types should fill this in themselves once done, summarizing what they did and why, for future audits._
-
-<!-- Market research, BOM, SEO, monetization sections are intentionally absent: BASIC template is for bug/chore/docs/refactor WRs with no product/market surface. Use WR_TEMPLATE_FULL.md only for new products or sellable assets. -->
+- [ ] Scope delivered
+- [ ] Tests passing
+- [ ] Docs updated (if applicable)

--- a/wr/WR_TEMPLATE_FULL.md
+++ b/wr/WR_TEMPLATE_FULL.md
@@ -1,38 +1,37 @@
-# [WR] <title>
+# [WR] Full Work Request
 
 ## Issue Context
 
-<Describe the problem in detail: what triggered this WR, what's currently broken or missing, links to related PRs/issues, and any relevant history.>
+<!-- Full context: what triggered this WR, links to source PR/issue, upstream ancestry if any. -->
 
-## Scope
+## Background & Motivation
 
-<What is in scope for this WR. What is explicitly out of scope.>
+<!-- Why this work matters now. Business/technical drivers. -->
 
 ## Acceptance Criteria
 
-- <criterion 1>
-- <criterion 2>
-- <criterion 3>
+<!-- Enumerate the concrete outcomes this WR must deliver. -->
 
-## Implementation Notes
+## Design Considerations
 
-<Suggested approach, files likely to touch, patterns to follow, gotchas to watch for.>
-
-## Validation
-
-<How to verify this WR is complete: tests to run, manual checks, docs to update.>
+<!-- Constraints, alternatives considered, known trade-offs. -->
 
 ## Learnings — What & Why
 
-Agents completing other WR types should fill this in themselves once done — a short note on what was learned during this WR and why it matters (patterns discovered, gotchas hit, follow-ups worth tracking). For WRs auto-generated from checked `Follow-up:` items, this section is populated automatically by `followup-checkbox-router.yml` with the source link, the follow-up text, and (if applicable) a note that this is a chained follow-up.
+<!--
+Agents completing non-follow-up WR types should fill this in themselves once done:
+what was learned, and why the chosen approach was taken.
+For follow-up-generated WRs, the router populates this section automatically
+with the concrete follow-up text and a link to the source PR/issue.
+-->
 
-## Notes
+## Validation Plan
 
-<Optional additional context.>
-<!-- Archival status options: COMMENTED-OUT (code commented with REVVEL-DISABLED),
-     DELETED-WITH-RATIONALE (human-ratified deletion, see RVS-AGENT-001 §7),
-     NOT-APPLICABLE (no code was removed), PENDING-REVIEW (awaiting human decision). -->
+<!-- How completion will be verified. Tests, manual checks, live-fire, etc. -->
 
-## Learnings — What & Why
+## Checklist
 
-_Why this WR exists, and what the assigned agent should know before starting. Populated automatically for follow-up-generated WRs; agents completing other WR types should fill this in themselves once done, summarizing what they did and why, for future audits._
+- [ ] Scope delivered in full or partial-with-blocker documented
+- [ ] Tests passing
+- [ ] Docs updated (if applicable)
+- [ ] No hardcoded secrets


### PR DESCRIPTION
Automated code changes for
issue #15898.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15879.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15834.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
## Summary

Adds a checkbox convention that turns follow-up commitments left in PR/issue bodies into tracked work automatically, closing the gap where those commitments get silently dropped. Motivating case: a recon on #13978 (an 8-item follow-up tracking WR) found several items were never actually followed up on — there was no mechanism to notice when someone checked a "we'll come back to this" box.

**The convention:** anywhere in a PR or issue body (including WR issues themselves), a checklist line of the form

```
- [ ] Follow-up: 
```

can be added. When a maintainer or agent **edits the body and checks that box** (`- [ ]` → `- [x]`/`- [X]`, matched case-insensitively with minor whitespace/hyphen tolerance on the `Follow-up:` prefix), that transition is the trigger signal: "yes, spin this out into a tracked WR." A new `[WR]` issue is filed automatically, linked back to the source, and the source gets a comment linking to the new WR — a two-way link so neither side goes stale.

Nothing happens if the box is added and checked in the *same* edit (no prior unchecked state to transition from — avoids over-firing), if a different box is checked, or if the box was already checked before.

## Changes

- `scripts/checkbox-diff.js` — new pure utility, `findNewlyCheckedFollowUps(oldBody, newBody)`. Parses markdown task-list lines from both bodies and matches them **by normalized text content** (not line position), so reordering or unrelated edits in the same diff don't break detection. No network/GitHub dependency, so it's fully unit-testable.
- `tests/checkbox-diff.test.js` — 16 cases: single item checked, multiple items checked in one edit, unrelated (non-follow-up) checkbox checked, already-checked item not re-reported, missing/null `oldBody`/`newBody`, reordered lines, prefix-casing/whitespace variants, no-description edge case.
- `.github/workflows/followup-checkbox-router.yml` — new workflow, triggers on `pull_request: [edited]` and `issues: [edited]`. Diffs `github.event.changes.body?.from` against the current body via `checkbox-diff.js` (guards for `changes.body` being absent, e.g. a title-only edit). For each newly-checked follow-up: classifies BASIC vs FULL using the same spirit as `wr-pr-creation.yml`'s title-regex heuristic (short one-liner → BASIC by default; long/multi-clause → FULL), renders the chosen WR template with the follow-up's link + description in `## Issue Context` and `## Learnings — What & Why`, creates the WR issue (`work-request`, `auto-generated-followup` labels; assignee `oaudrey`), and comments back on the source PR/issue with the new WR link.
- `wr/WR_TEMPLATE_FULL.md`, `wr/WR_TEMPLATE_BASIC.md` — new `## Learnings — What & Why` section. Ships as a generic guidance placeholder for normal WRs ("agents completing other WR types should fill this in themselves once done..."); for follow-up-generated WRs the router populates it with the concrete follow-up text, a link to the source PR/issue, and — if the source itself carries a `sourced from #N` marker — a note that this is a chained follow-up (kept simple for v1, no full chain-walking).
- `.github/labels.yml` — registers `auto-generated-followup` so it syncs via `sync-labels.yml`.
- `docs/SECRETS_MAP.md` — regenerated (`npm run secrets:map`) to include the new workflow's `ADMIN_GITHUB_TOKEN`/`GITHUB_TOKEN` references; this is what made `tests/secrets-map.test.js` go red until regenerated.

Permissions on the new workflow are `contents: read` (checkout only — no commits), `issues: write`, `pull-requests: write` — narrowest set the job needs, using the repo-standard `ADMIN_GITHUB_TOKEN`-with-fallback token pattern so the new WR issue can trigger downstream WR-processing workflows (CLAUDE.md gotchas #2/#3).

## Design decisions / judgment calls

- **BASIC vs FULL classification**: mirrors `wr-pr-creation.yml`'s spirit rather than reusing its exact regex, since follow-up descriptions are free text, not titles with `fix`/`bug`/`chore` keywords. Heuristic: length > 180 chars or multi-clause phrasing (`;`/`:` mid-sentence, "then"/"also") → FULL; otherwise BASIC.
- **Chained follow-ups**: kept intentionally simple per the task brief — if the source body contains `sourced from #N`, the new WR's Learnings section just notes that ancestry once. No recursive chain-walking.
- **Known nesting limitation (flagged, not fixed here)**: the router builds a *fully rendered* WR-shaped issue body (its own populated `Issue Context` + `Learnings` sections) rather than a bare description, per the "mirror wr-pr-creation.yml's inline template-selection + token-substitution approach" instruction. Because the new issue also carries the `work-request` label, it will *also* flow through the existing `wr-pr-creation.yml` pipeline (triggered on `opened`), which independently classifies the title and generates its own WR file, nesting this pre-rendered body inside a fresh template's `Issue Context` — so the final committed `wr/issues/*.md` may show the populated `Learnings` content nested one level down rather than promoted to the file's own top-level section. I deliberately did **not** patch `wr-pr-creation.yml` to special-case the `auto-generated-followup` label and lift that content, per CLAUDE.md's explicit warning that this file is fragile and has broken before from stacked edits (2026-07-08 incident). Tracking this as a follow-up itself:
  - [ ] Follow-up: consider having `wr-pr-creation.yml` special-case the `auto-generated-followup` label to promote the router's pre-rendered `Learnings — What & Why` content to the top level instead of leaving it nested under `Issue Context`.

## Validation

- `npm ci && npm test` — 574/574 passing, including the new `tests/checkbox-diff.test.js` (16 cases).
- `python3 -c "import yaml; yaml.safe_load(open(F))"` on both changed YAML files (`followup-checkbox-router.yml`, `labels.yml`) — clean.
- Changed-Markdown gate (`npx markdownlint-cli2` scoped to files changed vs. `origin/main`) — 0 errors.
- Manually simulated the workflow's template-rendering logic against the real `wr/WR_TEMPLATE_BASIC.md`/`FULL.md` files with sample short and long/chained follow-up descriptions — confirmed no leftover `{TOKEN}` placeholders and no strings that would trip `wr-lint`'s deferral-placeholder rule (no `TBD`/`TODO`/`N/A — pending ...`).

**Limitation:** this workflow's live trigger path (`issues: edited` / `pull_request: edited` with a real checkbox transition) **cannot be exercised end-to-end from this sandboxed session** — there's no way to fire a real GitHub webhook event here. The pure-logic half (`checkbox-diff.js`, the part that's actually verifiable without live GitHub state) has thorough unit coverage; the workflow YAML and its GitHub-API calls are unverified beyond YAML validity, the manual template-render simulation above, and careful reading against this repo's established patterns (`pdf-work-request-router.yml`'s `require(process.env.GITHUB_WORKSPACE + ...)` + token-fallback pattern, `wr-pr-creation.yml`'s classification/substitution approach). Recommend a maintainer exercises it live on a throwaway issue before relying on it.

`docs-freshness: checked both paired-doc targets -- docs/SYSTEM_MAP.md does not exist in this repo, and docs/AUTOMATION_AUDIT.md is a stale point-in-time audit snapshot (already lists "58 total" workflows against an actual count of 166+, and names workflows like openrouter-triage.yml that don't match the current tree). Adding one entry to an already-drifted historical doc wouldn't restore freshness, just add false confidence to it -- refreshing that doc is a separate, larger effort outside this PR's scope.`

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above




---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_


## High-level PR Summary
This PR introduces an automated mechanism to convert checked follow-up checklist items in PR/issue bodies into tracked Work Request (WR) issues. When a maintainer checks a box with the format `- [ ] Follow-up: `, a new workflow automatically creates a corresponding WR issue with appropriate templates, labels, and links back to the source. The implementation includes a pure-logic checkbox diff utility (`checkbox-diff.js`) with comprehensive unit tests, a new GitHub Actions workflow (`followup-checkbox-router.yml`) that triggers on issue/PR edits, and updates to WR templates to include a **Learnings — What & Why** section that gets populated automatically for follow-up-generated WRs.

⏱️ Estimated Review Time: 30-90 minutes


💡 Review Order Suggestion

| Order | File Path |
|-------|-----------|
| 1 | `scripts/checkbox-diff.js` |
| 2 | `tests/checkbox-diff.test.js` |
| 3 | `.github/workflows/followup-checkbox-router.yml` |
| 4 | `wr/WR_TEMPLATE_BASIC.md` |
| 5 | `wr/WR_TEMPLATE_FULL.md` |
| 6 | `.github/labels.yml` |
| 7 | `docs/SECRETS_MAP.md` |




[[Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)




---
## Summary by cubic
Automatically turns checked "Follow-up:" checklist items in PR/issue bodies into tracked WR issues to prevent dropped commitments. Detects unchecked→checked transitions and creates a new `[WR]` with two‑way links.

- **New Features**
  - Added `followup-checkbox-router.yml` to handle `pull_request.edited` / `issues.edited`: diffs `body`, creates a `[WR]` per newly checked `Follow-up:` item, labels `work-request` + `auto-generated-followup`, assigns `oaudrey`, and comments back with the link.
  - Introduced `scripts/checkbox-diff.js` with `tests/checkbox-diff.test.js` to find newly checked follow-ups by normalized text; ignores brand‑new or already‑checked boxes and handles reordering/casing/whitespace.
  - Added "Learnings — What & Why" to `wr/WR_TEMPLATE_BASIC.md` and `wr/WR_TEMPLATE_FULL.md`; router fills it with the follow-up text and source link; BASIC vs FULL chosen by a simple length/multi‑clause heuristic.
  - Registered the `auto-generated-followup` label and updated `docs/SECRETS_MAP.md` to include `followup-checkbox-router.yml` token references.

<sup>Written for commit f11a051100687f3ac45e6e5c4d1de679ba58421d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15834?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>

Closes #15834

Closes #15879

Closes #15898
closes #15898

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements an automated mechanism to convert checked follow-up checklist items in PR/issue bodies into tracked Work Request (WR) issues. When a maintainer checks a box with the pattern `- [ ] Follow-up: <description>`, a new GitHub Actions workflow (`followup-checkbox-router.yml`) detects the transition from unchecked to checked state and automatically creates a corresponding WR issue with appropriate labels (`work-request`, `auto-generated-followup`), assigns it to `oaudrey`, and establishes two-way links between the source and the new WR. The implementation includes a pure-logic utility (`checkbox-diff.js`) with comprehensive unit tests that matches items by normalized text content rather than line position, making it resilient to reordering. Both WR templates (`WR_TEMPLATE_BASIC.md` and `WR_TEMPLATE_FULL.md`) are updated to include a new **Learnings — What & Why** section that gets automatically populated for follow-up-generated WRs with the source context and description. The workflow uses a BASIC vs FULL classification heuristic based on description length and complexity (180+ chars or multi-clause phrasing → FULL), and includes guards against over-firing (items added and checked in the same edit are ignored, as are already-checked items).

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/checkbox-diff.js` |
| 2 | `tests/checkbox-diff.test.js` |
| 3 | `.github/workflows/followup-checkbox-router.yml` |
| 4 | `wr/WR_TEMPLATE_BASIC.md` |
| 5 | `wr/WR_TEMPLATE_FULL.md` |
| 6 | `.github/labels.yml` |
| 7 | `docs/SECRETS_MAP.md` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `.github/labels.yml` | The diff shows significant modifications to the labels file beyond just adding the `auto-generated-followup` label, but the actual changes are not visible in the provided diff snippet. Without seeing the full changes, this might include unrelated label modifications. |
| `docs/SECRETS_MAP.md` | This appears to be an auto-generated file that was regenerated to include references to the new workflow's token usage. While explained in the PR body as necessary to fix a failing test, the actual changes are not shown in the diff, making it difficult to verify the scope matches the stated purpose. |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically converts checked "Follow-up:" checklist items in PR/issue bodies into tracked `[WR]` issues so follow-up commitments don’t get lost. Detects unchecked→checked transitions, opens a WR using the basic or full template, and comments back on the source with a link.

- **New Features**
  - Added `scripts/checkbox-diff.js` to find newly checked follow-ups by normalized text (order-agnostic).
  - New workflow `/.github/workflows/followup-checkbox-router.yml` triggers on `pull_request.edited` and `issues.edited`, creates `[WR]` issues with `work-request` + `auto-generated-followup`, assigns `oaudrey`, and posts a back-link comment.
  - Updated `wr/WR_TEMPLATE_BASIC.md` and `wr/WR_TEMPLATE_FULL.md` with a “Learnings — What & Why” section auto-filled with the follow-up text and source link; BASIC vs FULL chosen via a simple length/multi‑clause heuristic and notes chained ancestry when `sourced from #N` is present.
  - Added unit tests in `tests/checkbox-diff.test.js` for parsing and transition detection.

Closes #15834, #15879, #15898.

<sup>Written for commit 74af7c52bf7fc7274fc229119fcd4592b32cd5a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

