### PR TITLE
[openrouter] [openrouter] [openrouter] [openrouter] feat: route checked Follow-up checklist items to tracked WR issues

### DIFF
--- a/scripts/checkbox-diff.js
+++ b/scripts/checkbox-diff.js
@@ -3,122 +3,140 @@
 /**
  * checkbox-diff.js
  *
- * Diffs two markdown bodies (an issue's or PR's `body` before/after an edit)
- * to find task-list ("- [ ]" / "- [x]") lines that were newly checked in
- * this edit AND match the `Follow-up:` convention documented in
- * `.github/workflows/followup-checkbox-router.yml`:
+ * Pure utility for detecting follow-up checkbox transitions in markdown bodies
+ * (issue/PR descriptions). Used by the follow-up-checkbox-router workflow to
+ * decide whether a maintainer just checked a `- [ ] Follow-up: ...` line, which
+ * is the trigger to spin out a tracked WR issue.
  *
- *   - [ ] Follow-up: <free text description of what needs tracking later>
+ * The core function `findNewlyCheckedFollowUps(oldBody, newBody)` returns an
+ * array of description strings for each follow-up that transitioned from
+ * unchecked in `oldBody` to checked in `newBody`.
  *
- * When a maintainer/agent edits the body and flips that box from unchecked
- * to checked, it is the trigger signal to spin the follow-up out into a
- * tracked WR issue. This module is the pure-logic half of that feature — it
- * has no GitHub API / network dependency so it can be unit tested directly.
+ * Matching is done by *normalized text content*, not line position, so that
+ * unrelated edits or reordering in the same body edit don't create false
+ * positives or false negatives.
+ *
+ * No network / GitHub API dependency — fully unit-testable.
  */
 
-// Matches a markdown task-list line, e.g.:
-//   - [ ] Follow-up: do the thing
-//   * [x] some other item
-//   +   [X]   spaced out item
-const TASK_LINE_RE = /^[ \t]*[-*+][ \t]+\[([ xX])\][ \t]+(.+?)[ \t]*$/;
+// Matches a markdown task-list line, capturing:
+//   1: the checkbox state character (space, x, or X)
+//   2: the rest of the line (the item text)
+//
+// Tolerates leading whitespace and common list markers (- / * / +).
+const TASK_LINE_RE = /^\s*[-*+]\s+\[( |x|X)\]\s+(.*)$/;
 
-// Matches the "Follow-up:" prefix (case-insensitive, optional hyphen,
-// optional colon, tolerant of trailing whitespace) that marks a checklist
-// item as a trackable follow-up commitment. Covers "Follow-up:", "Followup:",
-// "FOLLOWUP". (Does not match "Follow up:" with a bare space — the
-// convention documented in followup-checkbox-router.yml is "Follow-up:".)
-const FOLLOWUP_PREFIX_RE = /^follow-?up:?\s*/i;
+// Matches the follow-up prefix, case-insensitively, tolerating minor
+// whitespace/hyphen variants like "Follow up:", "follow-up :", "Followup:".
+const FOLLOWUP_PREFIX_RE = /^follow[\s-]?up\s*:\s*/i;
 
 /**
- * Parse every markdown task-list line out of a body.
- * @param {string|null|undefined} body
- * @returns {Array<{ text: string, checked: boolean }>}
+ * Normalize an item's text for cross-body matching.
+ *
+ * Collapses whitespace and lowercases so that trivial reformatting between the
+ * two body versions (e.g. an extra space, a capitalization change on the
+ * prefix) doesn't cause us to treat the same item as two different items.
+ *
+ * @param {string} text
+ * @returns {string}
  */
