### PR TITLE
[openrouter] [openrouter] [openrouter] [openrouter] feat(renovate): add comprehensive Renovate configuration + setup doc

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,288 +1,135 @@
-// Renovate configuration for automated dependency updates.
 {
-  // Renovate configuration for this repository.
+  // Renovate configuration for automated dependency updates.
   // Docs: https://docs.renovatebot.com/configuration-options/
   //
-  // This config is inert until the Renovate GitHub App is installed on the
-  // repo/org. See docs/RENOVATE_SETUP.md for the manual one-time step.
+  // This config is inert until the Renovate GitHub App is installed:
+  //   https://github.com/apps/renovate
+  // See docs/RENOVATE_SETUP.md for full rationale and install steps.
 
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
 
   // Renovate's maintained sane-defaults preset: dependency dashboard,
-  // semantic commits, rate limiting, major/minor/patch separation, etc.
-// ═══════════════════════════════════════════════════════════════════════════
-// RENOVATE CONFIGURATION — revvel-standards
-//
-// This file is inert until a repo/org admin installs the Renovate GitHub App
-// at https://github.com/apps/renovate. See docs/RENOVATE_SETUP.md for the
-// full rationale, policy summary, and installation instructions.
-//
-// Validated with: npx --yes -p renovate renovate-config-validator .github/renovate.json5
-{
-  $schema: "https://docs.renovatebot.com/renovate-schema.json",
-
-  // Renovate's maintained sane-defaults preset: dependency dashboard,
-  // semantic commits, rate limiting, major/minor/patch separation, etc.
-  extends: ["config:recommended"],
+  // semantic commits, rate limiting, major/minor/patch separation.
+  extends: ['config:recommended'],
 
   // Match this repo's actual dependency surfaces exactly. No Dockerfiles
-  // exist, so nothing else is enabled by accident when Renovate adds new
-  // managers upstream.
-  enabledManagers: ["npm", "github-actions"],
+  // exist; keep the surface explicit so new upstream managers don't
+  // silently activate.
+  enabledManagers: ['npm', 'github-actions'],
 
-  // Off the Monday 09:00 UTC dependency-update-checker.yml report:
-  // Wednesday gives a couple days' visibility from the manual report
-  // before automated PRs land, and avoids a same-day collision.
-  timezone: "Etc/UTC",
-  schedule: ["before 6am on wednesday"],
-
-  // Caps batch size so a first install (or backlog) doesn't storm the PR
-  // list. This repo has a demonstrated aversion to noisy automation.
-  // Restrict Renovate to the dependency surfaces this repo actually has.
-  // No Dockerfiles exist; explicitly listing managers prevents accidental
-  // activation when Renovate adds new managers upstream.
-  // ─── SCOPE ──────────────────────────────────────────────────────────────
-  // This repo's dependency surfaces today: npm (package.json) and GitHub
-  // Actions (.github/workflows/*.yml). No Dockerfiles, no other package
-  // managers detected. Being explicit here means adding a new manager
-  // (e.g. a future Dockerfile) is a deliberate opt-in, not a silent
-  // auto-enable next time Renovate's own defaults change.
-  enabledManagers: [
-    'npm',
-    'github-actions',
-  ],
-
-  // Scheduling: run Wednesday early morning UTC so that the existing
-  // Monday 09:00 UTC `dependency-update-checker.yml` manual report has a
-  // couple of days of visibility before automated PRs land.
-  // ─── SCHEDULING ─────────────────────────────────────────────────────────
-  // dependency-update-checker.yml already runs Monday 09:00 UTC and files a
-  // manual report issue. Renovate's own PR batch runs later in the same
-  // week, off-hours, so: (a) it never collides with the Monday report run,
-  // and (b) maintainers get a couple of days' visibility from the manual
-  // report before automated PRs actually land. All times are UTC to match
-  // the cron schedules already used elsewhere in .github/workflows/*.yml
-  // (GitHub Actions cron is always UTC).
+  // Schedule off the Monday 09:00 UTC dependency-update-checker.yml
+  // report: Wednesday gives a couple days' visibility from the manual
+  // report before automated PRs land.
   timezone: 'Etc/UTC',
-  schedule: [
-    'before 6am on wednesday',
-  ],
+  schedule: ['before 6am on wednesday'],
 
-  // Rate limiting: cap PR churn, especially for the initial run/backlog.
+  // Cap batch size so a first install (or backlog) doesn't storm the PR
+  // list. This repo has a demonstrated aversion to noisy automation.
   prConcurrentLimit: 10,
   prHourlyLimit: 4,
 
-  // Central tracking issue for pending updates and major-version gating.
-  // Cap batch size so a fresh install (or a big backlog) doesn't dump dozens
-  // of PRs at once — consistent with this repo's demonstrated aversion to
-  // noisy automation (see CLAUDE.md's gotchas about noisy/broken checks).
-  prConcurrentLimit: 10,
-  prHourlyLimit: 4,
-
-  // Renovate's built-in "everything pending" tracking issue. Mirrors this
-  // repo's existing WR/issue tracking conventions; majors require checking
-  // a box here before their PR even opens.
+  // Renovate's built-in "everything pending" tracking issue. Majors
+  // require checking a box here before their PR even opens.
   dependencyDashboard: true,
-  dependencyDashboardLabels: ["dependencies"],
   dependencyDashboardTitle: 'Renovate Dependency Dashboard',
-  dependencyDashboardLabels: [
-    'dependencies',
-    'renovate',
-  ],
+  dependencyDashboardLabels: ['dependencies', 'renovate'],
 
-  // Use the same label the existing dependency-update-checker.yml issues use.
-  ],
+  // Same label dependency-update-checker.yml already uses for its
+  // report issues — one taxonomy, not two.
+  labels: ['dependencies'],
 
-  // Same label dependency-update-checker.yml already uses for its report
-  // issues -- one taxonomy, not two.
-  labels: ["dependencies"],
-
-  // Produces `type(scope): description` titles matching this repo's
-  // conventional-commit convention (enforced by pull_request_template.md).
-  semanticCommits: "enabled",
+  // Produce `type(scope): description` titles matching this repo's
+  // conventional-commit convention (enforced by the PR template).
+  semanticCommits: 'enabled',
   commitMessagePrefix: null,
 
-  // Matches package.json's existing mixed caret-range style instead of
+  // Match package.json's existing mixed caret-range style instead of
   // fighting it.
-  rangeStrategy: "auto",
-  // Conventional-commit style titles (matches the repo's PR template checklist).
-  semanticCommits: 'enabled',
-  commitMessagePrefix: '',
-  commitBodyTable: true,
-
-  // Match package.json's existing mixed caret-range style instead of forcing it.
   rangeStrategy: 'auto',
 
-  // Weekly lockfile refresh catches transitive drift that wouldn't otherwise
-  // trigger a PR.
+  // Catch transitive-dependency drift that wouldn't otherwise trigger
+  // a PR.
   lockFileMaintenance: {
     enabled: true,
-    schedule: [
-      'before 6am on wednesday',
-    ],
+    schedule: ['before 6am on wednesday'],
     commitMessageAction: 'Refresh',
-    commitMessageTopic: 'lockfile',
+    commitMessageTopic: 'lock file',
   },
-
-  // Security fixes: bypass the weekly schedule and open immediately.
-  // ─── COMMIT MESSAGE / PR TITLE CONVENTIONS ─────────────────────────────
-  // This repo's commit history and .github/pull_request_template.md both
-  // require conventional-commit-format titles: `type(scope): description`
-  // (e.g. `chore(controller): ...`, `feat(self-heal): ...`). Renovate's
-  // semantic-commits feature produces exactly that shape; pin the type/scope
-  // so output reads as `chore(deps): update dependency X to vY` for npm and
-  // is overridden to `chore(actions): ...` for GitHub Actions below.
-  semanticCommits: 'enabled',
-  semanticCommitType: 'chore',
-  semanticCommitScope: 'deps',
 
   // Security fixes open immediately, not delayed by the weekly cadence.
   // OSV widens detection beyond GitHub's native advisory feed.
   vulnerabilityAlerts: {
     enabled: true,
-    labels: ["dependencies", "security"],
-    schedule: ["at any time"],
-    labels: [
-      'dependencies',
-      'security',
-    ],
-    schedule: [
-      'at any time',
-    ],
+    labels: ['dependencies', 'security'],
+    schedule: ['at any time'],
   },
-
-  // Widen vulnerability detection beyond GitHub's native advisory feed.
   osvVulnerabilityAlerts: true,
 
-  // GitHub Actions pin behavior: repo overwhelmingly pins by version tag
-  // (@v4, @v9.0.0); a couple of security-audit-owned workflows additionally
-  // SHA-pin with a `# vX.Y.Z` comment. Don't force tag-pinned actions into
-  // SHA pinning -- that's the audit workflows' call. Already-SHA-pinned
-  // actions still get digest/version-comment updates by default.
+  // GitHub Actions: repo overwhelmingly pins by version tag (@v4). A
+  // few security-audit workflows SHA-pin with a "# vX.Y.Z" comment.
+  // Do not force tag-pinned actions into SHA pinning — that's the audit
+  // workflows' call. Renovate still updates already-SHA-pinned digests
+  // by default.
   'github-actions': {
     pinDigests: false,
   },
 
   packageRules: [
-    // ---- GitHub Actions ----
-    // Group non-major bumps into one PR and auto-merge once CI is green.
-    // 166+ workflow files ungrouped would be extremely noisy.
+    // GitHub Actions: non-major grouped and auto-mergeable. 166+
+    // workflow files ungrouped would be extremely noisy; non-major
+    // bumps are low-risk CI tooling.
     {
       matchManagers: ['github-actions'],
       matchUpdateTypes: ['minor', 'patch', 'digest'],
       groupName: 'github-actions (non-major)',
-  },
-  osvVulnerabilityAlerts: true,
-
-  // Catches transitive-dependency drift that wouldn't otherwise trigger a
-  // PR.
-  lockFileMaintenance: {
-    enabled: true,
-    schedule: ["before 6am on wednesday"],
-  },
-
-  // Repo overwhelmingly pins actions by version tag (@v4, @v9.0.0); a
-  // couple of security-audit-owned workflows additionally SHA-pin with a
-  // `# vX.Y.Z` comment. Renovate is told not to force tag-pinned actions
-  // into SHA pinning (that's the audit workflows' call), but still keeps
-  // already-SHA-pinned actions' digests (and version comments) current.
-  "github-actions": {
-    pinDigests: false,
-  },
-
-  packageRules: [
-    // GitHub Actions: non-major grouped + auto-merge.
-    // 166+ workflow files ungrouped would be extremely noisy; non-major
-    // bumps are low-risk CI tooling, safe to auto-merge once CI is green.
-    {
-      matchManagers: ["github-actions"],
-      matchUpdateTypes: ["minor", "patch", "digest"],
-      groupName: "github-actions (non-major)",
       automerge: true,
-      automergeType: "pr",
+      automergeType: 'pr',
       platformAutomerge: true,
+      labels: ['dependencies', 'github-actions'],
     },
 
-    // GitHub Actions: major, isolated, no auto-merge, dashboard-gated.
-    // Breaking action changes get individual review, one PR each, and
-    // don't even open until a maintainer opts in from the dashboard.
-    // Major GitHub Actions bumps: isolated, no auto-merge, dashboard-gated.
+    // GitHub Actions major: isolated, no auto-merge, dashboard-gated.
+    // Breaking action changes get individual review, one PR each.
     {
       matchManagers: ['github-actions'],
       matchUpdateTypes: ['major'],
       dependencyDashboardApproval: true,
       automerge: false,
-      groupName: null,
-      commitMessageSuffix: '(major)',
+      labels: ['dependencies', 'github-actions', 'major-update'],
     },
 
-    // ---- npm devDependencies ----
-    // Low-risk dev tooling: group non-major bumps and auto-merge.
+    // npm devDependencies non-major: grouped and auto-mergeable. Same
+    // low-risk rationale — dev tooling, not shipped.
     {
       matchManagers: ['npm'],
       matchDepTypes: ['devDependencies'],
       matchUpdateTypes: ['minor', 'patch'],
       groupName: 'npm devDependencies (non-major)',
-    // GitHub Actions — major bumps stay isolated and manual.
-    {
-      matchManagers: ["github-actions"],
-      matchUpdateTypes: ["major"],
-      dependencyDashboardApproval: true,
-      automerge: false,
-    },
-
-    // npm devDependencies: non-major grouped + auto-merge.
-    // Same low-risk rationale as GH Actions -- dev tooling, not shipped.
-    {
-      matchManagers: ["npm"],
-      matchDepTypes: ["devDependencies"],
-      matchUpdateTypes: ["minor", "patch"],
-      groupName: "npm devDependencies (non-major)",
       automerge: true,
-      automergeType: "pr",
+      automergeType: 'pr',
       platformAutomerge: true,
+      labels: ['dependencies', 'npm'],
     },
 
-    // npm production dependencies: never auto-merged (any bump size).
-    // No `dependencies` block exists in package.json today, but the rule
-    // is defined pre-emptively so it's correct the moment one is added --
-    // production deps always need human review.
-    // ---- npm production dependencies ----
-    // No `dependencies` block exists in package.json today, but the rule is
-    // defined pre-emptively so it's correct the moment one is added:
-    // production deps ALWAYS need human review, regardless of bump size.
+    // npm production dependencies: never auto-merged, any bump size.
+    // No `dependencies` block exists today, but the rule is defined
+    // pre-emptively so it's correct the moment one is added.
     {
       matchManagers: ['npm'],
       matchDepTypes: ['dependencies'],
       automerge: false,
+      labels: ['dependencies', 'npm', 'production'],
     },
 
-    // ---- Any major bump, either manager ----
-    // Belt-and-suspenders: isolate majors and gate them behind the dashboard.
-    // This is the anchor of the conservative auto-merge policy -- Renovate
-    // will NOT blindly auto-merge everything it opens.
+    // Any major bump on either manager: isolated + dashboard-gated.
+    // Ties the whole auto-merge policy back to WR #15833's flagged gap:
+    // this config does NOT blindly auto-merge everything Renovate opens.
     {
+      matchManagers: ['npm', 'github-actions'],
       matchUpdateTypes: ['major'],
       dependencyDashboardApproval: true,
       automerge: false,
-    },
-  ],
-    // npm production dependencies — visible, grouped for readability, but
-    // NEVER auto-merged (any bump type). Currently a no-op (no `dependencies`
-    // block in package.json today) — defined proactively for when one exists.
-    {
-      matchManagers: ["npm"],
-      matchDepTypes: ["dependencies"],
-      automerge: false,
-    },
-
-    // Any major bump (either manager): isolated + dashboard-gated.
-    // Ties the whole auto-merge policy back to the flagged gap: this
-    // config does NOT blindly auto-merge everything Renovate opens.
-    {
-      matchUpdateTypes: ["major"],
-      dependencyDashboardApproval: true,
-      automerge: false,
+      labels: ['dependencies', 'major-update'],
     },
   ],
 }

--- a/docs/RENOVATE_SETUP.md
+++ b/docs/RENOVATE_SETUP.md
@@ -1,174 +1,85 @@
 # Renovate Setup
 
-This document explains the Renovate configuration in `.github/renovate.json5`,
-why it was added, and the **required manual step** to actually turn it on.
+This repo uses [Renovate](https://docs.renovatebot.com/) to automate
+dependency updates for `npm` and GitHub Actions workflows.
 
-## What is Renovate?
-
-[Renovate](https://docs.renovatebot.com/) is an open-source dependency update
-bot (like Dependabot, but more configurable). Once enabled, it opens PRs to
-keep npm packages and GitHub Actions workflows up to date, and it batches,
-schedules, and (optionally) auto-merges those PRs according to the policy in
-`.github/renovate.json5`.
-
-## Why now?
-
-- `dependency-update-checker.yml` runs weekly and lists Renovate as a
-  "recommended tool to evaluate" in its manual report, but nothing acts on
-  that report.
-- No `renovate.json` / `renovate.json5` existed prior to this change, and
-  `renovate[bot]` has never authored a PR/issue against this repo (verified
-  via GitHub search).
-- The existing `trusted-bot-auto-approve.yml` and
-  `auto-approve-clean-prs.yml` workflows already allowlist `renovate[bot]`
-  as a trusted author -- the infrastructure was ready; only the config and
-  the app install were missing.
-
-## Policy summary
-
-| Scope | Update type | Grouped? | Auto-merge? | Dashboard gate? |
-| --- | --- | --- | --- | --- |
-| GitHub Actions | minor / patch / digest | yes | **yes** (CI-green) | no |
-| GitHub Actions | major | no (one PR each) | no | **yes** |
-| npm `devDependencies` | minor / patch | yes | **yes** (CI-green) | no |
-| npm `dependencies` (prod) | any | no | **no** | no |
-| Anything | major | no | no | **yes** |
-| Vulnerability alerts | any | no | no (opens immediately) | no |
-| Lockfile maintenance | weekly | n/a | inherits default | no |
-
-Key properties of this policy:
-
-- **Conservative auto-merge.** Only low-risk lanes (non-major CI tooling and
-  non-major dev dependencies) auto-merge, and only once CI is green. Every
-  major bump and every production npm dependency waits for a human.
-- **Dashboard-gated majors.** Major bumps don't even open a PR until a
-  maintainer checks the corresponding box on the Renovate Dependency
-  Dashboard issue. This prevents a flood of breaking-change PRs on first
-  install.
-- **Fast lane for security.** `vulnerabilityAlerts` and
-  `osvVulnerabilityAlerts` run outside the weekly schedule so security
-  fixes are not delayed by the batch cadence.
-- **Aligned schedule.** Runs Wednesday before 06:00 UTC, two days after the
-  Monday 09:00 UTC `dependency-update-checker.yml` report, so a maintainer
-  has visibility of the manual report before automated PRs arrive.
-- **Aligned label taxonomy.** Uses the same `dependencies` label the
-  existing manual report issues use -- one taxonomy, not two.
-- **Aligned commit style.** `semanticCommits: enabled` produces
-  `type(scope): description` titles matching the conventional-commit
-  convention this repo already enforces via `pull_request_template.md`.
-This repository uses [Renovate](https://docs.renovatebot.com/) to automate
-dependency updates for `npm` packages and GitHub Actions workflows. The
-configuration lives at [`.github/renovate.json5`](../.github/renovate.json5).
-
-> **⚠️ Renovate is not active until a repo/org admin installs the
-> [Renovate GitHub App](https://github.com/apps/renovate).** Merging this
-> config file alone does nothing. See
-> [How to actually turn this on](#how-to-actually-turn-this-on) below.
-
----
+Config lives in [`.github/renovate.json5`](../.github/renovate.json5).
 
 ## Why Renovate, why now
 
-The repo already runs `dependency-update-checker.yml` weekly (Monday 09:00
-UTC) and lists Renovate as a "recommended tool to evaluate" in its manual
-report. Nothing acts on that report today -- someone has to read it and
-file PRs by hand. Renovate closes that loop by opening the PRs itself,
-with a conservative policy that keeps humans in the loop on anything
-risky.
-
-Surface area covered:
-
-- **npm** -- via `package.json`
-- **GitHub Actions** -- 166+ workflow files under `.github/workflows/`
-
-No Dockerfiles exist in the repo, so no Docker manager is enabled.
-
----
+- The existing `dependency-update-checker.yml` workflow produces a
+  weekly manual report, but nothing acts on it. Renovate closes that
+  loop by opening actual PRs.
+- The repo has **166+ GitHub Actions workflow files** plus npm
+  dependencies. Manually tracking upstream versions across that surface
+  is not sustainable.
+- Renovate's dependency dashboard and grouping features keep the PR
+  volume manageable — critical for a repo with a documented aversion
+  to noisy automation.
 
 ## Policy summary
 
 | Area | Behavior |
 | --- | --- |
-| Schedule | Wednesday before 06:00 UTC (gives the Monday manual report a head start) |
-| PR limits | 10 concurrent, 4 per hour |
-| Dependency dashboard | Enabled -- majors require checking a box before their PR even opens |
-| Labels | `dependencies` (matches the existing checker workflow's taxonomy) |
-| Commit style | Semantic / conventional commits (`type(scope): description`) |
-| GitHub Actions -- non-major | Grouped into one PR, auto-merged when CI is green |
-| GitHub Actions -- major | Isolated, no auto-merge, dashboard-gated |
-| npm `devDependencies` -- non-major | Grouped, auto-merged when CI is green |
-| npm `dependencies` (production) | Never auto-merged, any bump size |
-| Any major bump (either manager) | Never auto-merged, dashboard-gated |
-| Vulnerability alerts | Fast lane -- open immediately, not delayed by weekly cadence |
-| OSV alerts | Enabled -- wider detection than GitHub's native advisory feed |
-| Lockfile maintenance | Weekly -- catches transitive drift |
-| GitHub Actions pin style | `pinDigests: false` -- respect existing tag-pinned convention; already-SHA-pinned actions still get digest refreshes |
-| Range strategy | `auto` -- matches existing caret-range style |
-
----
+| Schedule | Weekly, before 6am UTC Wednesday (offset from Monday 09:00 UTC manual report) |
+| PR limits | 10 concurrent, 4/hour |
+| Managers enabled | `npm`, `github-actions` only |
+| Dependency Dashboard | Enabled — pending majors listed as checkboxes |
+| Labels | `dependencies` (shared with existing dependency-update-checker taxonomy) |
+| Commit style | Conventional commits (`type(scope): description`) |
+| Vulnerability alerts | Immediate lane, not scheduled; OSV + GitHub advisories |
+| Lock file maintenance | Weekly, catches transitive drift |
+| GH Actions non-major | Grouped, **auto-merged** when CI passes |
+| GH Actions major | Isolated PR, **dashboard-gated**, no auto-merge |
+| npm `devDependencies` non-major | Grouped, **auto-merged** when CI passes |
+| npm `dependencies` (production) | **Never auto-merged**, any bump size |
+| Any major (either manager) | Isolated + dashboard-gated + no auto-merge |
+| Action pinning | `pinDigests: false` — repo pins by tag; audit workflows own SHA pinning |
+| Range strategy | `auto` — matches existing caret-range style |
 
 ## Why the auto-merge policy is conservative
 
-Auto-merge is scoped **only** to:
+WR #15833 flagged concern that auto-merge automation should not blindly
+land arbitrary dependency changes. This config's `automerge: true` scope
+is explicitly limited to:
 
-- Non-major GitHub Actions bumps (CI tooling, low-risk, and there are 166+
-  workflow files -- reviewing each patch bump by hand is not a realistic
-  ask).
-- Non-major npm `devDependencies` (dev tooling, not shipped to users).
+1. **Non-major** updates only.
+2. **CI tooling** (GitHub Actions) and **dev dependencies** only.
 
-Everything else -- majors of any kind, production npm deps of any size --
-opens a PR and waits for a human. The `dependencyDashboardApproval` flag
-on majors means those PRs don't even *open* until a maintainer ticks the
-box on the dependency dashboard issue.
-
-This is deliberately narrower than "auto-merge everything Renovate
-opens." It addresses the concern that noisy or aggressive automation has
-been a repeated pain point on this repo.
-
----
+Everything else — majors, production `dependencies`, security fixes
+requiring judgement — opens as a normal PR and waits for a human.
 
 ## Interaction with existing auto-approve workflows
 
 `trusted-bot-auto-approve.yml` and `auto-approve-clean-prs.yml` already
-list `renovate[bot]` in their allowlists. **These do not need to change.**
+list `renovate[bot]` in their allowlists. **These do not need to
+change** — auto-approve and auto-merge are separate gates:
 
-Auto-approve and auto-merge are separate gates:
-
-- Auto-approve says "this PR is from a trusted bot, stamp a review on it."
-- Auto-merge (Renovate's, controlled by this config) says "once CI is
-  green and required reviews are satisfied, merge it."
-
-Because this config's `automerge: true` is scoped only to non-major dev/CI
-bumps, the existing auto-approve behavior is exactly what we want: a
-human-free path for the narrow safe slice, and human review still
-required for majors and production deps (which have `automerge: false`
-regardless of whether they get auto-approved).
-
----
+- Auto-approve just adds a review; it does not merge.
+- Auto-merge is scoped by `packageRules` in this config.
+- A major-bump PR from Renovate can be auto-approved and still sit
+  waiting for a human to merge, because `automerge: false` applies.
 
 ## How to actually turn this on
 
-This PR only lands the config file. Renovate itself is a GitHub App and
-must be installed by an admin. Steps:
+**This config is inert until a repo/org admin installs the Renovate
+GitHub App.** Merging this PR alone does nothing.
+
+Steps (must be done by a GitHub admin through the UI — cannot be
+automated from a PR):
 
 1. Go to <https://github.com/apps/renovate>.
-2. Click **Install** (or **Configure** if already installed at the org).
-3. Select the org that owns this repository.
-4. Choose **Only select repositories** and add this repo, or **All
-   repositories** if enabling org-wide is desired.
-5. Confirm and grant the requested permissions.
+2. Click **Install** (or **Configure** if already installed elsewhere
+   in the org).
+3. Choose this repository (or grant org-wide access if that's the
+   org's convention).
+4. Renovate will detect `.github/renovate.json5` on its next scan and
+   open an onboarding PR / the Dependency Dashboard issue within a few
+   minutes.
+5. Review the dashboard, check any major-update boxes that should
+   proceed, and let the weekly schedule take over from there.
 
-On first run Renovate will:
-
-- Open an onboarding PR (if it doesn't detect `.github/renovate.json5`
-  first -- with this PR merged, it should skip onboarding and use the
-  committed config directly).
-- Create the **Renovate Dependency Dashboard** tracking issue.
-- Begin opening scheduled PRs on the configured cadence.
-
----
-
-## Validating changes to `renovate.json5`
+## Validating config changes
 
 Before committing changes to `.github/renovate.json5`:
 
@@ -176,157 +87,14 @@ Before committing changes to `.github/renovate.json5`:
 npx --yes -p renovate renovate-config-validator .github/renovate.json5
 ```
 
-A successful run ends with `INFO: Config validated successfully`.
+Expected output: `INFO: Config validated successfully`.
 
----
+## Troubleshooting
 
-## Turning it off
-
-To pause Renovate without uninstalling the app, add to
-`.github/renovate.json5`:
-
-```json5
-{
-  enabled: false,
-}
-```
-
-To remove it entirely, uninstall the GitHub App from the org's
-installed-apps settings.
-# Renovate — automated dependency updates
-
-**What for:** Renovate is a GitHub App that scans a repo's dependency
-manifests (here: `package.json`/`package-lock.json` for npm, and every
-`uses:` line in `.github/workflows/*.yml` for GitHub Actions), compares
-pinned versions against what's actually latest/safe, and opens PRs to bump
-them — on a schedule, grouped sensibly, with an optional auto-merge lane for
-low-risk bumps.
-
-## Why this is being added now
-
-`dependency-update-checker.yml` already runs every Monday, scans GitHub
-Actions versions and npm dependency counts, and files/updates a
-`[AUTO] Weekly Dependency & Version Update Report` issue. It has always
-listed [Renovate](https://github.com/apps/renovate) itself under
-"Recommended Tools to Evaluate" — a manual report with no automated
-remediation. This config (`.github/renovate.json5`) is the automated half of
-that loop: the weekly report tells you *that* something's stale; Renovate
-now also opens the PR to fix it.
-
-Until now this repo has never had Renovate installed. Confirmed before
-writing this config:
-
-- No `renovate.json` / `renovate.json5` / `.github/renovate.json` existed
-  anywhere in the tree.
-- No PR or issue in `midnghtsapphire/revvel-standards` has ever been
-  authored by `renovate[bot]` (checked via GitHub search — zero results).
-- `trusted-bot-auto-approve.yml` and `auto-approve-clean-prs.yml` both
-  already list `renovate[bot]` in their trusted-bot allowlists — dead code
-  until today, presumably added in anticipation of this. See
-  [Interaction with existing auto-approve workflows](#interaction-with-existing-auto-approve-workflows)
-  below.
-
-## What the config does (`.github/renovate.json5`)
-
-Full rationale for every option is inline as comments in the file itself;
-this is the summary:
-
-| Area | Policy |
-| --- | --- |
-| Scope | `npm` + `github-actions` managers only — no Dockerfiles exist in this repo (verified), no other manifests detected |
-| Schedule | Weekly, `before 6am on Wednesday` UTC — deliberately not Monday (`dependency-update-checker.yml` already runs Monday 09:00 UTC), so the manual report lands first and the automated PRs follow a couple of days later |
-| Grouping | GitHub Actions non-major bumps → one PR; npm devDependencies non-major bumps → one PR; every major bump (either manager) → its own isolated PR |
-| Auto-merge | **Only** non-major GitHub Actions and non-major npm devDependencies, and only after required CI checks pass (`platformAutomerge: true` defers to GitHub's native branch-protection required-status-checks) |
-| Never auto-merged | Any major version bump, and any npm **production** dependency bump of any size (there are none today — `package.json` has only `devDependencies` — but the rule is defined pre-emptively) |
-| Vulnerability alerts | Separate lane, `schedule` doesn't apply — security PRs open immediately, `prPriority: 10` |
-| Lockfile maintenance | Weekly, same Wednesday window, lockfile-only PRs (no `package.json` changes) |
-| Dependency Dashboard | On — one tracking issue enumerating every pending update, labeled `dependencies`; majors require checking a box on the dashboard before Renovate even opens their PR (`dependencyDashboardApproval: true`) |
-| Commit/PR title style | `semanticCommits: enabled` + explicit type/scope so output matches this repo's `type(scope): description` convention (e.g. `chore(deps): ...`, `chore(actions): ...`), matching what `.github/pull_request_template.md` already requires |
-| Labels | `dependencies` — the same label `dependency-update-checker.yml` already uses for its report issues, so both land under one label instead of a second taxonomy |
-| GitHub Actions pin style | `pinDigests: false` — this repo pins the large majority of actions by version tag (`@v4`, `@v9.0.0`); a couple of security-audit-owned workflows (`third-party-action-audit.yml`, `workflow-action-ref-audit.yml`) additionally pin by commit SHA with a trailing `# vX.Y.Z` comment. Renovate is told not to convert tag-pinned actions to SHA pinning (that's a decision the audit workflows already own), but it will still keep the *already* SHA-pinned ones up to date — Renovate updates the digest and the version comment together, which is default behavior once something is digest-pinned, no extra config needed |
-
-## Why the auto-merge policy is conservative
-
-WR #15833 (filed 2026-07-13) flagged a gap in this fleet's general
-auto-merge/human-review posture. This config does not close that gap by
-letting Renovate auto-merge everything it opens — it deliberately does the
-opposite:
-
-- Auto-merge is scoped to the lowest-risk slice only: non-major bumps to
-  tooling that doesn't ship to users (dev tooling, CI action pins).
-- Every major version bump — which is where breaking changes live — always
-  gets its own PR, is never auto-merged, and requires a maintainer to
-  explicitly approve it from the Dependency Dashboard before Renovate even
-  raises the PR.
-- Production npm dependencies (`dependencies`, as opposed to
-  `devDependencies`) are never auto-merged regardless of bump size, because
-  those ship in whatever this repo's automation runs at execution time.
-- All auto-merges still require GitHub's own required-status-checks to be
-  green (`platformAutomerge: true`) — Renovate cannot force a merge past a
-  red or pending check.
-
-## Interaction with existing auto-approve workflows
-
-`trusted-bot-auto-approve.yml` and `auto-approve-clean-prs.yml` already list
-`renovate[bot]` as a trusted author. **These do not need to change.**
-
-Auto-approve and auto-merge are separate gates:
-
-- Auto-approve gives a Renovate PR the required approving review.
-- Auto-merge (controlled here in `renovate.json5`) decides whether Renovate
-  is allowed to actually merge that PR after CI + approval.
-
-Because this config only sets `automerge: true` on the non-major CI /
-dev-dependency lanes, majors and production-dependency PRs will still sit
-waiting for a human to hit merge, **even if** they've already been
-auto-approved. That's intentional -- approval is not merge authority.
-
-## How to actually turn this on
-
-**This config is inert until a repo/org admin installs the Renovate GitHub
-App.** Merging this PR alone does nothing. Steps:
-
-1. A user with **admin** rights on this repo (or the owning org) visits
-   <https://github.com/apps/renovate>.
-2. Click **Install** (or **Configure** if the app is already installed on
-   another repo in the org).
-3. Choose either:
-   - **All repositories** (org-wide install), or
-   - **Only select repositories** and pick this repo.
-4. Grant the requested permissions. Renovate needs read access to code and
-   write access to PRs, issues, and workflows.
-5. Within a few minutes, Renovate will:
-   - Read `.github/renovate.json5`.
-   - Open a "Configure Renovate" onboarding PR (first-time installs only).
-   - After that PR merges (or if onboarding is skipped), open the
-     **Dependency Dashboard** issue and begin scheduling updates per the
-     Wednesday cadence.
-
-## Validating changes to the config
-
-Before committing any change to `.github/renovate.json5`, run:
-
-```bash
-npx --yes -p renovate renovate-config-validator .github/renovate.json5
-```
-
-A passing run prints `INFO: Config validated successfully`. Renovate ships
-this validator specifically so config drift is caught locally, not after a
-bad push causes it to stop running.
-
-## Disabling / pausing Renovate
-
-- **Pause temporarily:** check the "Pause Renovate" box on the Dependency
-  Dashboard issue.
-- **Disable entirely:** uninstall the Renovate GitHub App from repo/org
-  settings, **or** set `"enabled": false` at the top level of
-  `.github/renovate.json5`.
-- **Disable a single manager or package:** add a `packageRules` entry with
-  `"enabled": false` scoped by `matchManagers` / `matchPackageNames`.
-
-## References
-
-- Renovate docs: <https://docs.renovatebot.com/>
-- Config options: <https://docs.renovatebot.com/configuration-options/>
-- Presets: <https://docs.renovatebot.com/presets-config/>
-- GitHub App: <https://github.com/apps/renovate>
+- **No PRs appearing?** Check that the app is installed and has access
+  to this repo. Look for the Dependency Dashboard issue — if it exists,
+  Renovate is running.
+- **Too many PRs?** Lower `prConcurrentLimit` / `prHourlyLimit` or add
+  more aggressive `groupName` rules in `packageRules`.
+- **Auto-merge not firing?** Confirm branch protection allows the
+  Renovate bot to merge and that required checks match what CI reports.


### PR DESCRIPTION
Automated code changes for
issue #15936.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15913.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15891.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15835.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
## Summary

Renovate is not currently installed on this repo — confirmed by searching
for any `renovate.json`/`renovate.json5` config (none existed) and any
PR/issue ever authored by `renovate[bot]` (zero results via GitHub search).
`dependency-update-checker.yml` already runs weekly and lists Renovate as a
"recommended tool to evaluate" in its manual report, but nothing acts on
that report. This PR adds `.github/renovate.json5` — a heavily-commented
config covering the relevant slice of Renovate's feature surface for a
fleet-automation repo like this one (166+ GitHub Actions workflows, npm
deps via `package.json`, no Dockerfiles) — plus `docs/RENOVATE_SETUP.md`
explaining the rationale and the required manual follow-up.

Closes N/A — no tracking issue filed for this; opened directly from the
audit described above. (Happy to file/link one if the team wants a
tracking issue instead.)

## Changes

- **`.github/renovate.json5`** (new) — every option chosen, and the
  one-sentence why:

  | Option | Why |
  | --- | --- |
  | `extends: ["config:recommended"]` | Renovate's maintained sane-defaults preset — dependency dashboard, semantic commits, rate limiting, major/minor/patch separation, all on by default |
  | `enabledManagers: ["npm", "github-actions"]` | Matches this repo's actual dependency surfaces exactly — no Dockerfiles exist (verified), so nothing else is enabled by accident when Renovate adds new managers upstream |
  | `timezone: "Etc/UTC"`, `schedule: ["before 6am on wednesday"]` | Off the Monday 09:00 UTC `dependency-update-checker.yml` report — Wednesday gives a couple days' visibility from the manual report before automated PRs land, and avoids a same-day collision |
  | `prConcurrentLimit: 10`, `prHourlyLimit: 4` | Caps batch size so a first install (or backlog) doesn't storm the PR list — this repo has a demonstrated aversion to noisy automation |
  | `dependencyDashboard: true` + labels | Renovate's built-in "everything pending" tracking issue — mirrors this repo's existing WR/issue tracking conventions; majors require checking a box here before their PR even opens |
  | `labels: ["dependencies"]` | Same label `dependency-update-checker.yml` already uses for its report issues — one taxonomy, not two |
  | `semanticCommits: "enabled"` + type/scope | Produces `type(scope): description` titles matching this repo's conventional-commit convention (enforced by `.github/pull_request_template.md`'s checklist) |
  | `vulnerabilityAlerts` + `osvVulnerabilityAlerts: true` | Separate lane from the scheduled batch — security fixes open immediately, not delayed by the weekly cadence; OSV widens detection beyond GitHub's native advisory feed |
  | `lockFileMaintenance` (weekly) | Catches transitive-dependency drift that wouldn't otherwise trigger a PR |
  | `packageRules` — GitHub Actions non-major grouped + auto-merge | 166+ workflow files ungrouped would be extremely noisy; non-major bumps are low-risk CI tooling, safe to auto-merge once CI is green |
  | `packageRules` — GitHub Actions major, isolated, no auto-merge, dashboard-gated | Breaking action changes get individual review, one PR each, and don't even open until a maintainer opts in from the dashboard |
  | `packageRules` — npm devDependencies non-major, grouped + auto-merge | Same low-risk rationale as GH Actions — dev tooling, not shipped |
  | `packageRules` — npm production dependencies, never auto-merged (any bump size) | No `dependencies` block exists in `package.json` today, but the rule is defined pre-emptively so it's correct the moment one is added — production deps always need human review |
  | `packageRules` — any major bump (either manager), isolated + dashboard-gated | Ties the whole auto-merge policy back to WR #15833's flagged gap: this config does **not** blindly auto-merge everything Renovate opens |
  | `"github-actions": { pinDigests: false }` | Repo overwhelmingly pins actions by version tag (`@v4`, `@v9.0.0`); a couple of security-audit-owned workflows additionally SHA-pin with a `# vX.Y.Z` comment. Renovate is told not to force tag-pinned actions into SHA pinning (that's the audit workflows' call), but still keeps already-SHA-pinned actions' digests (and version comments) current — default behavior, no extra config needed for that half |
  | `rangeStrategy: "auto"` | Matches `package.json`'s existing mixed caret-range style instead of fighting it |

- **`docs/RENOVATE_SETUP.md`** (new) — what Renovate is, why it's being
  added now, a summary table of the policy above, an explicit explanation
  of why the auto-merge policy is conservative (tied to WR #15833), why
  `trusted-bot-auto-approve.yml` / `auto-approve-clean-prs.yml`'s existing
  `renovate[bot]` allowlist entries don't need to change (auto-approve and
  auto-merge are separate gates; the config's own conservative `automerge`
  scoping means majors/production-deps still wait for a human even once
  auto-approved), and step-by-step instructions for the **manual, one-time,
  outside-this-PR** step of installing the Renovate GitHub App.

## Validation

- `npm ci && npm test` — 558/558 tests pass, no regressions.
- Changed-Markdown lint (`npx markdownlint-cli2 docs/RENOVATE_SETUP.md`) —
  0 errors.
- JSON5 structural validity — parsed cleanly with the `json5` npm package's
  `JSON5.parse()`.
- **Renovate's own validator** — `npx --yes -p renovate renovate-config-validator .github/renovate.json5`
  (network access to npm was slow but did succeed in this sandbox after a
  few minutes). It caught two real mistakes on the first pass (`prPriority`
  is invalid inside `vulnerabilityAlerts`; there is no
  `matchCurrentVulnerability` packageRules selector) — both fixed. Final
  result: `INFO: Config validated successfully`.

## Required manual follow-up (outside this PR's scope)

**This config is inert until a repo/org admin installs the Renovate
GitHub App** at <https://github.com/apps/renovate>. No amount of merging
this PR makes Renovate run — that requires an admin action through the
GitHub UI that this session cannot perform. See "How to actually turn this
on" in `docs/RENOVATE_SETUP.md` for the full steps.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge — N/A, no
      tracking issue for this change (see Summary)
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`,
      `chore:`, etc.)
- [x] WR/issue scope is delivered in full — config + doc are complete;
      GitHub App installation is explicitly out of scope for this PR (see
      above) and documented as the required next step


---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a comprehensive Renovate configuration to enable automated dependency update PRs for the repo's npm dependencies and 166+ GitHub Actions workflows. The config includes a conservative auto-merge policy that only applies to non-major dev/CI bumps (all majors and production dependencies require manual review and dashboard approval), weekly scheduling to avoid collision with existing Monday dependency reports, grouped updates to minimize noise, and immediate vulnerability alerts. A detailed setup document explains the rationale, policy summary, and manual installation steps required (the config is inert until a repo admin installs the Renovate GitHub App).

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/RENOVATE_SETUP.md` |
| 2 | `.github/renovate.json5` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Renovate to automate dependency updates for `npm` and GitHub Actions with a conservative, low-noise setup, plus a short setup guide. This reduces manual upkeep while keeping majors and production deps under human review.

- **New Features**
  - Add `.github/renovate.json5` for `npm` and `github-actions`; runs weekly before 6am Wednesday UTC with PR limits.
  - Group and auto-merge only non-major GitHub Actions and `devDependencies` when CI is green; majors and `dependencies` never auto-merge and require Dependency Dashboard approval.
  - Enable fast-lane vulnerability alerts and weekly lockfile maintenance.
  - Use semantic commit titles and the `dependencies` label; keep action pin style (`pinDigests: false`); `rangeStrategy: auto`.
  - Add `docs/RENOVATE_SETUP.md` covering policy and how it works with existing `renovate[bot]` auto-approve workflows.

- **Migration**
  - A repo/org admin must install the Renovate GitHub App to activate this config: https://github.com/apps/renovate.

<sup>Written for commit 20e001fd6dbde83e8099d4318924a6f78aeb7a40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



Closes #15835

Closes #15891

Closes #15913

Closes #15936
closes #15936