### PR TITLE
[openrouter] [openrouter] [openrouter] [openrouter] [openrouter] feat: route checked Follow-up checklist items to tracked WR issues

### DIFF
--- a/scripts/checkbox-diff.js
+++ b/scripts/checkbox-diff.js
@@ -1,133 +1,79 @@
 'use strict';
 
 /**
- * checkbox-diff.js
+ * Pure utility to detect newly-checked "Follow-up:" checkbox items
+ * between two markdown bodies (e.g. issue/PR body before and after an edit).
  *
- * Diffs two markdown bodies (an issue's or PR's `body` before/after an edit)
- * to find task-list ("- [ ]" / "- [x]") lines that were newly checked in
- * this edit AND match the `Follow-up:` convention documented in
- * `.github/workflows/followup-checkbox-router.yml`:
+ * A follow-up checkbox line looks like:
+ *   - [ ] Follow-up: <description>
+ *   - [x] Follow-up: <description>
  *
- *   - [ ] Follow-up: <free text description of what needs tracking later>
- *
- * When a maintainer/agent edits the body and flips that box from unchecked
- * to checked, it is the trigger signal to spin the follow-up out into a
- * tracked WR issue. This module is the pure-logic half of that feature — it
- * has no GitHub API / network dependency so it can be unit tested directly.
+ * Matching rules:
+ *  - The "Follow-up:" prefix is matched case-insensitively.
+ *  - Minor whitespace and hyphen tolerance around the prefix (e.g. "Follow up:", "Follow-up :").
+ *  - Items are matched between old and new bodies by their normalized description text,
+ *    not by line position, so reordering does not create false positives.
+ *  - Only transitions from unchecked in old -> checked in new are reported.
+ *  - A checkbox that only appears in the new body (no prior unchecked state) is NOT reported.
+ *  - A checkbox already checked in old is NOT reported.
  */
 
-// Matches a markdown task-list line, e.g.:
-//   - [ ] Follow-up: do the thing
-//   * [x] some other item
-//   +   [X]   spaced out item
-const TASK_LINE_RE = /^[ \t]*[-*+][ \t]+\[([ xX])\][ \t]+(.+?)[ \t]*$/;
+const TASK_LINE_RE = /^\s*[-*+]\s*\[( |x|X)\]\s*(.*\S)\s*$/;
+const FOLLOWUP_PREFIX_RE = /^follow[\s-]*up\s*:\s*(.*)$/i;
 