-function parseTaskItems(body) {
-  if (!body) return [];
-  const items = [];
+function normalizeItemText(text) {
+  return String(text || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Extract the follow-up description (text after the `Follow-up:` prefix), or
+ * null if this task-list line is not a follow-up item at all.
+ *
+ * @param {string} itemText - the text of a task list line, without the `[ ]`/`[x]` box.
+ * @returns {string|null} - the description, or null if not a follow-up line.
+ */
+function extractFollowUpDescription(itemText) {
+  if (typeof itemText !== 'string') return null;
+  const match = itemText.match(FOLLOWUP_PREFIX_RE);
+  if (!match) return null;
+  const description = itemText.slice(match[0].length).trim();
+  // A follow-up line with no description at all is not actionable — skip it
+  // rather than firing a WR with an empty body.
+  if (!description) return null;
+  return description;
+}
+
+/**
+ * Parse a body string into an array of task-list items.
+ *
+ * @param {string|null|undefined} body
+ * @returns {Array<{checked: boolean, text: string, normalized: string, followUpDescription: string|null}>}
+ */
+function parseTaskListItems(body) {
+  if (body == null) return [];
   const lines = String(body).split(/\r?\n/);
+  const items = [];
   for (const line of lines) {
-    const match = TASK_LINE_RE.exec(line);
+    const match = line.match(TASK_LINE_RE);
     if (!match) continue;
+    const box = match[1];
+    const text = match[2];
     items.push({
-      checked: match[1].toLowerCase() === 'x',
-      text: match[2].trim(),
+      checked: box === 'x' || box === 'X',
+      text: text,
+      normalized: normalizeItemText(text),
+      followUpDescription: extractFollowUpDescription(text),
     });
   }
   return items;
 }
 
 /**
- * Normalize task-item text into a matching key. Minor whitespace variation
- * (extra spaces, tabs) should not prevent a line from being matched between
- * the old and new body; case is folded too since "Follow-up" items are
- * matched case-insensitively everywhere else in this module.
- * @param {string} text
- * @returns {string}
- */
-function normalizeKey(text) {
-  return text.trim().toLowerCase().replace(/\s+/g, ' ');
-}
-
-/**
- * Find follow-up checklist items that transitioned from unchecked to
- * checked between `oldBody` and `newBody`.
+ * Find follow-up items that were unchecked in `oldBody` and are now checked in
+ * `newBody`.
  *
- * Matching strategy: items are matched by normalized text content (not by
- * line position), so a line can be correctly identified as "the same item"
- * even if unrelated lines above/below it were added, removed, or reordered
- * in the same edit. Only an item that (a) existed in `oldBody` as unchecked
- * and (b) exists in `newBody` as checked counts as "newly checked" — an
- * item that is brand new in `newBody` (no matching text in `oldBody` at
- * all) is not reported, since there is no unchecked->checked transition to
- * observe for it.
+ * Behavior:
+ *  - If a follow-up line exists in newBody but did not exist at all in
+ *    oldBody, it is NOT reported (added-and-checked in the same edit — no
+ *    prior unchecked state to transition from).
+ *  - If a follow-up line was already checked in oldBody, it is NOT reported
+ *    (no transition).
+ *  - Non-follow-up checkboxes are ignored entirely.
+ *  - Matching between the two bodies is done by normalized item text, so
+ *    reorderings in the same edit still match correctly.
  *
- * @param {string|null|undefined} oldBody - body before the edit
- *   (`github.event.changes.body.from`). May be null/undefined, e.g. when
- *   the issue/PR was just created and there is no prior body to diff
- *   against, or when the edit didn't touch the body field at all.
- * @param {string|null|undefined} newBody - body after the edit (current
- *   `issue.body` / `pull_request.body`).
- * @returns {string[]} the free-text description of each newly-checked
- *   follow-up item, with the `Follow-up:` prefix stripped and trimmed. If
- *   multiple follow-up items were checked in the same edit, all of them are
- *   returned, in the order they appear in `newBody`.
+ * @param {string|null|undefined} oldBody
+ * @param {string|null|undefined} newBody
+ * @returns {Array<string>} - array of follow-up description strings that were newly checked.
  */
 function findNewlyCheckedFollowUps(oldBody, newBody) {
-  if (!oldBody || !newBody) return [];
+  const oldItems = parseTaskListItems(oldBody);
+  const newItems = parseTaskListItems(newBody);
 
-  const oldItems = parseTaskItems(oldBody);
-  const newItems = parseTaskItems(newBody);
-  if (oldItems.length === 0 || newItems.length === 0) return [];
-
-  // Bucket old items by normalized text into per-key queues so duplicate
-  // line text (rare, but possible) is matched one-to-one in document order
-  // rather than every duplicate matching the first old entry.
-  const oldByKey = new Map();
+  // Build a map of oldBody items keyed by normalized text — used to look up
+  // "was this same item unchecked before?"
+  const oldByNormalized = new Map();
   for (const item of oldItems) {
-    const key = normalizeKey(item.text);
-    if (!oldByKey.has(key)) oldByKey.set(key, []);
-    oldByKey.get(key).push(item);
+    // If duplicates exist in the old body, prefer the first occurrence.
+    if (!oldByNormalized.has(item.normalized)) {
+      oldByNormalized.set(item.normalized, item);
+    }
   }
 
   const results = [];
-  for (const newItem of newItems) {
-    if (!newItem.checked) continue;
+  const seenNormalized = new Set();
 
-    const key = normalizeKey(newItem.text);
-    const queue = oldByKey.get(key);
-    if (!queue || queue.length === 0) continue; // no matching prior line found
-    const oldItem = queue.shift();
-    if (oldItem.checked) continue; // already checked before this edit
+  for (const item of newItems) {
+    if (!item.checked) continue;
+    if (!item.followUpDescription) continue;
+    // Deduplicate within newBody itself in case the same follow-up appears twice.
+    if (seenNormalized.has(item.normalized)) continue;
+    seenNormalized.add(item.normalized);
 
-    const followUpMatch = FOLLOWUP_PREFIX_RE.exec(newItem.text);
-    if (!followUpMatch) continue; // checked, but not a "Follow-up:" item
+    const previous = oldByNormalized.get(item.normalized);
+    if (!previous) continue; // added-and-checked in same edit — skip
+    if (previous.checked) continue; // already checked before — skip
 
-    const description = newItem.text.slice(followUpMatch[0].length).trim();
-    if (!description) continue; // "Follow-up:" with no description — nothing to track
-
-    results.push(description);
+    results.push(item.followUpDescription);
   }
 
   return results;
@@ -126,8 +144,8 @@ function findNewlyCheckedFollowUps(oldBody, newBody) {
 
 module.exports = {
   findNewlyCheckedFollowUps,
-  parseTaskItems,
-  normalizeKey,
-  TASK_LINE_RE,
-  FOLLOWUP_PREFIX_RE,
+  // Exported for testing / reuse:
+  parseTaskListItems,
+  extractFollowUpDescription,
+  normalizeItemText,
 };

--- a/tests/checkbox-diff.test.js
+++ b/tests/checkbox-diff.test.js
@@ -1,185 +1,191 @@
 'use strict';
 
-const test = require('node:test');
-const assert = require('node:assert');
-
+const assert = require('assert');
 const {
   findNewlyCheckedFollowUps,
-  parseTaskItems,
-  normalizeKey,
+  parseTaskListItems,
+  extractFollowUpDescription,
 } = require('../scripts/checkbox-diff');
 
-// ── findNewlyCheckedFollowUps ───────────────────────────────────────────────
+let passed = 0;
+let failed = 0;
 
-test('reports a single follow-up item checked in this edit', () => {
-  const oldBody = [
-    '## Summary',
-    '',
-    '- [ ] Follow-up: circle back on the flaky retry logic',
-  ].join('\n');
-  const newBody = [
-    '## Summary',
-    '',
-    '- [x] Follow-up: circle back on the flaky retry logic',
-  ].join('\n');
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
 
+console.log('checkbox-diff');
+
+// 1. Single item transitioned from unchecked to checked.
+test('detects a single newly-checked follow-up', () => {
+  const oldBody = '- [ ] Follow-up: revisit caching strategy';
+  const newBody = '- [x] Follow-up: revisit caching strategy';
   const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['circle back on the flaky retry logic']);
+  assert.deepStrictEqual(result, ['revisit caching strategy']);
 });
 
-test('reports multiple follow-up items checked in the same edit', () => {
+// 2. Multiple items checked in the same edit.
+test('detects multiple newly-checked follow-ups in one edit', () => {
   const oldBody = [
-    '- [ ] Follow-up: item one',
-    '- [ ] Follow-up: item two',
-    '- [ ] some unrelated task',
+    '- [ ] Follow-up: first item',
+    '- [ ] Follow-up: second item',
+    '- [ ] Follow-up: third item',
   ].join('\n');
   const newBody = [
-    '- [x] Follow-up: item one',
-    '- [x] Follow-up: item two',
-    '- [x] some unrelated task',
+    '- [x] Follow-up: first item',
+    '- [ ] Follow-up: second item',
+    '- [X] Follow-up: third item',
   ].join('\n');
-
   const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['item one', 'item two']);
+  assert.deepStrictEqual(result, ['first item', 'third item']);
 });
 
-test('does not match a checked box whose text is not a follow-up item', () => {
-  const oldBody = '- [ ] Deploy to staging';
-  const newBody = '- [x] Deploy to staging';
-
+// 3. An unrelated (non-follow-up) checkbox being checked is ignored.
+test('ignores non-follow-up checkboxes', () => {
+  const oldBody = [
+    '- [ ] Some random task',
+    '- [ ] Closes #N is present',
+  ].join('\n');
+  const newBody = [
+    '- [x] Some random task',
+    '- [x] Closes #N is present',
+  ].join('\n');
   const result = findNewlyCheckedFollowUps(oldBody, newBody);
   assert.deepStrictEqual(result, []);
 });
 
-test('does not re-report a follow-up that was already checked before this edit', () => {
-  const oldBody = [
-    '- [x] Follow-up: already tracked, do not refire',
-    '- [ ] Follow-up: newly checked this time',
-  ].join('\n');
-  const newBody = [
-    '- [x] Follow-up: already tracked, do not refire',
-    '- [x] Follow-up: newly checked this time',
-  ].join('\n');
-
+// 4. Already-checked item is not re-reported.
+test('does not re-report already-checked items', () => {
+  const oldBody = '- [x] Follow-up: previously handled';
+  const newBody = '- [x] Follow-up: previously handled';
   const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['newly checked this time']);
+  assert.deepStrictEqual(result, []);
 });
 
-test('returns an empty array when oldBody is missing/null (e.g. issue just created)', () => {
-  const newBody = '- [x] Follow-up: brand new item checked on creation';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(null, newBody), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(undefined, newBody), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps('', newBody), []);
+// 5. Item added-and-checked in the same edit (no prior unchecked state) is
+//    NOT reported — that's the anti-overfire rule.
+test('does not report items added-and-checked in the same edit', () => {
+  const oldBody = 'Some description with no checkboxes yet.';
+  const newBody = [
+    'Some description with no checkboxes yet.',
+    '- [x] Follow-up: brand new item',
+  ].join('\n');
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, []);
 });
 
-test('returns an empty array when newBody is missing/null', () => {
+// 6. Null / undefined oldBody handled gracefully.
+test('handles null oldBody without throwing', () => {
+  const newBody = '- [x] Follow-up: something';
+  const result = findNewlyCheckedFollowUps(null, newBody);
+  // No prior state to transition from → nothing reported.
+  assert.deepStrictEqual(result, []);
+});
+
+// 7. Null / undefined newBody handled gracefully.
+test('handles null newBody without throwing', () => {
   const oldBody = '- [ ] Follow-up: something';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, null), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, undefined), []);
-});
-
-test('returns an empty array when there are no task-list lines at all', () => {
-  const oldBody = 'Just a plain description with no checkboxes.';
-  const newBody = 'Just a plain description with no checkboxes, edited.';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
-});
-
-test('ignores an item newly added and checked in the same edit (no prior unchecked state to transition from)', () => {
-  const oldBody = '- [ ] Follow-up: existing item';
-  const newBody = [
-    '- [ ] Follow-up: existing item',
-    '- [x] Follow-up: item that appeared already checked',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  const result = findNewlyCheckedFollowUps(oldBody, null);
   assert.deepStrictEqual(result, []);
 });
 
-test('matches follow-up items by text even when unrelated lines are reordered', () => {
+// 8. Both bodies null — returns empty, no throw.
+test('handles both bodies null', () => {
+  const result = findNewlyCheckedFollowUps(null, null);
+  assert.deepStrictEqual(result, []);
+});
+
+// 9. Reordered lines between old and new body still match by content.
+test('matches items across reordering', () => {
   const oldBody = [
-    '- [ ] alpha task',
-    '- [ ] Follow-up: track the migration cleanup',
-    '- [ ] beta task',
+    '- [ ] Follow-up: item A',
+    '- [ ] Follow-up: item B',
   ].join('\n');
   const newBody = [
-    '- [x] beta task',
-    '- [x] Follow-up: track the migration cleanup',
-    '- [ ] alpha task',
+    '- [x] Follow-up: item B',
+    '- [ ] Follow-up: item A',
   ].join('\n');
-
   const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['track the migration cleanup']);
+  assert.deepStrictEqual(result, ['item B']);
 });
 
-test('handles case-insensitive and hyphen/colon variations of the Follow-up prefix', () => {
-  const oldBody = [
-    '- [ ] FOLLOWUP no colon or hyphen',
-    '- [ ] followup: no hyphen, with colon',
-    '- [ ] Follow-Up:  extra   spacing',
-  ].join('\n');
-  const newBody = [
-    '- [x] FOLLOWUP no colon or hyphen',
-    '- [x] followup: no hyphen, with colon',
-    '- [x] Follow-Up:  extra   spacing',
-  ].join('\n');
-
+// 10. Prefix casing variants — "follow-up:", "Follow-Up:", "FOLLOW-UP:".
+test('recognizes case-insensitive Follow-up prefix', () => {
+  const oldBody = '- [ ] follow-up: lowercase prefix';
+  const newBody = '- [x] FOLLOW-UP: lowercase prefix';
   const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, [
-    'no colon or hyphen',
-    'no hyphen, with colon',
-    'extra   spacing',
-  ]);
+  assert.deepStrictEqual(result, ['lowercase prefix']);
 });
 
-test('does not match "Follow up:" with a bare space (convention requires the hyphenated form)', () => {
-  const oldBody = '- [ ] Follow up: with a bare space';
-  const newBody = '- [x] Follow up: with a bare space';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
+// 11. Whitespace-variant prefix ("Follow up:" with space, "Followup:" without hyphen).
+test('tolerates minor whitespace/hyphen variants on the prefix', () => {
+  assert.strictEqual(extractFollowUpDescription('Follow up: no hyphen'), 'no hyphen');
+  assert.strictEqual(extractFollowUpDescription('Followup: joined'), 'joined');
+  assert.strictEqual(extractFollowUpDescription('Follow-up : trailing space'), 'trailing space');
 });
 
-test('tolerates minor whitespace differences between old and new line text when matching', () => {
-  const oldBody = '- [ ]   Follow-up:   trim me   ';
-  const newBody = '- [x] Follow-up:   trim me';
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['trim me']);
-});
-
-test('drops a Follow-up item with no description text', () => {
+// 12. Follow-up line with no description is skipped (not actionable).
+test('skips follow-up lines with no description', () => {
   const oldBody = '- [ ] Follow-up:';
   const newBody = '- [x] Follow-up:';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, []);
 });
 
-// ── parseTaskItems ───────────────────────────────────────────────────────
+// 13. Different list markers (`*`, `+`) still parsed.
+test('parses task lists with * and + markers', () => {
+  const items = parseTaskListItems('* [ ] Follow-up: star marker\n+ [x] Follow-up: plus marker');
+  assert.strictEqual(items.length, 2);
+  assert.strictEqual(items[0].followUpDescription, 'star marker');
+  assert.strictEqual(items[1].followUpDescription, 'plus marker');
+  assert.strictEqual(items[1].checked, true);
+});
 
-test('parseTaskItems parses checked/unchecked markers and strips marker syntax', () => {
-  const body = [
-    '- [ ] unchecked item',
-    '- [x] checked lowercase',
-    '- [X] checked uppercase',
-    '* [x] asterisk bullet',
-    '+ [x] plus bullet',
-    'not a task line',
+// 14. Mixed edit: one newly checked, one unchecked, one unrelated toggled.
+test('mixed edit reports only the newly-checked follow-up', () => {
+  const oldBody = [
+    '- [ ] Follow-up: relevant transition',
+    '- [ ] Follow-up: still unchecked',
+    '- [ ] Some unrelated checkbox',
   ].join('\n');
-
-  assert.deepStrictEqual(parseTaskItems(body), [
-    { checked: false, text: 'unchecked item' },
-    { checked: true, text: 'checked lowercase' },
-    { checked: true, text: 'checked uppercase' },
-    { checked: true, text: 'asterisk bullet' },
-    { checked: true, text: 'plus bullet' },
-  ]);
+  const newBody = [
+    '- [x] Follow-up: relevant transition',
+    '- [ ] Follow-up: still unchecked',
+    '- [x] Some unrelated checkbox',
+  ].join('\n');
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, ['relevant transition']);
 });
 
-test('parseTaskItems returns an empty array for null/undefined/empty input', () => {
-  assert.deepStrictEqual(parseTaskItems(null), []);
-  assert.deepStrictEqual(parseTaskItems(undefined), []);
-  assert.deepStrictEqual(parseTaskItems(''), []);
+// 15. Empty bodies handled.
+test('handles empty-string bodies', () => {
+  assert.deepStrictEqual(findNewlyCheckedFollowUps('', ''), []);
+  assert.deepStrictEqual(findNewlyCheckedFollowUps('', '- [x] Follow-up: anything'), []);
 });
 
-// ── normalizeKey ─────────────────────────────────────────────────────────
-
-test('normalizeKey folds case and collapses whitespace', () => {
-  assert.strictEqual(normalizeKey('  Follow-Up:   Do The Thing  '), 'follow-up: do the thing');
+// 16. Duplicated follow-up in newBody deduplicated in output.
+test('deduplicates identical follow-up descriptions within newBody', () => {
+  const oldBody = [
+    '- [ ] Follow-up: same text',
+    '- [ ] Follow-up: same text',
+  ].join('\n');
+  const newBody = [
+    '- [x] Follow-up: same text',
+    '- [x] Follow-up: same text',
+  ].join('\n');
+  const result = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepStrictEqual(result, ['same text']);
 });
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
Automated code changes for
issue #15924.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15898.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15879.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15834.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
## Summary

Adds a checkbox convention that turns follow-up commitments left in PR/issue bodies into tracked work automatically, closing the gap where those commitments get silently dropped. Motivating case: a recon on #13978 (an 8-item follow-up tracking WR) found several items were never actually followed up on — there was no mechanism to notice when someone checked a "we'll come back to this" box.

**The convention:** anywhere in a PR or issue body (including WR issues themselves), a checklist line of the form

```
- [ ] Follow-up: 
```

can be added. When a maintainer or agent **edits the body and checks that box** (`- [ ]` → `- [x]`/`- [X]`, matched case-insensitively with minor whitespace/hyphen tolerance on the `Follow-up:` prefix), that transition is the trigger signal: "yes, spin this out into a tracked WR." A new `[WR]` issue is filed automatically, linked back to the source, and the source gets a comment linking to the new WR — a two-way link so neither side goes stale.

Nothing happens if the box is added and checked in the *same* edit (no prior unchecked state to transition from — avoids over-firing), if a different box is checked, or if the box was already checked before.

## Changes

- `scripts/checkbox-diff.js` — new pure utility, `findNewlyCheckedFollowUps(oldBody, newBody)`. Parses markdown task-list lines from both bodies and matches them **by normalized text content** (not line position), so reordering or unrelated edits in the same diff don't break detection. No network/GitHub dependency, so it's fully unit-testable.
- `tests/checkbox-diff.test.js` — 16 cases: single item checked, multiple items checked in one edit, unrelated (non-follow-up) checkbox checked, already-checked item not re-reported, missing/null `oldBody`/`newBody`, reordered lines, prefix-casing/whitespace variants, no-description edge case.
- `.github/workflows/followup-checkbox-router.yml` — new workflow, triggers on `pull_request: [edited]` and `issues: [edited]`. Diffs `github.event.changes.body?.from` against the current body via `checkbox-diff.js` (guards for `changes.body` being absent, e.g. a title-only edit). For each newly-checked follow-up: classifies BASIC vs FULL using the same spirit as `wr-pr-creation.yml`'s title-regex heuristic (short one-liner → BASIC by default; long/multi-clause → FULL), renders the chosen WR template with the follow-up's link + description in `## Issue Context` and `## Learnings — What & Why`, creates the WR issue (`work-request`, `auto-generated-followup` labels; assignee `oaudrey`), and comments back on the source PR/issue with the new WR link.
- `wr/WR_TEMPLATE_FULL.md`, `wr/WR_TEMPLATE_BASIC.md` — new `## Learnings — What & Why` section. Ships as a generic guidance placeholder for normal WRs ("agents completing other WR types should fill this in themselves once done..."); for follow-up-generated WRs the router populates it with the concrete follow-up text, a link to the source PR/issue, and — if the source itself carries a `sourced from #N` marker — a note that this is a chained follow-up (kept simple for v1, no full chain-walking).
- `.github/labels.yml` — registers `auto-generated-followup` so it syncs via `sync-labels.yml`.
- `docs/SECRETS_MAP.md` — regenerated (`npm run secrets:map`) to include the new workflow's `ADMIN_GITHUB_TOKEN`/`GITHUB_TOKEN` references; this is what made `tests/secrets-map.test.js` go red until regenerated.

Permissions on the new workflow are `contents: read` (checkout only — no commits), `issues: write`, `pull-requests: write` — narrowest set the job needs, using the repo-standard `ADMIN_GITHUB_TOKEN`-with-fallback token pattern so the new WR issue can trigger downstream WR-processing workflows (CLAUDE.md gotchas #2/#3).

## Design decisions / judgment calls

- **BASIC vs FULL classification**: mirrors `wr-pr-creation.yml`'s spirit rather than reusing its exact regex, since follow-up descriptions are free text, not titles with `fix`/`bug`/`chore` keywords. Heuristic: length > 180 chars or multi-clause phrasing (`;`/`:` mid-sentence, "then"/"also") → FULL; otherwise BASIC.
- **Chained follow-ups**: kept intentionally simple per the task brief — if the source body contains `sourced from #N`, the new WR's Learnings section just notes that ancestry once. No recursive chain-walking.
- **Known nesting limitation (flagged, not fixed here)**: the router builds a *fully rendered* WR-shaped issue body (its own populated `Issue Context` + `Learnings` sections) rather than a bare description, per the "mirror wr-pr-creation.yml's inline template-selection + token-substitution approach" instruction. Because the new issue also carries the `work-request` label, it will *also* flow through the existing `wr-pr-creation.yml` pipeline (triggered on `opened`), which independently classifies the title and generates its own WR file, nesting this pre-rendered body inside a fresh template's `Issue Context` — so the final committed `wr/issues/*.md` may show the populated `Learnings` content nested one level down rather than promoted to the file's own top-level section. I deliberately did **not** patch `wr-pr-creation.yml` to special-case the `auto-generated-followup` label and lift that content, per CLAUDE.md's explicit warning that this file is fragile and has broken before from stacked edits (2026-07-08 incident). Tracking this as a follow-up itself:
  - [ ] Follow-up: consider having `wr-pr-creation.yml` special-case the `auto-generated-followup` label to promote the router's pre-rendered `Learnings — What & Why` content to the top level instead of leaving it nested under `Issue Context`.

## Validation

- `npm ci && npm test` — 574/574 passing, including the new `tests/checkbox-diff.test.js` (16 cases).
- `python3 -c "import yaml; yaml.safe_load(open(F))"` on both changed YAML files (`followup-checkbox-router.yml`, `labels.yml`) — clean.
- Changed-Markdown gate (`npx markdownlint-cli2` scoped to files changed vs. `origin/main`) — 0 errors.
- Manually simulated the workflow's template-rendering logic against the real `wr/WR_TEMPLATE_BASIC.md`/`FULL.md` files with sample short and long/chained follow-up descriptions — confirmed no leftover `{TOKEN}` placeholders and no strings that would trip `wr-lint`'s deferral-placeholder rule (no `TBD`/`TODO`/`N/A — pending ...`).

**Limitation:** this workflow's live trigger path (`issues: edited` / `pull_request: edited` with a real checkbox transition) **cannot be exercised end-to-end from this sandboxed session** — there's no way to fire a real GitHub webhook event here. The pure-logic half (`checkbox-diff.js`, the part that's actually verifiable without live GitHub state) has thorough unit coverage; the workflow YAML and its GitHub-API calls are unverified beyond YAML validity, the manual template-render simulation above, and careful reading against this repo's established patterns (`pdf-work-request-router.yml`'s `require(process.env.GITHUB_WORKSPACE + ...)` + token-fallback pattern, `wr-pr-creation.yml`'s classification/substitution approach). Recommend a maintainer exercises it live on a throwaway issue before relying on it.

`docs-freshness: checked both paired-doc targets -- docs/SYSTEM_MAP.md does not exist in this repo, and docs/AUTOMATION_AUDIT.md is a stale point-in-time audit snapshot (already lists "58 total" workflows against an actual count of 166+, and names workflows like openrouter-triage.yml that don't match the current tree). Adding one entry to an already-drifted historical doc wouldn't restore freshness, just add false confidence to it -- refreshing that doc is a separate, larger effort outside this PR's scope.`

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above




---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_


## High-level PR Summary
This PR introduces an automated mechanism to convert checked follow-up checklist items in PR/issue bodies into tracked Work Request (WR) issues. When a maintainer checks a box with the format `- [ ] Follow-up: `, a new workflow automatically creates a corresponding WR issue with appropriate templates, labels, and links back to the source. The implementation includes a pure-logic checkbox diff utility (`checkbox-diff.js`) with comprehensive unit tests, a new GitHub Actions workflow (`followup-checkbox-router.yml`) that triggers on issue/PR edits, and updates to WR templates to include a **Learnings — What & Why** section that gets populated automatically for follow-up-generated WRs.

⏱️ Estimated Review Time: 30-90 minutes


💡 Review Order Suggestion

| Order | File Path |
|-------|-----------|
| 1 | `scripts/checkbox-diff.js` |
| 2 | `tests/checkbox-diff.test.js` |
| 3 | `.github/workflows/followup-checkbox-router.yml` |
| 4 | `wr/WR_TEMPLATE_BASIC.md` |
| 5 | `wr/WR_TEMPLATE_FULL.md` |
| 6 | `.github/labels.yml` |
| 7 | `docs/SECRETS_MAP.md` |




[[Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)




---
## Summary by cubic
Automatically turns checked "Follow-up:" checklist items in PR/issue bodies into tracked WR issues to prevent dropped commitments. Detects unchecked→checked transitions and creates a new `[WR]` with two‑way links.

- **New Features**
  - Added `followup-checkbox-router.yml` to handle `pull_request.edited` / `issues.edited`: diffs `body`, creates a `[WR]` per newly checked `Follow-up:` item, labels `work-request` + `auto-generated-followup`, assigns `oaudrey`, and comments back with the link.
  - Introduced `scripts/checkbox-diff.js` with `tests/checkbox-diff.test.js` to find newly checked follow-ups by normalized text; ignores brand‑new or already‑checked boxes and handles reordering/casing/whitespace.
  - Added "Learnings — What & Why" to `wr/WR_TEMPLATE_BASIC.md` and `wr/WR_TEMPLATE_FULL.md`; router fills it with the follow-up text and source link; BASIC vs FULL chosen by a simple length/multi‑clause heuristic.
  - Registered the `auto-generated-followup` label and updated `docs/SECRETS_MAP.md` to include `followup-checkbox-router.yml` token references.

<sup>Written for commit f11a051100687f3ac45e6e5c4d1de679ba58421d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15834?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>

Closes #15834

Closes #15879

Closes #15898

Closes #15924
closes #15924