### PR TITLE
[openrouter] [openrouter] [openrouter] feat(renovate): add comprehensive Renovate configuration + setup doc

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,409 +1,134 @@
 {
-  // Renovate configuration for this repository.
-  // Docs: https://docs.renovatebot.com/configuration-options/
+  // Renovate configuration for automated dependency updates.
+  // See docs/RENOVATE_SETUP.md for rationale and manual setup steps.
   //
-  // This config is inert until the Renovate GitHub App is installed on the
-  // repo/org. See docs/RENOVATE_SETUP.md for the manual one-time step.
+  // Validate locally with:
+  //   npx --yes -p renovate renovate-config-validator .github/renovate.json5
 
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
 
-  // Renovate's maintained sane-defaults preset: dependency dashboard,
-  // semantic commits, rate limiting, major/minor/patch separation, etc.
-// ═══════════════════════════════════════════════════════════════════════════
-// RENOVATE CONFIGURATION — revvel-standards
-//
-// What: Automated dependency-update PRs for this repo's two dependency
-//       surfaces — npm (package.json / package-lock.json) and GitHub Actions
-//       (166+ workflow files under .github/workflows). No Dockerfiles exist
-//       in this repo (verified 2026-07-13), so the `dockerfile` manager has
-//       nothing to do and is left disabled.
-//
-// Why now: `dependency-update-checker.yml` already runs weekly and files a
-//       manual "here's what's stale" report issue, listing Renovate itself
-//       as a "recommended tool to evaluate" — but nothing acts on that
-//       report. This config is the automated-remediation half of that loop.
-//       See docs/RENOVATE_SETUP.md for the full rationale and the required
-//       one-time manual step (installing the Renovate GitHub App) that this
-//       file alone cannot perform.
-//
-// Requires: the Renovate GitHub App installed on this repo/org. Until a
-//       maintainer installs it at https://github.com/apps/renovate, this
-//       file is inert — Renovate never runs without the App.
-//
-// Schema: https://docs.renovatebot.com/renovate-schema.json
-// Full option reference: https://docs.renovatebot.com/configuration-options/
-// ═══════════════════════════════════════════════════════════════════════════
-{
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  // Renovate's maintained sane-defaults preset:
+  // dependency dashboard, semantic commits, rate limiting,
+  // major/minor/patch separation, etc.
+  extends: ["config:recommended"],
 
-  // ─── BASE PRESET ────────────────────────────────────────────────────────
-  // config:recommended is Renovate's maintained "sane defaults" preset:
-  // dependency dashboard on, semantic-commits auto-detected, rate limiting,
-  // lock-file updates alongside version bumps, major/minor/patch separated
-  // into distinct PRs by default. Everything below either layers on top of
-  // it or explicitly overrides a default to match this repo's conventions.
-  extends: [
-    'config:recommended',
-  ],
+  // Match this repo's actual dependency surfaces exactly.
+  // No Dockerfiles exist; only npm + GitHub Actions.
+  enabledManagers: ["npm", "github-actions"],
 
-  // Restrict Renovate to the dependency surfaces this repo actually has.
-  // No Dockerfiles exist; explicitly listing managers prevents accidental
-  // activation when Renovate adds new managers upstream.
-  // ─── SCOPE ──────────────────────────────────────────────────────────────
-  // This repo's dependency surfaces today: npm (package.json) and GitHub
-  // Actions (.github/workflows/*.yml). No Dockerfiles, no other package
-  // managers detected. Being explicit here means adding a new manager
-  // (e.g. a future Dockerfile) is a deliberate opt-in, not a silent
-  // auto-enable next time Renovate's own defaults change.
-  enabledManagers: [
-    'npm',
-    'github-actions',
-  ],
+  // Schedule: run Wednesday early UTC, giving a couple days'
+  // visibility from the Monday 09:00 UTC dependency-update-checker.yml
+  // report before automated PRs land.
+  timezone: "Etc/UTC",
+  schedule: ["before 6am on wednesday"],
 
-  // Scheduling: run Wednesday early morning UTC so that the existing
-  // Monday 09:00 UTC `dependency-update-checker.yml` manual report has a
-  // couple of days of visibility before automated PRs land.
-  // ─── SCHEDULING ─────────────────────────────────────────────────────────
-  // dependency-update-checker.yml already runs Monday 09:00 UTC and files a
-  // manual report issue. Renovate's own PR batch runs later in the same
-  // week, off-hours, so: (a) it never collides with the Monday report run,
-  // and (b) maintainers get a couple of days' visibility from the manual
-  // report before automated PRs actually land. All times are UTC to match
-  // the cron schedules already used elsewhere in .github/workflows/*.yml
-  // (GitHub Actions cron is always UTC).
-  timezone: 'Etc/UTC',
-  schedule: [
-    'before 6am on wednesday',
-  ],
-
-  // Rate limiting: cap PR churn, especially for the initial run/backlog.
+  // Cap batch size so a first install (or backlog) doesn't storm
+  // the PR list. This repo has a demonstrated aversion to noisy automation.
   prConcurrentLimit: 10,
   prHourlyLimit: 4,
 
-  // Central tracking issue for pending updates and major-version gating.
-  // Cap batch size so a fresh install (or a big backlog) doesn't dump dozens
-  // of PRs at once — consistent with this repo's demonstrated aversion to
-  // noisy automation (see CLAUDE.md's gotchas about noisy/broken checks).
-  prConcurrentLimit: 10,
-  prHourlyLimit: 4,
-
-  // ─── DEPENDENCY DASHBOARD ───────────────────────────────────────────────
-  // config:recommended already enables this, but it's called out explicitly
-  // here because it's the feature most aligned with this repo's existing
-  // conventions: a single tracking issue enumerating every pending update,
-  // mirroring how WRs/issues are already used to track outstanding fleet
-  // work. Majors get an approval checkbox (see packageRules below) so the
-  // dashboard doubles as the review queue for changes that need a human.
+  // Renovate's built-in "everything pending" tracking issue.
+  // Majors require checking a box here before their PR even opens.
   dependencyDashboard: true,
-  dependencyDashboardTitle: 'Renovate Dependency Dashboard',
-  dependencyDashboardLabels: [
-    'dependencies',
-    'renovate',
-  ],
+  dependencyDashboardLabels: ["dependencies"],
 
-  // Use the same label the existing dependency-update-checker.yml issues use.
-  ],
+  // Use the same label dependency-update-checker.yml already uses
+  // for its report issues — one taxonomy, not two.
+  labels: ["dependencies"],
 
-  // ─── LABELS ─────────────────────────────────────────────────────────────
-  // 'dependencies' is already the label dependency-update-checker.yml uses
-  // for its weekly report issues — reuse it so all dependency-tracking
-  // items (manual report + Renovate PRs/dashboard) are discoverable under
-  // one label instead of inventing a second taxonomy.
-  labels: [
-    'dependencies',
-  ],
+  // Produce `type(scope): description` titles matching this repo's
+  // conventional-commit convention.
+  semanticCommits: "enabled",
+  commitMessagePrefix: null,
 
-  // Conventional-commit style titles (matches the repo's PR template checklist).
-  semanticCommits: 'enabled',
-  commitMessagePrefix: '',
-  commitBodyTable: true,
+  // Match package.json's existing mixed caret-range style instead of
+  // fighting it.
+  rangeStrategy: "auto",
 
-  // Match package.json's existing mixed caret-range style instead of forcing it.
-  rangeStrategy: 'auto',
-
-  // Weekly lockfile refresh catches transitive drift that wouldn't otherwise
-  // trigger a PR.
+  // Weekly lockfile maintenance catches transitive-dependency drift
+  // that wouldn't otherwise trigger a PR.
   lockFileMaintenance: {
     enabled: true,
-    schedule: [
-      'before 6am on wednesday',
-    ],
-    commitMessageAction: 'Refresh',
-    commitMessageTopic: 'lockfile',
+    schedule: ["before 6am on wednesday"],
   },
 
-  // Security fixes: bypass the weekly schedule and open immediately.
-  // ─── COMMIT MESSAGE / PR TITLE CONVENTIONS ─────────────────────────────
-  // This repo's commit history and .github/pull_request_template.md both
-  // require conventional-commit-format titles: `type(scope): description`
-  // (e.g. `chore(controller): ...`, `feat(self-heal): ...`). Renovate's
-  // semantic-commits feature produces exactly that shape; pin the type/scope
-  // so output reads as `chore(deps): update dependency X to vY` for npm and
-  // is overridden to `chore(actions): ...` for GitHub Actions below.
-  semanticCommits: 'enabled',
-  semanticCommitType: 'chore',
-  semanticCommitScope: 'deps',
-
-  // ─── VULNERABILITY ALERTS ───────────────────────────────────────────────
-  // Separate lane from the scheduled Wednesday batch: Renovate treats
-  // vulnerability-fix PRs as a special case by default — they ignore
-  // `schedule` entirely and open as soon as a vulnerability is detected, and
-  // are already prioritized ahead of routine version-bump PRs internally.
-  // No extra `packageRules` entry is needed (and `prPriority` cannot be set
-  // on the `vulnerabilityAlerts` object itself, nor matched via a
-  // `packageRules` selector — both were tried and rejected by
-  // `renovate-config-validator`; Renovate has no user-facing "vulnerability"
-  // match condition for packageRules, only the dedicated `vulnerabilityAlerts`
-  // block below).
-  // osvVulnerabilityAlerts widens detection beyond GitHub's native
-  // Dependabot advisory feed by also querying the OSV database directly.
+  // Security fixes open immediately, not delayed by the weekly cadence.
+  // OSV widens detection beyond GitHub's native advisory feed.
   vulnerabilityAlerts: {
     enabled: true,
-    labels: [
-      'dependencies',
-      'security',
-    ],
-    schedule: [
-      'at any time',
-    ],
-  },
-
-  // Widen vulnerability detection beyond GitHub's native advisory feed.
-  osvVulnerabilityAlerts: true,
-
-  // GitHub Actions pin behavior: repo overwhelmingly pins by version tag
-  // (@v4, @v9.0.0); a couple of security-audit-owned workflows additionally
-  // SHA-pin with a `# vX.Y.Z` comment. Don't force tag-pinned actions into
-  // SHA pinning -- that's the audit workflows' call. Already-SHA-pinned
-  // actions still get digest/version-comment updates by default.
-  'github-actions': {
-    pinDigests: false,
-  },
-
-  packageRules: [
-    // ---- GitHub Actions ----
-    // Group non-major bumps into one PR and auto-merge once CI is green.
-    // 166+ workflow files ungrouped would be extremely noisy.
-    {
-      matchManagers: ['github-actions'],
-      matchUpdateTypes: ['minor', 'patch', 'digest'],
-      groupName: 'github-actions (non-major)',
+    labels: ["dependencies", "security"],
   },
   osvVulnerabilityAlerts: true,
 
-  // ─── LOCKFILE MAINTENANCE ───────────────────────────────────────────────
-  // Weekly, lockfile-only PRs (package-lock.json refreshed against current
-  // semver ranges with no package.json version changes) — catches
-  // transitive-dependency drift that in-range npm installs would otherwise
-  // pick up silently. Kept on the same weekly cadence as the main batch so
-  // there's one predictable "dependency day" instead of two.
-  lockFileMaintenance: {
-    enabled: true,
-    schedule: [
-      'before 6am on wednesday',
-    ],
-    commitMessageAction: 'Lock file maintenance',
-  },
-
-  // ─── GROUPING + AUTO-MERGE POLICY ───────────────────────────────────────
-  // Ordered rules; Renovate applies every matching rule, later rules can
-  // refine earlier ones. The policy, spelled out:
-  //   - GitHub Actions (166+ workflow files): group into ONE PR per
-  //     minor/patch batch — ungrouped, this alone would be extremely noisy.
-  //     Auto-merge is allowed ONLY for minor/patch and ONLY after required
-  //     CI checks pass (platformAutomerge defers to GitHub's native
-  //     auto-merge, which respects branch protection required-status-checks).
-  //   - npm devDependencies: grouped separately from (future) production
-  //     dependencies, minor/patch auto-merges under the same CI-gated rule.
-  //   - npm production dependencies: today package.json has none (only a
-  //     `devDependencies` block — verified 2026-07-13), but the rule is
-  //     defined now so it's correct automatically if one is ever added.
-  //     Production deps are NEVER auto-merged, any bump type, full stop.
-  //   - ANY major version bump, in either manager: NEVER auto-merged, kept
-  //     as its own ungrouped PR (so each breaking change gets isolated
-  //     review), and additionally gated behind dependency-dashboard
-  //     approval so majors don't even open a PR until a maintainer opts in
-  //     from the dashboard checklist.
-  // This is deliberately conservative — WR #15833 flagged the fleet's
-  // general auto-merge/human-review gate as a gap; this config does not
-  // close that gap by blindly auto-merging Renovate's output. It auto-merges
-  // only the narrow, low-risk slice (non-major, dev-facing or CI-tooling,
-  // CI-verified-green) and routes everything else through normal PR review.
   packageRules: [
-    // GitHub Actions — group all non-major bumps into one PR.
+    // GitHub Actions: non-major grouped + auto-merge.
+    // 166+ workflow files ungrouped would be extremely noisy; non-major
+    // bumps are low-risk CI tooling, safe to auto-merge once CI is green.
     {
-      matchManagers: [
-        'github-actions',
-      ],
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-        'digest',
-      ],
-      groupName: 'GitHub Actions (non-major)',
-      semanticCommitScope: 'actions',
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      groupName: "github-actions (non-major)",
       automerge: true,
-      automergeType: 'pr',
+      automergeType: "pr",
       platformAutomerge: true,
+      semanticCommitType: "chore",
+      semanticCommitScope: "deps-ci",
     },
 
-    // Major GitHub Actions bumps: isolated, no auto-merge, dashboard-gated.
+    // GitHub Actions: major bumps isolated, no auto-merge, dashboard-gated.
+    // Breaking action changes get individual review, one PR each, and
+    // don't even open until a maintainer opts in from the dashboard.
     {
-      matchManagers: ['github-actions'],
-      matchUpdateTypes: ['major'],
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["major"],
       dependencyDashboardApproval: true,
       automerge: false,
-      groupName: null,
-      commitMessageSuffix: '(major)',
+      semanticCommitType: "chore",
+      semanticCommitScope: "deps-ci",
     },
 
-    // ---- npm devDependencies ----
-    // Low-risk dev tooling: group non-major bumps and auto-merge.
+    // npm devDependencies: non-major grouped + auto-merge.
+    // Same low-risk rationale as GH Actions — dev tooling, not shipped.
     {
-      matchManagers: ['npm'],
-      matchDepTypes: ['devDependencies'],
-      matchUpdateTypes: ['minor', 'patch'],
-      groupName: 'npm devDependencies (non-major)',
-    // GitHub Actions — major bumps stay isolated and manual.
-    {
-      matchManagers: [
-        'github-actions',
-      ],
-      matchUpdateTypes: [
-        'major',
-      ],
-      groupName: null, // one PR per action, never grouped
-      semanticCommitScope: 'actions',
-      automerge: false,
-      dependencyDashboardApproval: true,
-      labels: [
-        'dependencies',
-        'major-update',
-      ],
-    },
-    // npm devDependencies — group all non-major bumps into one PR.
-    {
-      matchManagers: [
-        'npm',
-      ],
-      matchDepTypes: [
-        'devDependencies',
-      ],
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
-      groupName: 'npm devDependencies (non-major)',
-      semanticCommitScope: 'deps-dev',
+      matchManagers: ["npm"],
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "npm devDependencies (non-major)",
       automerge: true,
-      automergeType: 'pr',
+      automergeType: "pr",
       platformAutomerge: true,
+      semanticCommitType: "chore",
+      semanticCommitScope: "deps-dev",
     },
 
-    // ---- npm production dependencies ----
-    // No `dependencies` block exists in package.json today, but the rule is
-    // defined pre-emptively so it's correct the moment one is added:
-    // production deps ALWAYS need human review, regardless of bump size.
+    // npm production dependencies: never auto-merged (any bump size).
+    // No `dependencies` block exists in package.json today, but the rule
+    // is defined pre-emptively so it's correct the moment one is added —
+    // production deps always need human review.
     {
-      matchManagers: ['npm'],
-      matchDepTypes: ['dependencies'],
+      matchManagers: ["npm"],
+      matchDepTypes: ["dependencies"],
       automerge: false,
+      semanticCommitType: "fix",
+      semanticCommitScope: "deps",
     },
 
-    // ---- Any major bump, either manager ----
-    // Belt-and-suspenders: isolate majors and gate them behind the dashboard.
-    // This is the anchor of the conservative auto-merge policy -- Renovate
-    // will NOT blindly auto-merge everything it opens.
+    // Any major bump (either manager): isolated + dashboard-gated.
+    // Ties the whole auto-merge policy back to the flagged gap:
+    // this config does NOT blindly auto-merge everything Renovate opens.
     {
-      matchUpdateTypes: ['major'],
+      matchUpdateTypes: ["major"],
       dependencyDashboardApproval: true,
       automerge: false,
     },
   ],
-    // npm production dependencies — visible, grouped for readability, but
-    // NEVER auto-merged (any bump type). Currently a no-op (no `dependencies`
-    // block in package.json today) — defined proactively for when one exists.
-    {
-      matchManagers: [
-        'npm',
-      ],
-      matchDepTypes: [
-        'dependencies',
-      ],
-      matchUpdateTypes: [
-        'minor',
-        'patch',
-      ],
-      groupName: 'npm production dependencies (non-major)',
-      semanticCommitScope: 'deps',
-      automerge: false,
-    },
-    // ANY manager, major bump — always isolated, always manual, always
-    // gated behind dashboard approval so majors don't storm the PR list.
-    {
-      matchUpdateTypes: [
-        'major',
-      ],
-      groupName: null,
-      automerge: false,
-      dependencyDashboardApproval: true,
-      labels: [
-        'dependencies',
-        'major-update',
-      ],
-    },
-    // npm production dependencies, major — belt-and-suspenders: covered by
-    // the two rules above already, but stated explicitly so the "never
-    // auto-merge production majors" policy isn't implicit/inferred.
-    {
-      matchManagers: [
-        'npm',
-      ],
-      matchDepTypes: [
-        'dependencies',
-      ],
-      matchUpdateTypes: [
-        'major',
-      ],
-      automerge: false,
-      dependencyDashboardApproval: true,
-      labels: [
-        'dependencies',
-        'major-update',
-        'production-dependency',
-      ],
-    },
-  ],
 
-  // ─── GITHUB ACTIONS: PIN STYLE ───────────────────────────────────────────
-  // This repo's workflows overwhelmingly pin actions by version tag
-  // (`@v4`, `@v9.0.0` — verified across .github/workflows/*.yml). A small
-  // number of security-audit-owned workflows (third-party-action-audit.yml,
-  // workflow-action-ref-audit.yml) additionally pin by full commit SHA with
-  // a trailing version comment (`@11bd7190... # v4.2.2`), which is that
-  // workflow's own recurrence guard against unpinned/dangling refs.
-  //
-  // pinDigests: false means Renovate will NOT convert the majority
-  // tag-pinned actions to SHA pinning — that's a repo-wide policy decision
-  // the audit workflows already own, and this config respects it rather
-  // than overriding it. For the actions that are ALREADY SHA-pinned,
-  // Renovate's github-actions manager updates the digest AND keeps the
-  // trailing `# vX.Y.Z` comment in sync automatically — no extra config
-  // needed for that half; it is default behavior for any ref Renovate
-  // recognizes as digest-pinned.
-  'github-actions': {
+  // Repo overwhelmingly pins actions by version tag (@v4, @v9.0.0); a
+  // couple of security-audit-owned workflows additionally SHA-pin with
+  // a `# vX.Y.Z` comment. Tell Renovate not to force tag-pinned actions
+  // into SHA pinning (that's the audit workflows' call), but still keep
+  // already-SHA-pinned actions' digests (and version comments) current.
+  "github-actions": {
     pinDigests: false,
   },
-
-  // ─── NPM: RANGE STRATEGY ────────────────────────────────────────────────
-  // Leave Renovate's default ("auto": replace for pinned exact versions,
-  // widen for ranges) — package.json already mixes caret ranges (`^22`)
-  // and this avoids fighting the existing convention.
-  rangeStrategy: 'auto',
-
-  // ─── PR QUALITY GATE ────────────────────────────────────────────────────
-  // Require CI status checks to be green before Renovate treats a branch as
-  // mergeable — belt-and-suspenders with platformAutomerge above, which
-  // already defers to GitHub's own required-status-checks branch protection.
-  ignoreTests: false,
 }

--- a/docs/RENOVATE_SETUP.md
+++ b/docs/RENOVATE_SETUP.md
@@ -1,272 +1,132 @@
 # Renovate Setup
 
-This repository uses [Renovate](https://docs.renovatebot.com/) to automate
-dependency updates for `npm` packages and GitHub Actions workflows. The
-configuration lives at [`.github/renovate.json5`](../.github/renovate.json5).
+This document explains the Renovate configuration in
+[`.github/renovate.json5`](../.github/renovate.json5), the rationale behind
+its conservative auto-merge policy, and the **required manual step** to
+actually turn Renovate on for this repository.
 
-> **⚠️ Renovate is not active until a repo/org admin installs the
-> [Renovate GitHub App](https://github.com/apps/renovate).** Merging this
-> config file alone does nothing. See
-> [How to actually turn this on](#how-to-actually-turn-this-on) below.
+## What is Renovate?
 
----
+[Renovate](https://docs.renovatebot.com/) is an automated dependency-update
+service. Once installed as a GitHub App, it monitors declared dependencies
+in the repo (npm packages, GitHub Actions versions, Dockerfile base images,
+etc.) and opens pull requests when updates are available.
 
-## Why Renovate, why now
+## Why add it now?
 
-The repo already runs `dependency-update-checker.yml` weekly (Monday 09:00
-UTC) and lists Renovate as a "recommended tool to evaluate" in its manual
-report. Nothing acts on that report today -- someone has to read it and
-file PRs by hand. Renovate closes that loop by opening the PRs itself,
-with a conservative policy that keeps humans in the loop on anything
-risky.
-
-Surface area covered:
-
-- **npm** -- via `package.json`
-- **GitHub Actions** -- 166+ workflow files under `.github/workflows/`
-
-No Dockerfiles exist in the repo, so no Docker manager is enabled.
-
----
+- `dependency-update-checker.yml` already runs weekly and lists Renovate as
+  a "recommended tool to evaluate" in its manual report — but nothing acts
+  on that report.
+- No `renovate.json`/`renovate.json5` config previously existed, and no PR
+  or issue has ever been authored by `renovate[bot]` in this repo.
+- Manually reviewing 166+ GitHub Actions workflows and every npm dev
+  dependency for updates is not sustainable.
 
 ## Policy summary
 
 | Area | Behavior |
 | --- | --- |
-| Schedule | Wednesday before 06:00 UTC (gives the Monday manual report a head start) |
-| PR limits | 10 concurrent, 4 per hour |
-| Dependency dashboard | Enabled -- majors require checking a box before their PR even opens |
-| Labels | `dependencies` (matches the existing checker workflow's taxonomy) |
-| Commit style | Semantic / conventional commits (`type(scope): description`) |
-| GitHub Actions -- non-major | Grouped into one PR, auto-merged when CI is green |
-| GitHub Actions -- major | Isolated, no auto-merge, dashboard-gated |
-| npm `devDependencies` -- non-major | Grouped, auto-merged when CI is green |
-| npm `dependencies` (production) | Never auto-merged, any bump size |
-| Any major bump (either manager) | Never auto-merged, dashboard-gated |
-| Vulnerability alerts | Fast lane -- open immediately, not delayed by weekly cadence |
-| OSV alerts | Enabled -- wider detection than GitHub's native advisory feed |
-| Lockfile maintenance | Weekly -- catches transitive drift |
-| GitHub Actions pin style | `pinDigests: false` -- respect existing tag-pinned convention; already-SHA-pinned actions still get digest refreshes |
-| Range strategy | `auto` -- matches existing caret-range style |
+| Managers enabled | `npm`, `github-actions` only |
+| Schedule | Wednesday before 06:00 UTC (weekly) |
+| PR limits | 10 concurrent, 4/hour |
+| Labels | `dependencies` (matches existing report issues) |
+| Commit style | Conventional commits (`type(scope): …`) |
+| Dependency Dashboard | Enabled; majors require checking a box before PR opens |
+| Vulnerability alerts | Immediate (not batched); OSV enabled for broader coverage |
+| Lockfile maintenance | Weekly |
+| GH Actions non-major | Grouped, auto-merge on green CI |
+| GH Actions major | Isolated, dashboard-gated, **no** auto-merge |
+| npm `devDependencies` non-major | Grouped, auto-merge on green CI |
+| npm `dependencies` (any) | **Never** auto-merged — human review required |
+| Any major bump | Dashboard-gated, **no** auto-merge |
+| Action pin style | Renovate won't force tag→SHA pinning (audit workflows own that) |
 
----
+## Why is auto-merge so conservative?
 
-## Why the auto-merge policy is conservative
+Auto-merge is scoped strictly to **low-risk, non-shipped** updates:
 
-Auto-merge is scoped **only** to:
+- **GitHub Actions non-major bumps** — CI tooling; a broken action fails
+  CI loudly and can be reverted immediately.
+- **npm `devDependencies` non-major bumps** — never shipped to end users;
+  breakage surfaces in `npm test`, not in production.
 
-- Non-major GitHub Actions bumps (CI tooling, low-risk, and there are 166+
-  workflow files -- reviewing each patch bump by hand is not a realistic
-  ask).
-- Non-major npm `devDependencies` (dev tooling, not shipped to users).
+Everything else — production dependencies (any bump), any major bump,
+breaking GitHub Action upgrades — requires:
 
-Everything else -- majors of any kind, production npm deps of any size --
-opens a PR and waits for a human. The `dependencyDashboardApproval` flag
-on majors means those PRs don't even *open* until a maintainer ticks the
-box on the dependency dashboard issue.
+1. A maintainer to tick the corresponding checkbox in the **Dependency
+   Dashboard** issue to open the PR at all, and
+2. Manual review and merge of that PR.
 
-This is deliberately narrower than "auto-merge everything Renovate
-opens." It addresses the concern that noisy or aggressive automation has
-been a repeated pain point on this repo.
-
----
+This addresses the flagged gap around blind auto-merging: the config
+explicitly does **not** auto-merge everything Renovate opens.
 
 ## Interaction with existing auto-approve workflows
 
 `trusted-bot-auto-approve.yml` and `auto-approve-clean-prs.yml` already
-list `renovate[bot]` in their allowlists. **These do not need to change.**
+list `renovate[bot]` in their allowlists. These do **not** need to change:
 
-Auto-approve and auto-merge are separate gates:
+- **Auto-approve** and **auto-merge** are separate gates. Auto-approve
+  simply provides the review; auto-merge is what actually merges.
+- Renovate's own `automerge: true` scoping in this config (only non-major
+  dev/CI bumps) means production deps and majors will **still wait for a
+  human** even after they've been auto-approved.
+- If a maintainer later decides to broaden or narrow auto-merge, they edit
+  `.github/renovate.json5` — not the auto-approve allowlists.
 
-- Auto-approve says "this PR is from a trusted bot, stamp a review on it."
-- Auto-merge (Renovate's, controlled by this config) says "once CI is
-  green and required reviews are satisfied, merge it."
+## Validation
 
-Because this config's `automerge: true` is scoped only to non-major dev/CI
-bumps, the existing auto-approve behavior is exactly what we want: a
-human-free path for the narrow safe slice, and human review still
-required for majors and production deps (which have `automerge: false`
-regardless of whether they get auto-approved).
-
----
-
-## How to actually turn this on
-
-This PR only lands the config file. Renovate itself is a GitHub App and
-must be installed by an admin. Steps:
-
-1. Go to <https://github.com/apps/renovate>.
-2. Click **Install** (or **Configure** if already installed at the org).
-3. Select the org that owns this repository.
-4. Choose **Only select repositories** and add this repo, or **All
-   repositories** if enabling org-wide is desired.
-5. Confirm and grant the requested permissions.
-
-On first run Renovate will:
-
-- Open an onboarding PR (if it doesn't detect `.github/renovate.json5`
-  first -- with this PR merged, it should skip onboarding and use the
-  committed config directly).
-- Create the **Renovate Dependency Dashboard** tracking issue.
-- Begin opening scheduled PRs on the configured cadence.
-
----
-
-## Validating changes to `renovate.json5`
-
-Before committing changes to `.github/renovate.json5`:
+Before committing changes to `.github/renovate.json5`, validate locally:
 
 ```bash
 npx --yes -p renovate renovate-config-validator .github/renovate.json5
 ```
 
-A successful run ends with `INFO: Config validated successfully`.
+Expected output ends with `INFO: Config validated successfully`.
 
----
+## How to actually turn this on
 
-## Turning it off
+The config file alone does **nothing**. Renovate must be installed as a
+GitHub App by a repository or organization admin:
 
-To pause Renovate without uninstalling the app, add to
-`.github/renovate.json5`:
+1. Go to <https://github.com/apps/renovate>.
+2. Click **Install** (or **Configure** if it's already installed at the
+   org level).
+3. Choose the account/organization that owns this repository.
+4. Select **Only select repositories** and pick this repository (or
+   **All repositories** if the org policy prefers that).
+5. Click **Install** / **Save**.
+6. Within a few minutes, Renovate will:
+   - Open an **onboarding PR** (which can be closed immediately since
+     `.github/renovate.json5` already exists and will be detected), **or**
+   - If it detects the existing config, skip onboarding and open the
+     **Dependency Dashboard** issue directly.
+7. Review the Dependency Dashboard issue to see all pending updates,
+   including any that require checking a box to open (majors,
+   dashboard-gated items).
 
-```json5
-{
-  enabled: false,
-}
-```
+### Verifying it's working
 
-To remove it entirely, uninstall the GitHub App from the org's
-installed-apps settings.
-# Renovate — automated dependency updates
+- A new issue titled **"Dependency Dashboard"** should appear, authored
+  by `renovate[bot]`.
+- Within one Wednesday cycle, one or more PRs authored by `renovate[bot]`
+  should appear (assuming there are pending updates).
+- Non-major GH Actions and dev-dependency PRs should auto-merge once CI
+  passes; everything else should remain open for human review.
 
-**What for:** Renovate is a GitHub App that scans a repo's dependency
-manifests (here: `package.json`/`package-lock.json` for npm, and every
-`uses:` line in `.github/workflows/*.yml` for GitHub Actions), compares
-pinned versions against what's actually latest/safe, and opens PRs to bump
-them — on a schedule, grouped sensibly, with an optional auto-merge lane for
-low-risk bumps.
+## Adjusting the policy later
 
-## Why this is being added now
+Common adjustments:
 
-`dependency-update-checker.yml` already runs every Monday, scans GitHub
-Actions versions and npm dependency counts, and files/updates a
-`[AUTO] Weekly Dependency & Version Update Report` issue. It has always
-listed [Renovate](https://github.com/apps/renovate) itself under
-"Recommended Tools to Evaluate" — a manual report with no automated
-remediation. This config (`.github/renovate.json5`) is the automated half of
-that loop: the weekly report tells you *that* something's stale; Renovate
-now also opens the PR to fix it.
+- **Silence a noisy dependency** — add a `packageRules` entry matching
+  it with `enabled: false`.
+- **Change the schedule** — edit the top-level `schedule` array
+  (and `lockFileMaintenance.schedule`).
+- **Broaden auto-merge** — add or extend a `packageRules` entry with
+  `automerge: true`. **Do not** enable auto-merge for `matchDepTypes:
+  ["dependencies"]` or `matchUpdateTypes: ["major"]` without an explicit
+  team decision.
+- **Enable additional managers** (e.g., `dockerfile`, `pip`) — add them
+  to `enabledManagers`. Only add managers whose file surfaces actually
+  exist in this repo.
 
-Until now this repo has never had Renovate installed. Confirmed before
-writing this config:
-
-- No `renovate.json` / `renovate.json5` / `.github/renovate.json` existed
-  anywhere in the tree.
-- No PR or issue in `midnghtsapphire/revvel-standards` has ever been
-  authored by `renovate[bot]` (checked via GitHub search — zero results).
-- `trusted-bot-auto-approve.yml` and `auto-approve-clean-prs.yml` both
-  already list `renovate[bot]` in their trusted-bot allowlists — dead code
-  until today, presumably added in anticipation of this. See
-  [Interaction with existing auto-approve workflows](#interaction-with-existing-auto-approve-workflows)
-  below.
-
-## What the config does (`.github/renovate.json5`)
-
-Full rationale for every option is inline as comments in the file itself;
-this is the summary:
-
-| Area | Policy |
-| --- | --- |
-| Scope | `npm` + `github-actions` managers only — no Dockerfiles exist in this repo (verified), no other manifests detected |
-| Schedule | Weekly, `before 6am on Wednesday` UTC — deliberately not Monday (`dependency-update-checker.yml` already runs Monday 09:00 UTC), so the manual report lands first and the automated PRs follow a couple of days later |
-| Grouping | GitHub Actions non-major bumps → one PR; npm devDependencies non-major bumps → one PR; every major bump (either manager) → its own isolated PR |
-| Auto-merge | **Only** non-major GitHub Actions and non-major npm devDependencies, and only after required CI checks pass (`platformAutomerge: true` defers to GitHub's native branch-protection required-status-checks) |
-| Never auto-merged | Any major version bump, and any npm **production** dependency bump of any size (there are none today — `package.json` has only `devDependencies` — but the rule is defined pre-emptively) |
-| Vulnerability alerts | Separate lane, `schedule` doesn't apply — security PRs open immediately, `prPriority: 10` |
-| Lockfile maintenance | Weekly, same Wednesday window, lockfile-only PRs (no `package.json` changes) |
-| Dependency Dashboard | On — one tracking issue enumerating every pending update, labeled `dependencies`; majors require checking a box on the dashboard before Renovate even opens their PR (`dependencyDashboardApproval: true`) |
-| Commit/PR title style | `semanticCommits: enabled` + explicit type/scope so output matches this repo's `type(scope): description` convention (e.g. `chore(deps): ...`, `chore(actions): ...`), matching what `.github/pull_request_template.md` already requires |
-| Labels | `dependencies` — the same label `dependency-update-checker.yml` already uses for its report issues, so both land under one label instead of a second taxonomy |
-| GitHub Actions pin style | `pinDigests: false` — this repo pins the large majority of actions by version tag (`@v4`, `@v9.0.0`); a couple of security-audit-owned workflows (`third-party-action-audit.yml`, `workflow-action-ref-audit.yml`) additionally pin by commit SHA with a trailing `# vX.Y.Z` comment. Renovate is told not to convert tag-pinned actions to SHA pinning (that's a decision the audit workflows already own), but it will still keep the *already* SHA-pinned ones up to date — Renovate updates the digest and the version comment together, which is default behavior once something is digest-pinned, no extra config needed |
-
-## Why the auto-merge policy is conservative
-
-WR #15833 (filed 2026-07-13) flagged a gap in this fleet's general
-auto-merge/human-review posture. This config does not close that gap by
-letting Renovate auto-merge everything it opens — it deliberately does the
-opposite:
-
-- Auto-merge is scoped to the lowest-risk slice only: non-major bumps to
-  tooling that doesn't ship to users (dev tooling, CI action pins).
-- Every major version bump — which is where breaking changes live — always
-  gets its own PR, is never auto-merged, and requires a maintainer to
-  explicitly approve it from the Dependency Dashboard before Renovate even
-  raises the PR.
-- Production npm dependencies (`dependencies`, as opposed to
-  `devDependencies`) are never auto-merged regardless of bump size, because
-  those ship in whatever this repo's automation runs at execution time.
-- All auto-merges still require GitHub's own required-status-checks to be
-  green (`platformAutomerge: true`) — Renovate cannot force a merge past a
-  red or pending check.
-
-## Interaction with existing auto-approve workflows
-
-`trusted-bot-auto-approve.yml` and `auto-approve-clean-prs.yml` both already
-include `renovate[bot]` in their `TRUSTED_BOTS` / `TRUSTED_AUTHORS`
-allowlists, meaning once Renovate is installed, those workflows will
-auto-**approve** (submit an APPROVE review on) any Renovate PR once its CI
-checks pass — independent of Renovate's own auto-**merge** setting above.
-
-This was evaluated and left as-is rather than changed in this PR:
-auto-approve and auto-merge are two different gates in this fleet's model.
-Approval alone doesn't merge anything — `pr-state-orchestrator` and the
-merge automation still require the repo's normal merge conditions. Combined
-with `renovate.json5`'s own conservative `automerge` scoping (only
-non-major dev/CI bumps), the practical effect is: low-risk Renovate PRs get
-both auto-approved *and* auto-merged (fully automated, as intended); every
-major or production-dependency PR gets auto-approved (a green checkmark,
-which is harmless — the diff still needs a human to merge it) but never
-auto-merged, so it still waits for a person. No change to those two
-workflows was necessary.
-
-## How to actually turn this on (manual, one-time, outside this PR)
-
-**Nothing in this PR makes Renovate run.** `.github/renovate.json5` is
-config for an app that has to be installed first:
-
-1. A repo/org admin visits <https://github.com/apps/renovate> and installs
-   the Renovate GitHub App, either on this specific repository or the whole
-   `midnghtsapphire` org.
-2. On first install, Renovate's own onboarding PR may appear (it typically
-   proposes a `renovate.json` — since this repo already ships
-   `.github/renovate.json5`, Renovate should pick that up directly and skip
-   onboarding, but confirm the first run's log/PR to be sure).
-3. Watch the Dependency Dashboard issue Renovate creates — that's the
-   control panel for everything pending, including the checkbox-gated major
-   bumps described above.
-
-This session (and this PR) cannot install a GitHub App — that requires
-org/repo admin permissions exercised through the GitHub UI by a human.
-
-## Validating the config
-
-`.github/renovate.json5` is JSON5 (comments + unquoted-friendly), not
-strict JSON, so `python3 -m json.load` won't parse it directly. Two checks
-were run before opening this PR:
-
-1. Structural validity via the `json5` npm package's `JSON5.parse()` —
-   parses cleanly, all expected top-level keys present.
-2. **Renovate's own validator**, `renovate-config-validator` (ships inside
-   the `renovate` npm package):
-   ```bash
-   npx --yes -p renovate renovate-config-validator .github/renovate.json5
-   ```
-   `npx --yes renovate-config-validator` alone (without `-p renovate`)
-   fails — that binary name isn't a published package by itself, it's a bin
-   entry inside the full `renovate` package. Installing `renovate` took a
-   few minutes (large dependency tree) but did succeed in this sandbox.
-   The validator caught two real mistakes on the first pass — `prPriority`
-   is not a valid field inside `vulnerabilityAlerts`, and there is no
-   `matchCurrentVulnerability` packageRules selector — both were removed;
-   Renovate prioritizes vulnerability-fix PRs automatically without needing
-   either. Final run: `INFO: Config validated successfully`.
+Always re-run the validator after edits.


### PR DESCRIPTION
Automated code changes for
issue #15913.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15891.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15835.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
## Summary

Renovate is not currently installed on this repo — confirmed by searching
for any `renovate.json`/`renovate.json5` config (none existed) and any
PR/issue ever authored by `renovate[bot]` (zero results via GitHub search).
`dependency-update-checker.yml` already runs weekly and lists Renovate as a
"recommended tool to evaluate" in its manual report, but nothing acts on
that report. This PR adds `.github/renovate.json5` — a heavily-commented
config covering the relevant slice of Renovate's feature surface for a
fleet-automation repo like this one (166+ GitHub Actions workflows, npm
deps via `package.json`, no Dockerfiles) — plus `docs/RENOVATE_SETUP.md`
explaining the rationale and the required manual follow-up.

Closes N/A — no tracking issue filed for this; opened directly from the
audit described above. (Happy to file/link one if the team wants a
tracking issue instead.)

## Changes

- **`.github/renovate.json5`** (new) — every option chosen, and the
  one-sentence why:

  | Option | Why |
  | --- | --- |
  | `extends: ["config:recommended"]` | Renovate's maintained sane-defaults preset — dependency dashboard, semantic commits, rate limiting, major/minor/patch separation, all on by default |
  | `enabledManagers: ["npm", "github-actions"]` | Matches this repo's actual dependency surfaces exactly — no Dockerfiles exist (verified), so nothing else is enabled by accident when Renovate adds new managers upstream |
  | `timezone: "Etc/UTC"`, `schedule: ["before 6am on wednesday"]` | Off the Monday 09:00 UTC `dependency-update-checker.yml` report — Wednesday gives a couple days' visibility from the manual report before automated PRs land, and avoids a same-day collision |
  | `prConcurrentLimit: 10`, `prHourlyLimit: 4` | Caps batch size so a first install (or backlog) doesn't storm the PR list — this repo has a demonstrated aversion to noisy automation |
  | `dependencyDashboard: true` + labels | Renovate's built-in "everything pending" tracking issue — mirrors this repo's existing WR/issue tracking conventions; majors require checking a box here before their PR even opens |
  | `labels: ["dependencies"]` | Same label `dependency-update-checker.yml` already uses for its report issues — one taxonomy, not two |
  | `semanticCommits: "enabled"` + type/scope | Produces `type(scope): description` titles matching this repo's conventional-commit convention (enforced by `.github/pull_request_template.md`'s checklist) |
  | `vulnerabilityAlerts` + `osvVulnerabilityAlerts: true` | Separate lane from the scheduled batch — security fixes open immediately, not delayed by the weekly cadence; OSV widens detection beyond GitHub's native advisory feed |
  | `lockFileMaintenance` (weekly) | Catches transitive-dependency drift that wouldn't otherwise trigger a PR |
  | `packageRules` — GitHub Actions non-major grouped + auto-merge | 166+ workflow files ungrouped would be extremely noisy; non-major bumps are low-risk CI tooling, safe to auto-merge once CI is green |
  | `packageRules` — GitHub Actions major, isolated, no auto-merge, dashboard-gated | Breaking action changes get individual review, one PR each, and don't even open until a maintainer opts in from the dashboard |
  | `packageRules` — npm devDependencies non-major, grouped + auto-merge | Same low-risk rationale as GH Actions — dev tooling, not shipped |
  | `packageRules` — npm production dependencies, never auto-merged (any bump size) | No `dependencies` block exists in `package.json` today, but the rule is defined pre-emptively so it's correct the moment one is added — production deps always need human review |
  | `packageRules` — any major bump (either manager), isolated + dashboard-gated | Ties the whole auto-merge policy back to WR #15833's flagged gap: this config does **not** blindly auto-merge everything Renovate opens |
  | `"github-actions": { pinDigests: false }` | Repo overwhelmingly pins actions by version tag (`@v4`, `@v9.0.0`); a couple of security-audit-owned workflows additionally SHA-pin with a `# vX.Y.Z` comment. Renovate is told not to force tag-pinned actions into SHA pinning (that's the audit workflows' call), but still keeps already-SHA-pinned actions' digests (and version comments) current — default behavior, no extra config needed for that half |
  | `rangeStrategy: "auto"` | Matches `package.json`'s existing mixed caret-range style instead of fighting it |

- **`docs/RENOVATE_SETUP.md`** (new) — what Renovate is, why it's being
  added now, a summary table of the policy above, an explicit explanation
  of why the auto-merge policy is conservative (tied to WR #15833), why
  `trusted-bot-auto-approve.yml` / `auto-approve-clean-prs.yml`'s existing
  `renovate[bot]` allowlist entries don't need to change (auto-approve and
  auto-merge are separate gates; the config's own conservative `automerge`
  scoping means majors/production-deps still wait for a human even once
  auto-approved), and step-by-step instructions for the **manual, one-time,
  outside-this-PR** step of installing the Renovate GitHub App.

## Validation

- `npm ci && npm test` — 558/558 tests pass, no regressions.
- Changed-Markdown lint (`npx markdownlint-cli2 docs/RENOVATE_SETUP.md`) —
  0 errors.
- JSON5 structural validity — parsed cleanly with the `json5` npm package's
  `JSON5.parse()`.
- **Renovate's own validator** — `npx --yes -p renovate renovate-config-validator .github/renovate.json5`
  (network access to npm was slow but did succeed in this sandbox after a
  few minutes). It caught two real mistakes on the first pass (`prPriority`
  is invalid inside `vulnerabilityAlerts`; there is no
  `matchCurrentVulnerability` packageRules selector) — both fixed. Final
  result: `INFO: Config validated successfully`.

## Required manual follow-up (outside this PR's scope)

**This config is inert until a repo/org admin installs the Renovate
GitHub App** at <https://github.com/apps/renovate>. No amount of merging
this PR makes Renovate run — that requires an admin action through the
GitHub UI that this session cannot perform. See "How to actually turn this
on" in `docs/RENOVATE_SETUP.md` for the full steps.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — N/A, no
      tracking issue for this change (see Summary)
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`,
      `chore:`, etc.)
- [x] WR/issue scope is delivered in full — config + doc are complete;
      GitHub App installation is explicitly out of scope for this PR (see
      above) and documented as the required next step


---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a comprehensive Renovate configuration to enable automated dependency update PRs for the repo's npm dependencies and 166+ GitHub Actions workflows. The config includes a conservative auto-merge policy that only applies to non-major dev/CI bumps (all majors and production dependencies require manual review and dashboard approval), weekly scheduling to avoid collision with existing Monday dependency reports, grouped updates to minimize noise, and immediate vulnerability alerts. A detailed setup document explains the rationale, policy summary, and manual installation steps required (the config is inert until a repo admin installs the Renovate GitHub App).

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/RENOVATE_SETUP.md` |
| 2 | `.github/renovate.json5` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Renovate to automate dependency updates for `npm` and GitHub Actions with a conservative, low-noise setup, plus a short setup guide. This reduces manual upkeep while keeping majors and production deps under human review.

- **New Features**
  - Add `.github/renovate.json5` for `npm` and `github-actions`; runs weekly before 6am Wednesday UTC with PR limits.
  - Group and auto-merge only non-major GitHub Actions and `devDependencies` when CI is green; majors and `dependencies` never auto-merge and require Dependency Dashboard approval.
  - Enable fast-lane vulnerability alerts and weekly lockfile maintenance.
  - Use semantic commit titles and the `dependencies` label; keep action pin style (`pinDigests: false`); `rangeStrategy: auto`.
  - Add `docs/RENOVATE_SETUP.md` covering policy and how it works with existing `renovate[bot]` auto-approve workflows.

- **Migration**
  - A repo/org admin must install the Renovate GitHub App to activate this config: https://github.com/apps/renovate.

<sup>Written for commit 20e001fd6dbde83e8099d4318924a6f78aeb7a40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Closes #15835

Closes #15891

Closes #15913
closes #15913

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refines the Renovate configuration by significantly streamlining both the config file (`.github/renovate.json5`) and documentation (`docs/RENOVATE_SETUP.md`). The changes reduce verbosity while preserving the conservative auto-merge policy: only non-major GitHub Actions and npm `devDependencies` updates auto-merge once CI passes, while major bumps and production dependencies always require manual review and dashboard approval. The refactor removes redundant comments and rules, consolidates semantic commit configuration into individual package rules, and tightens the documentation to focus on rationale, policy summary, and installation steps rather than exhaustive option-by-option walkthroughs.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/RENOVATE_SETUP.md` |
| 2 | `.github/renovate.json5` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->