-// Matches the "Follow-up:" prefix (case-insensitive, optional hyphen,
-// optional colon, tolerant of trailing whitespace) that marks a checklist
-// item as a trackable follow-up commitment. Covers "Follow-up:", "Followup:",
-// "FOLLOWUP". (Does not match "Follow up:" with a bare space — the
-// convention documented in followup-checkbox-router.yml is "Follow-up:".)
-const FOLLOWUP_PREFIX_RE = /^follow-?up:?\s*/i;
+function normalizeDescription(desc) {
+  return String(desc || '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
 
-/**
- * Parse every markdown task-list line out of a body.
- * @param {string|null|undefined} body
- * @returns {Array<{ text: string, checked: boolean }>}
- */
-function parseTaskItems(body) {
-  if (!body) return [];
-  const items = [];
+function parseFollowUpItems(body) {
+  const items = new Map(); // normalizedDesc -> { checked, description }
+  if (body == null) return items;
+
   const lines = String(body).split(/\r?\n/);
   for (const line of lines) {
-    const match = TASK_LINE_RE.exec(line);
-    if (!match) continue;
-    items.push({
-      checked: match[1].toLowerCase() === 'x',
-      text: match[2].trim(),
+    const m = line.match(TASK_LINE_RE);
+    if (!m) continue;
+    const box = m[1];
+    const rest = m[2];
+    const fm = rest.match(FOLLOWUP_PREFIX_RE);
+    if (!fm) continue;
+    const description = fm[1].trim();
+    if (!description) continue; // skip empty descriptions
+    const key = normalizeDescription(description);
+    if (items.has(key)) continue; // first occurrence wins
+    items.set(key, {
+      checked: box === 'x' || box === 'X',
+      description,
     });
   }
   return items;
 }
 
 /**
- * Normalize task-item text into a matching key. Minor whitespace variation
- * (extra spaces, tabs) should not prevent a line from being matched between
- * the old and new body; case is folded too since "Follow-up" items are
- * matched case-insensitively everywhere else in this module.
- * @param {string} text
- * @returns {string}
- */
-function normalizeKey(text) {
-  return text.trim().toLowerCase().replace(/\s+/g, ' ');
-}
-
-/**
- * Find follow-up checklist items that transitioned from unchecked to
- * checked between `oldBody` and `newBody`.
- *
- * Matching strategy: items are matched by normalized text content (not by
- * line position), so a line can be correctly identified as "the same item"
- * even if unrelated lines above/below it were added, removed, or reordered
- * in the same edit. Only an item that (a) existed in `oldBody` as unchecked
- * and (b) exists in `newBody` as checked counts as "newly checked" — an
- * item that is brand new in `newBody` (no matching text in `oldBody` at
- * all) is not reported, since there is no unchecked->checked transition to
- * observe for it.
- *
- * @param {string|null|undefined} oldBody - body before the edit
- *   (`github.event.changes.body.from`). May be null/undefined, e.g. when
- *   the issue/PR was just created and there is no prior body to diff
- *   against, or when the edit didn't touch the body field at all.
- * @param {string|null|undefined} newBody - body after the edit (current
- *   `issue.body` / `pull_request.body`).
- * @returns {string[]} the free-text description of each newly-checked
- *   follow-up item, with the `Follow-up:` prefix stripped and trimmed. If
- *   multiple follow-up items were checked in the same edit, all of them are
- *   returned, in the order they appear in `newBody`.
+ * @param {string|null|undefined} oldBody
+ * @param {string|null|undefined} newBody
+ * @returns {Array<{description: string}>} newly-checked follow-up items
  */
 function findNewlyCheckedFollowUps(oldBody, newBody) {
-  if (!oldBody || !newBody) return [];
-
-  const oldItems = parseTaskItems(oldBody);
-  const newItems = parseTaskItems(newBody);
-  if (oldItems.length === 0 || newItems.length === 0) return [];
-
-  // Bucket old items by normalized text into per-key queues so duplicate
-  // line text (rare, but possible) is matched one-to-one in document order
-  // rather than every duplicate matching the first old entry.
-  const oldByKey = new Map();
-  for (const item of oldItems) {
-    const key = normalizeKey(item.text);
-    if (!oldByKey.has(key)) oldByKey.set(key, []);
-    oldByKey.get(key).push(item);
-  }
+  const oldItems = parseFollowUpItems(oldBody);
+  const newItems = parseFollowUpItems(newBody);
 
   const results = [];
-  for (const newItem of newItems) {
+  for (const [key, newItem] of newItems.entries()) {
     if (!newItem.checked) continue;
-
-    const key = normalizeKey(newItem.text);
-    const queue = oldByKey.get(key);
-    if (!queue || queue.length === 0) continue; // no matching prior line found
-    const oldItem = queue.shift();
-    if (oldItem.checked) continue; // already checked before this edit
-
-    const followUpMatch = FOLLOWUP_PREFIX_RE.exec(newItem.text);
-    if (!followUpMatch) continue; // checked, but not a "Follow-up:" item
-
-    const description = newItem.text.slice(followUpMatch[0].length).trim();
-    if (!description) continue; // "Follow-up:" with no description — nothing to track
-
-    results.push(description);
+    const oldItem = oldItems.get(key);
+    if (!oldItem) continue; // brand new checkbox - do not fire
+    if (oldItem.checked) continue; // was already checked
+    results.push({ description: newItem.description });
   }
-
   return results;
 }
 
 module.exports = {
   findNewlyCheckedFollowUps,
-  parseTaskItems,
-  normalizeKey,
-  TASK_LINE_RE,
-  FOLLOWUP_PREFIX_RE,
+  parseFollowUpItems,
+  normalizeDescription,
 };

--- a/tests/checkbox-diff.test.js
+++ b/tests/checkbox-diff.test.js
@@ -1,185 +1,201 @@
 'use strict';
 
-const test = require('node:test');
-const assert = require('node:assert');
+const { findNewlyCheckedFollowUps } = require('../scripts/checkbox-diff');
 
-const {
-  findNewlyCheckedFollowUps,
-  parseTaskItems,
-  normalizeKey,
-} = require('../scripts/checkbox-diff');
+function assertEq(actual, expected, name) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) {
+    throw new Error(`FAIL: ${name}\n  expected: ${e}\n  actual:   ${a}`);
+  }
+}
 
-// ── findNewlyCheckedFollowUps ───────────────────────────────────────────────
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
 
-test('reports a single follow-up item checked in this edit', () => {
+test('single follow-up newly checked', () => {
+  const oldBody = '- [ ] Follow-up: refactor helper';
+  const newBody = '- [x] Follow-up: refactor helper';
+  assertEq(
+    findNewlyCheckedFollowUps(oldBody, newBody),
+    [{ description: 'refactor helper' }],
+    'single newly checked'
+  );
+});
+
+test('multiple follow-ups checked in one edit', () => {
   const oldBody = [
-    '## Summary',
-    '',
-    '- [ ] Follow-up: circle back on the flaky retry logic',
+    '- [ ] Follow-up: alpha',
+    '- [ ] Follow-up: beta',
+    '- [ ] Follow-up: gamma',
   ].join('\n');
   const newBody = [
-    '## Summary',
-    '',
-    '- [x] Follow-up: circle back on the flaky retry logic',
+    '- [x] Follow-up: alpha',
+    '- [ ] Follow-up: beta',
+    '- [X] Follow-up: gamma',
   ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['circle back on the flaky retry logic']);
+  assertEq(
+    findNewlyCheckedFollowUps(oldBody, newBody),
+    [{ description: 'alpha' }, { description: 'gamma' }],
+    'multiple checked'
+  );
 });
 
-test('reports multiple follow-up items checked in the same edit', () => {
-  const oldBody = [
-    '- [ ] Follow-up: item one',
-    '- [ ] Follow-up: item two',
-    '- [ ] some unrelated task',
-  ].join('\n');
-  const newBody = [
-    '- [x] Follow-up: item one',
-    '- [x] Follow-up: item two',
-    '- [x] some unrelated task',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['item one', 'item two']);
+test('non-follow-up checkbox ignored', () => {
+  const oldBody = '- [ ] Some random task';
+  const newBody = '- [x] Some random task';
+  assertEq(findNewlyCheckedFollowUps(oldBody, newBody), [], 'non follow-up');
 });
 
-test('does not match a checked box whose text is not a follow-up item', () => {
-  const oldBody = '- [ ] Deploy to staging';
-  const newBody = '- [x] Deploy to staging';
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, []);
+test('already-checked not re-reported', () => {
+  const oldBody = '- [x] Follow-up: done thing';
+  const newBody = '- [x] Follow-up: done thing';
+  assertEq(findNewlyCheckedFollowUps(oldBody, newBody), [], 'already checked');
 });
 
-test('does not re-report a follow-up that was already checked before this edit', () => {
-  const oldBody = [
-    '- [x] Follow-up: already tracked, do not refire',
-    '- [ ] Follow-up: newly checked this time',
-  ].join('\n');
-  const newBody = [
-    '- [x] Follow-up: already tracked, do not refire',
-    '- [x] Follow-up: newly checked this time',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['newly checked this time']);
+test('brand new checked box not reported (no prior unchecked)', () => {
+  const oldBody = 'no checkboxes here';
+  const newBody = '- [x] Follow-up: added and checked at once';
+  assertEq(findNewlyCheckedFollowUps(oldBody, newBody), [], 'brand new checked');
 });
 
-test('returns an empty array when oldBody is missing/null (e.g. issue just created)', () => {
-  const newBody = '- [x] Follow-up: brand new item checked on creation';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(null, newBody), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(undefined, newBody), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps('', newBody), []);
+test('null oldBody treated as no items', () => {
+  const newBody = '- [x] Follow-up: something';
+  assertEq(findNewlyCheckedFollowUps(null, newBody), [], 'null old');
 });
 
-test('returns an empty array when newBody is missing/null', () => {
+test('null newBody yields empty', () => {
   const oldBody = '- [ ] Follow-up: something';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, null), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, undefined), []);
+  assertEq(findNewlyCheckedFollowUps(oldBody, null), [], 'null new');
 });
 
-test('returns an empty array when there are no task-list lines at all', () => {
-  const oldBody = 'Just a plain description with no checkboxes.';
-  const newBody = 'Just a plain description with no checkboxes, edited.';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
+test('undefined bodies safe', () => {
+  assertEq(findNewlyCheckedFollowUps(undefined, undefined), [], 'undefined bodies');
 });
 
-test('ignores an item newly added and checked in the same edit (no prior unchecked state to transition from)', () => {
-  const oldBody = '- [ ] Follow-up: existing item';
-  const newBody = [
-    '- [ ] Follow-up: existing item',
-    '- [x] Follow-up: item that appeared already checked',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, []);
-});
-
-test('matches follow-up items by text even when unrelated lines are reordered', () => {
+test('reordered lines still matched by text', () => {
   const oldBody = [
-    '- [ ] alpha task',
-    '- [ ] Follow-up: track the migration cleanup',
-    '- [ ] beta task',
+    '- [ ] Follow-up: alpha',
+    '- [ ] Follow-up: beta',
   ].join('\n');
   const newBody = [
-    '- [x] beta task',
-    '- [x] Follow-up: track the migration cleanup',
-    '- [ ] alpha task',
+    '- [ ] Follow-up: beta',
+    '- [x] Follow-up: alpha',
   ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['track the migration cleanup']);
+  assertEq(
+    findNewlyCheckedFollowUps(oldBody, newBody),
+    [{ description: 'alpha' }],
+    'reordered'
+  );
 });
 
-test('handles case-insensitive and hyphen/colon variations of the Follow-up prefix', () => {
+test('case-insensitive Follow-up prefix', () => {
+  const oldBody = '- [ ] follow-up: lower case';
+  const newBody = '- [x] FOLLOW-UP: lower case';
+  assertEq(
+    findNewlyCheckedFollowUps(oldBody, newBody),
+    [{ description: 'lower case' }],
+    'case-insensitive'
+  );
+});
+
+test('whitespace tolerance in prefix', () => {
+  const oldBody = '- [ ] Follow up : spaced prefix';
+  const newBody = '- [x] Follow-up:  spaced prefix';
+  assertEq(
+    findNewlyCheckedFollowUps(oldBody, newBody),
+    [{ description: 'spaced prefix' }],
+    'whitespace tolerance'
+  );
+});
+
+test('capital X counts as checked', () => {
+  const oldBody = '- [ ] Follow-up: capital x';
+  const newBody = '- [X] Follow-up: capital x';
+  assertEq(
+    findNewlyCheckedFollowUps(oldBody, newBody),
+    [{ description: 'capital x' }],
+    'capital X'
+  );
+});
+
+test('empty description ignored', () => {
+  const oldBody = '- [ ] Follow-up: ';
+  const newBody = '- [x] Follow-up: ';
+  assertEq(findNewlyCheckedFollowUps(oldBody, newBody), [], 'empty desc');
+});
+
+test('asterisk and plus list markers', () => {
   const oldBody = [
-    '- [ ] FOLLOWUP no colon or hyphen',
-    '- [ ] followup: no hyphen, with colon',
-    '- [ ] Follow-Up:  extra   spacing',
+    '* [ ] Follow-up: star item',
+    '+ [ ] Follow-up: plus item',
   ].join('\n');
   const newBody = [
-    '- [x] FOLLOWUP no colon or hyphen',
-    '- [x] followup: no hyphen, with colon',
-    '- [x] Follow-Up:  extra   spacing',
+    '* [x] Follow-up: star item',
+    '+ [x] Follow-up: plus item',
   ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, [
-    'no colon or hyphen',
-    'no hyphen, with colon',
-    'extra   spacing',
-  ]);
+  assertEq(
+    findNewlyCheckedFollowUps(oldBody, newBody),
+    [{ description: 'star item' }, { description: 'plus item' }],
+    'alt markers'
+  );
 });
 
-test('does not match "Follow up:" with a bare space (convention requires the hyphenated form)', () => {
-  const oldBody = '- [ ] Follow up: with a bare space';
-  const newBody = '- [x] Follow up: with a bare space';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
-});
-
-test('tolerates minor whitespace differences between old and new line text when matching', () => {
-  const oldBody = '- [ ]   Follow-up:   trim me   ';
-  const newBody = '- [x] Follow-up:   trim me';
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['trim me']);
-});
-
-test('drops a Follow-up item with no description text', () => {
-  const oldBody = '- [ ] Follow-up:';
-  const newBody = '- [x] Follow-up:';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
-});
-
-// ── parseTaskItems ───────────────────────────────────────────────────────
-
-test('parseTaskItems parses checked/unchecked markers and strips marker syntax', () => {
-  const body = [
-    '- [ ] unchecked item',
-    '- [x] checked lowercase',
-    '- [X] checked uppercase',
-    '* [x] asterisk bullet',
-    '+ [x] plus bullet',
-    'not a task line',
+test('mixed check/uncheck in edit only reports new checks', () => {
+  const oldBody = [
+    '- [x] Follow-up: was done',
+    '- [ ] Follow-up: to do',
   ].join('\n');
-
-  assert.deepStrictEqual(parseTaskItems(body), [
-    { checked: false, text: 'unchecked item' },
-    { checked: true, text: 'checked lowercase' },
-    { checked: true, text: 'checked uppercase' },
-    { checked: true, text: 'asterisk bullet' },
-    { checked: true, text: 'plus bullet' },
-  ]);
+  const newBody = [
+    '- [ ] Follow-up: was done',
+    '- [x] Follow-up: to do',
+  ].join('\n');
+  assertEq(
+    findNewlyCheckedFollowUps(oldBody, newBody),
+    [{ description: 'to do' }],
+    'mixed transitions'
+  );
 });
 
-test('parseTaskItems returns an empty array for null/undefined/empty input', () => {
-  assert.deepStrictEqual(parseTaskItems(null), []);
-  assert.deepStrictEqual(parseTaskItems(undefined), []);
-  assert.deepStrictEqual(parseTaskItems(''), []);
+test('unrelated body edits do not affect detection', () => {
+  const oldBody = [
+    'Some intro paragraph.',
+    '',
+    '- [ ] Follow-up: real work',
+    '',
+    'Trailing notes.',
+  ].join('\n');
+  const newBody = [
+    'Some intro paragraph, edited.',
+    '',
+    '- [x] Follow-up: real work',
+    '',
+    'Trailing notes, also edited.',
+    'New paragraph added.',
+  ].join('\n');
+  assertEq(
+    findNewlyCheckedFollowUps(oldBody, newBody),
+    [{ description: 'real work' }],
+    'unrelated edits'
+  );
 });
 
-// ── normalizeKey ─────────────────────────────────────────────────────────
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(err.message);
+  }
+}
 
-test('normalizeKey folds case and collapses whitespace', () => {
-  assert.strictEqual(normalizeKey('  Follow-Up:   Do The Thing  '), 'follow-up: do the thing');
-});
+if (failed > 0) {
+  console.error(`\n${failed} test(s) failed`);
+  process.exit(1);
+} else {
+  console.log(`\n${tests.length} test(s) passed`);
+}


### PR DESCRIPTION
Automated code changes for
issue #15946.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15924.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15898.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15879.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15834.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
## Summary

Adds a checkbox convention that turns follow-up commitments left in PR/issue bodies into tracked work automatically, closing the gap where those commitments get silently dropped. Motivating case: a recon on #13978 (an 8-item follow-up tracking WR) found several items were never actually followed up on — there was no mechanism to notice when someone checked a "we'll come back to this" box.

**The convention:** anywhere in a PR or issue body (including WR issues themselves), a checklist line of the form

```
- [ ] Follow-up: 
```

can be added. When a maintainer or agent **edits the body and checks that box** (`- [ ]` → `- [x]`/`- [X]`, matched case-insensitively with minor whitespace/hyphen tolerance on the `Follow-up:` prefix), that transition is the trigger signal: "yes, spin this out into a tracked WR." A new `[WR]` issue is filed automatically, linked back to the source, and the source gets a comment linking to the new WR — a two-way link so neither side goes stale.

Nothing happens if the box is added and checked in the *same* edit (no prior unchecked state to transition from — avoids over-firing), if a different box is checked, or if the box was already checked before.

## Changes

- `scripts/checkbox-diff.js` — new pure utility, `findNewlyCheckedFollowUps(oldBody, newBody)`. Parses markdown task-list lines from both bodies and matches them **by normalized text content** (not line position), so reordering or unrelated edits in the same diff don't break detection. No network/GitHub dependency, so it's fully unit-testable.
- `tests/checkbox-diff.test.js` — 16 cases: single item checked, multiple items checked in one edit, unrelated (non-follow-up) checkbox checked, already-checked item not re-reported, missing/null `oldBody`/`newBody`, reordered lines, prefix-casing/whitespace variants, no-description edge case.
- `.github/workflows/followup-checkbox-router.yml` — new workflow, triggers on `pull_request: [edited]` and `issues: [edited]`. Diffs `github.event.changes.body?.from` against the current body via `checkbox-diff.js` (guards for `changes.body` being absent, e.g. a title-only edit). For each newly-checked follow-up: classifies BASIC vs FULL using the same spirit as `wr-pr-creation.yml`'s title-regex heuristic (short one-liner → BASIC by default; long/multi-clause → FULL), renders the chosen WR template with the follow-up's link + description in `## Issue Context` and `## Learnings — What & Why`, creates the WR issue (`work-request`, `auto-generated-followup` labels; assignee `oaudrey`), and comments back on the source PR/issue with the new WR link.
- `wr/WR_TEMPLATE_FULL.md`, `wr/WR_TEMPLATE_BASIC.md` — new `## Learnings — What & Why` section. Ships as a generic guidance placeholder for normal WRs ("agents completing other WR types should fill this in themselves once done..."); for follow-up-generated WRs the router populates it with the concrete follow-up text, a link to the source PR/issue, and — if the source itself carries a `sourced from #N` marker — a note that this is a chained follow-up (kept simple for v1, no full chain-walking).
- `.github/labels.yml` — registers `auto-generated-followup` so it syncs via `sync-labels.yml`.
- `docs/SECRETS_MAP.md` — regenerated (`npm run secrets:map`) to include the new workflow's `ADMIN_GITHUB_TOKEN`/`GITHUB_TOKEN` references; this is what made `tests/secrets-map.test.js` go red until regenerated.

Permissions on the new workflow are `contents: read` (checkout only — no commits), `issues: write`, `pull-requests: write` — narrowest set the job needs, using the repo-standard `ADMIN_GITHUB_TOKEN`-with-fallback token pattern so the new WR issue can trigger downstream WR-processing workflows (CLAUDE.md gotchas #2/#3).

## Design decisions / judgment calls

- **BASIC vs FULL classification**: mirrors `wr-pr-creation.yml`'s spirit rather than reusing its exact regex, since follow-up descriptions are free text, not titles with `fix`/`bug`/`chore` keywords. Heuristic: length > 180 chars or multi-clause phrasing (`;`/`:` mid-sentence, "then"/"also") → FULL; otherwise BASIC.
- **Chained follow-ups**: kept intentionally simple per the task brief — if the source body contains `sourced from #N`, the new WR's Learnings section just notes that ancestry once. No recursive chain-walking.
- **Known nesting limitation (flagged, not fixed here)**: the router builds a *fully rendered* WR-shaped issue body (its own populated `Issue Context` + `Learnings` sections) rather than a bare description, per the "mirror wr-pr-creation.yml's inline template-selection + token-substitution approach" instruction. Because the new issue also carries the `work-request` label, it will *also* flow through the existing `wr-pr-creation.yml` pipeline (triggered on `opened`), which independently classifies the title and generates its own WR file, nesting this pre-rendered body inside a fresh template's `Issue Context` — so the final committed `wr/issues/*.md` may show the populated `Learnings` content nested one level down rather than promoted to the file's own top-level section. I deliberately did **not** patch `wr-pr-creation.yml` to special-case the `auto-generated-followup` label and lift that content, per CLAUDE.md's explicit warning that this file is fragile and has broken before from stacked edits (2026-07-08 incident). Tracking this as a follow-up itself:
  - [ ] Follow-up: consider having `wr-pr-creation.yml` special-case the `auto-generated-followup` label to promote the router's pre-rendered `Learnings — What & Why` content to the top level instead of leaving it nested under `Issue Context`.

## Validation

- `npm ci && npm test` — 574/574 passing, including the new `tests/checkbox-diff.test.js` (16 cases).
- `python3 -c "import yaml; yaml.safe_load(open(F))"` on both changed YAML files (`followup-checkbox-router.yml`, `labels.yml`) — clean.
- Changed-Markdown gate (`npx markdownlint-cli2` scoped to files changed vs. `origin/main`) — 0 errors.
- Manually simulated the workflow's template-rendering logic against the real `wr/WR_TEMPLATE_BASIC.md`/`FULL.md` files with sample short and long/chained follow-up descriptions — confirmed no leftover `{TOKEN}` placeholders and no strings that would trip `wr-lint`'s deferral-placeholder rule (no `TBD`/`TODO`/`N/A — pending ...`).

**Limitation:** this workflow's live trigger path (`issues: edited` / `pull_request: edited` with a real checkbox transition) **cannot be exercised end-to-end from this sandboxed session** — there's no way to fire a real GitHub webhook event here. The pure-logic half (`checkbox-diff.js`, the part that's actually verifiable without live GitHub state) has thorough unit coverage; the workflow YAML and its GitHub-API calls are unverified beyond YAML validity, the manual template-render simulation above, and careful reading against this repo's established patterns (`pdf-work-request-router.yml`'s `require(process.env.GITHUB_WORKSPACE + ...)` + token-fallback pattern, `wr-pr-creation.yml`'s classification/substitution approach). Recommend a maintainer exercises it live on a throwaway issue before relying on it.

`docs-freshness: checked both paired-doc targets -- docs/SYSTEM_MAP.md does not exist in this repo, and docs/AUTOMATION_AUDIT.md is a stale point-in-time audit snapshot (already lists "58 total" workflows against an actual count of 166+, and names workflows like openrouter-triage.yml that don't match the current tree). Adding one entry to an already-drifted historical doc wouldn't restore freshness, just add false confidence to it -- refreshing that doc is a separate, larger effort outside this PR's scope.`

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above




---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_


## High-level PR Summary
This PR introduces an automated mechanism to convert checked follow-up checklist items in PR/issue bodies into tracked Work Request (WR) issues. When a maintainer checks a box with the format `- [ ] Follow-up: `, a new workflow automatically creates a corresponding WR issue with appropriate templates, labels, and links back to the source. The implementation includes a pure-logic checkbox diff utility (`checkbox-diff.js`) with comprehensive unit tests, a new GitHub Actions workflow (`followup-checkbox-router.yml`) that triggers on issue/PR edits, and updates to WR templates to include a **Learnings — What & Why** section that gets populated automatically for follow-up-generated WRs.

⏱️ Estimated Review Time: 30-90 minutes


💡 Review Order Suggestion

| Order | File Path |
|-------|-----------|
| 1 | `scripts/checkbox-diff.js` |
| 2 | `tests/checkbox-diff.test.js` |
| 3 | `.github/workflows/followup-checkbox-router.yml` |
| 4 | `wr/WR_TEMPLATE_BASIC.md` |
| 5 | `wr/WR_TEMPLATE_FULL.md` |
| 6 | `.github/labels.yml` |
| 7 | `docs/SECRETS_MAP.md` |




[[Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)




---
## Summary by cubic
Automatically turns checked "Follow-up:" checklist items in PR/issue bodies into tracked WR issues to prevent dropped commitments. Detects unchecked→checked transitions and creates a new `[WR]` with two‑way links.

- **New Features**
  - Added `followup-checkbox-router.yml` to handle `pull_request.edited` / `issues.edited`: diffs `body`, creates a `[WR]` per newly checked `Follow-up:` item, labels `work-request` + `auto-generated-followup`, assigns `oaudrey`, and comments back with the link.
  - Introduced `scripts/checkbox-diff.js` with `tests/checkbox-diff.test.js` to find newly checked follow-ups by normalized text; ignores brand‑new or already‑checked boxes and handles reordering/casing/whitespace.
  - Added "Learnings — What & Why" to `wr/WR_TEMPLATE_BASIC.md` and `wr/WR_TEMPLATE_FULL.md`; router fills it with the follow-up text and source link; BASIC vs FULL chosen by a simple length/multi‑clause heuristic.
  - Registered the `auto-generated-followup` label and updated `docs/SECRETS_MAP.md` to include `followup-checkbox-router.yml` token references.

<sup>Written for commit f11a051100687f3ac45e6e5c4d1de679ba58421d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15834?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>

Closes #15834

Closes #15879

Closes #15898

Closes #15924

Closes #15946
closes #15946