### PR TITLE
[openrouter] [openrouter] [openrouter] [openrouter] [openrouter] docs: add audit and self-healing playbook, extend CLAUDE.md gotchas

### DIFF
--- a/standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md
+++ b/standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md
@@ -1,338 +1,131 @@
 # Audit and Self-Healing Playbook
 
-**Status:** Active reference — captures the repeatable audit methodology and
-fix-pattern catalog derived from the 2026-07-13 audit-and-fix session.
-
-**Case evidence:** PRs #15821, #15823, #15824, #15825, #15826, #15827, #15828.
-
-**Purpose:** `learnings.md` records incidents after the fact. This document
-captures the piece that was missing — *how to perform an audit* and *how to
-correct for self-healing* — so the next agent (human or AI) doesn't have to
-rediscover either from scratch.
-
----
-
-## How to Run an Audit
-
-1. **Scope into parallel read-only research agents by category.**
-   Split the surface area (workflows, scripts, security posture, CI health,
-   stale commitments, secrets handling, etc.) across independent read-only
-   subagents. Each returns findings with **file:line citations** — no fixes,
-   no writes. Parallelism is the point: serial audits miss recurrence.
-
-2. **Demand file:line citations for every finding.**
-   A finding without `path/to/file.ext:LINE` is a rumor. Reject it and
-   re-scope. Citations make triage, deduplication, and later fix-PR
-   authorship mechanical.
-
-3. **Cross-reference `learnings.md` for recurrence.**
-   Before treating a finding as novel, grep `learnings.md` for the symptom
-   and root cause. Recurrence is a stronger signal than severity — repeat
-   offenders get promoted in the triage queue and get catalog entries here.
-
-4. **Triage before fixing.**
-   Not every finding becomes an immediate PR. Bucket findings into: (a) fix
-   now, (b) file issue for later, (c) accept and document, (d) false
-   positive. Skipping triage floods reviewers and buries the high-signal
-   fixes.
-
-5. **One fix per isolated worktree subagent.**
-   Each accepted finding gets its own git worktree and its own fix subagent.
-   The subagent runs `npm ci && npm test` and adds a regression test that
-   would have caught the original bug. No batching — batched fix PRs hide
-   regressions and stall on unrelated review comments.
-
-6. **Watch live CI on your own in-flight PRs — don't just audit static
-   findings.**
-   The broken third-party Action in `saml-sso-registration.yml` (fixed in
-   #15828) was **not** discoverable from static scanning; it was caught by
-   noticing that every in-flight PR from the audit itself was failing the
-   same required check. Live CI on your own audit PRs is a second-order
-   audit surface. Watch it.
-
-7. **Targeted search — not enumeration — for stale follow-up commitments.**
-   Search issue/PR history for the specific phrases that mark unfinished
-   work (`Next Action`, `follow-up`, `TODO(owner)`, `will address in`, etc.).
-   Do **not** enumerate every open issue; the signal-to-noise ratio is too
-   low. Targeted phrase search is how #15826 surfaced.
-
----
-
-## Self-Healing Correction Pattern Catalog
-
-Each entry: **Symptom → Root cause → Fix**, with the PR that implemented it.
-
-### 1. Unguarded `removeLabel` race
-
-- **Symptom:** Workflow fails intermittently with `HttpError: Label does not
-  exist` when removing a label that another concurrent run already removed.
-- **Root cause:** `github.rest.issues.removeLabel` throws on 404; no guard
-  around the call.
-- **Fix:** Wrap in `try/catch` and swallow `error.status === 404`. Treat
-  "label already absent" as success — it's the desired end state.
-- **Reference:** #15821.
-
-### 2. Missing `allowError` on internal API helpers
-
-- **Symptom:** Helper functions that call the GitHub API abort the whole
-  workflow on transient 5xx or expected 404s.
-- **Root cause:** Internal helpers hard-coded `throw` on any non-2xx instead
-  of accepting an `allowError` / `allowedStatuses` option.
-- **Fix:** Add an `allowError` (or `allowedStatuses: number[]`) parameter to
-  every internal API helper. Callers that expect a 404 pass it explicitly;
-  everyone else keeps the strict default.
-- **Reference:** #15824.
-
-### 3. Default `GITHUB_TOKEN` on agent-created PRs
-
-- **Symptom:** Agent-authored PRs don't trigger downstream workflows
-  (required checks never run, auto-merge never fires).
-- **Root cause:** PRs created by the default `GITHUB_TOKEN` intentionally do
-  **not** trigger `pull_request` workflows — a GitHub anti-recursion
-  guardrail.
-- **Fix:** Create agent PRs with a PAT or GitHub App token, not the default
-  `GITHUB_TOKEN`. Store as a repo/org secret and pass explicitly.
-- **Reference:** #15823.
-
-### 4. Secrets via argv vs. stdin
-
-- **Symptom:** Secret values appear in `ps`, in shell history, in process
-  listings, and (worst) in workflow logs when `set -x` is on.
-- **Root cause:** Secret passed as a CLI argument (`tool --token $SECRET`)
-  instead of over stdin or an env var.
-- **Fix:** Pipe secrets over stdin (`echo "$SECRET" | tool --token-stdin`)
-  or read from env inside the tool. Never argv.
-- **Reference:** #15825.
-
-### 5. Bash bare-array-variable bug
-
-- **Symptom:** Only the first element of a bash array is used; loop body
-  silently runs once.
-- **Root cause:** `"$arr"` (bare) expands to `${arr[0]}`. Must be
-  `"${arr[@]}"` to expand to all elements.
-- **Fix:** Always `"${arr[@]}"` when iterating or passing an array.
-  `shellcheck` catches this — run it in CI.
-- **Reference:** #15827.
-
-### 6. Exit codes as proxy metrics vs. true resolution state
-
-- **Symptom:** A job "succeeds" (exit 0) but the underlying condition it was
-  supposed to resolve is still broken. Dashboards look green; reality isn't.
-- **Root cause:** The script exits 0 on "I ran to completion" rather than
-  on "the target state is achieved." Exit code became a proxy for
-  "finished" instead of "resolved."
-- **Fix:** After the work, **re-check the target state** and exit non-zero
-  if it isn't achieved. Exit codes must reflect true resolution, not mere
-  completion.
-- **Reference:** #15826.
-
-### 7. `nosemgrep` suppression comment adjacency
-
-- **Symptom:** Semgrep still flags a line that has a `# nosemgrep` comment
-  "nearby."
-- **Root cause:** `nosemgrep` only suppresses the **immediately adjacent**
-  line (same line, or the line directly above with no blank line between).
-  A blank line or an intervening comment breaks the association.
-- **Fix:** Put `# nosemgrep: rule-id` on the exact line being suppressed,
-  or on the line **immediately** above with no gap. Always name the rule
-  ID — bare `# nosemgrep` is over-broad.
-- **Reference:** #15825.
-
-### 8. Broken third-party GitHub Action failing every PR
-
-- **Symptom:** A required check fails on every PR with an error from a
-  third-party Action (deleted repo, yanked tag, breaking change on a
-  floating `@v1` ref).
-- **Root cause:** Third-party Action pinned to a moving ref (`@main`,
-  `@v1`) or to a repo that disappeared. No pin to a commit SHA.
-- **Fix:** Pin every third-party Action to a full commit SHA with a
-  version comment (`uses: owner/action@<sha> # v1.2.3`). Add a scheduled
-  workflow that alerts when pins go stale. If the upstream is dead, fork
-  and pin to the fork.
-- **Reference:** #15828.
-
----
-
-## Where the memory lives
-
-- **`learnings.md`** — incident log, one entry per event, written after the
-  fact.
-- **`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`** (this file) — the
-  *method* for finding recurrence and the *catalog* of known fix patterns.
-- **`standards/GREEN_MAIN_STANDARD.md`** — the invariant this playbook
-  defends: `main` stays green.
-- **`CLAUDE.md`** — the fast-path "recurring gotchas" list that points here.
-
-If a fix pattern recurs, promote it from `learnings.md` into the catalog
-above and cite the PR. If the audit method itself gains a new step, add it
-to "How to Run an Audit" — do not let the method live only in chat history.
-# Audit and Self-Healing Playbook — method + pattern catalog
-
 **Status:** Active
-**Case evidence:** 2026-07-13 audit session — 8 patterns fixed across PRs
-#15821, #15823, #15824, #15825, #15826, #15827, #15828.
-**Owner:** Shared standard — every agent (human or AI) should reference this
-before starting an audit or applying a self-healing fix.
+**Case evidence:** 2026-07-13 audit session (PRs #15821, #15823, #15824, #15825, #15826, #15827, #15828)
+**Related:** `standards/GREEN_MAIN_STANDARD.md`, `learnings.md`, `CLAUDE.md`
 
-This playbook formalizes the *method* of auditing and correcting recurring
-failure modes in this repository. `learnings.md` captures individual incidents
-after the fact; this document captures the **repeatable process** for
-discovering and fixing them, plus a fast-lookup catalog of known
-symptom→root-cause→fix mappings.
+This playbook formalizes the repeatable **audit methodology** and **fix-pattern
+catalog** used to keep automated agent PRs green and self-healing. `learnings.md`
+captures individual incidents; this document captures the *process* for finding
+them and the *shapes* of the fixes so the next agent (human or AI) doesn't have
+to rediscover either from scratch.
 
 ---
 
 ## How to Run an Audit
 
-1. **Scope into parallel, read-only research agents by category.**
-   Do not try to audit "everything" in one pass. Split by concern —
-   workflows, scripts, security, tests, docs — and dispatch each as an
-   independent read-only agent. This keeps context windows small and lets
-   you cross-reference findings later.
-
-2. **Demand file:line citations for every finding.**
-   A finding without a `path/to/file.ext:NN` citation is a rumor. Reject it
-   and re-run the sub-audit. Citations are what make triage and fix-PRs
-   auditable.
-
-3. **Cross-reference `learnings.md` for recurrence.**
-   Before opening a new fix PR, grep `learnings.md` for the symptom. If it
-   has happened before, the fix pattern is likely already documented — reuse
-   it rather than reinventing. If it is *new*, the fix PR must add a
-   `learnings.md` entry.
-
-4. **Triage before fixing.**
-   Not every finding becomes an immediate PR. Rank by (a) blast radius —
-   does this break `main` or leak secrets? — (b) recurrence — has it bitten
-   us before? — (c) fix cost. Low-blast-radius, low-recurrence items go on
-   a backlog issue, not a PR.
-
-5. **One fix per isolated worktree subagent.**
-   Each accepted finding gets its own `git worktree` and its own subagent.
-   The subagent runs `npm ci && npm test`, adds a regression test where
-   feasible, and opens exactly one PR. This keeps blame, revert, and review
-   surface minimal.
-
-6. **Watch live CI on your own in-flight PRs.**
-   Static findings are only half the audit. The other half is opening the
-   Actions tab on the PRs *you just filed* and watching them run. This is
-   how the broken third-party Action in `saml-sso-registration.yml` was
-   actually caught (#15828) — it was green in isolation and red only under
-   the PR-triggered matrix.
-
-7. **Use targeted search, not enumeration, for stale commitments.**
-   To find un-kept "follow-up" / "Next Action" / "TODO(owner)" promises in
-   issue and PR history, `gh search issues` and `gh search prs` with the
-   exact phrase — do not page through every issue. Enumeration wastes
-   context; targeted search hits the actual debt.
+1. **Scope into parallel read-only research agents by category.** Do not have
+   one agent try to audit everything. Split the surface into categories
+   (workflows, scripts, standards docs, in-flight PRs, stale follow-ups) and
+   dispatch a read-only subagent per category. Each agent returns findings
+   with **file:line citations** — never vague prose.
+2. **Cross-reference `learnings.md` for recurrence.** Before flagging a finding
+   as novel, grep `learnings.md` and prior PRs. Recurrence = higher priority
+   and signals a missing guardrail (test, lint rule, standards entry).
+3. **Triage before fixing.** Not every finding becomes an immediate PR. Sort
+   into: (a) breaks main / blocks agents now, (b) latent risk, (c) doc/nice-
+   to-have. Fix (a) first, file issues for (b), batch (c).
+4. **One fix per isolated worktree subagent.** Each fix runs in its own git
+   worktree with `npm ci && npm test` plus a regression test that would have
+   caught the original bug. No mixing unrelated fixes in one PR.
+5. **Watch live CI on your own in-flight PRs.** Static findings are not enough.
+   The broken third-party `saml-sso-registration.yml` Action (#15828) was
+   only caught by watching CI fail on unrelated PRs. Every open agent PR is a
+   live probe — read its checks.
+6. **Targeted search, not enumeration, for stale follow-ups.** When hunting
+   "Next Action" / "follow-up" / "TODO(agent)" commitments in issue/PR history,
+   grep for the specific phrases. Do not try to read every issue.
 
 ---
 
 ## Self-Healing Correction Pattern Catalog
 
-Each entry: **Symptom** → **Root cause** → **Fix** → **Reference PR**.
+Each entry: **Symptom** → **Root Cause** → **Fix** → **Citing PR**.
 
 ### 1. Unguarded `removeLabel` race
-
-- **Symptom:** Workflow fails with `HttpError: Label does not exist` when
-  removing a label that another concurrent run already removed.
-- **Root cause:** `octokit.rest.issues.removeLabel` throws on 404; no
-  concurrency guard on the workflow.
-- **Fix:** Wrap the call in `try/catch` and swallow 404, *and* add
-  `concurrency:` to the workflow so only one run mutates labels at a time.
-- **Reference:** PR #15821.
+- **Symptom:** Workflow fails with 404 on `removeLabel` when two jobs race to
+  remove the same trigger label.
+- **Root cause:** `github.rest.issues.removeLabel` throws on missing label;
+  no try/catch or existence check.
+- **Fix:** Wrap in try/catch and swallow 404 only; re-throw other errors.
+- **PR:** #15821
 
 ### 2. Missing `allowError` on internal API helpers
-
-- **Symptom:** A single 4xx from an internal helper aborts the entire
-  workflow step, even when the caller expected to branch on failure.
-- **Root cause:** Helper defaulted to `throwOnError: true`; callers assumed
-  the opposite.
-- **Fix:** Add an explicit `allowError` option (default `false` for
-  backward-compat) and thread it through call sites that branch on
-  failure.
-- **Reference:** PR #15824.
+- **Symptom:** Agent scripts crash on transient GitHub API errors that should
+  be retried or ignored.
+- **Root cause:** Internal helper wrappers didn't expose an `allowError` /
+  `continueOnError` flag; every caller had to hand-roll try/catch.
+- **Fix:** Add `allowError` option to shared API helpers; default `false` to
+  preserve strictness, opt-in for known-flaky calls.
+- **PR:** #15824
 
 ### 3. Default `GITHUB_TOKEN` on agent-created PRs
+- **Symptom:** Follow-up CI runs on agent-authored PRs don't trigger required
+  workflows because commits are attributed to `github-actions[bot]`.
+- **Root cause:** Using the default `GITHUB_TOKEN` for pushes prevents
+  workflow-triggering commits (by design).
+- **Fix:** Use a scoped PAT (or GitHub App token) for agent commits when
+  downstream workflows must run.
+- **PR:** #15823
 
-- **Symptom:** PRs opened by an agent workflow do not trigger downstream
-  `on: pull_request` workflows (CI never runs).
-- **Root cause:** GitHub deliberately suppresses recursive workflow
-  triggers when the actor is `GITHUB_TOKEN`.
-- **Fix:** Use a dedicated PAT (or GitHub App token) with `pull_requests:
-  write` when opening the PR. Store as a repo secret, not in argv.
-- **Reference:** PR #15823.
-
-### 4. Secrets via argv vs. stdin
-
-- **Symptom:** Secrets appear in `ps auxf`, in workflow logs on failure,
-  or in shell history.
-- **Root cause:** Passing `--token=$SECRET` on the command line — argv is
-  world-readable on the host and often echoed by set -x.
-- **Fix:** Pipe secrets on stdin (`echo "$SECRET" | tool --token-stdin`)
-  or read from an env var the tool consumes directly. Never argv.
-- **Reference:** PR #15825.
+### 4. Secrets via `argv` vs. `stdin`
+- **Symptom:** Secrets appear in `ps` output / process listings / error logs.
+- **Root cause:** Passing tokens as CLI arguments (`--token=$SECRET`) instead
+  of piping via stdin or env.
+- **Fix:** Pass secrets via stdin (`echo "$SECRET" | tool --token-stdin`) or
+  env var; never as argv.
+- **PR:** #15825
 
 ### 5. Bash bare-array-variable bug
-
-- **Symptom:** Loop iterates once over a joined string instead of N times
-  over N elements; or `"${arr}"` silently drops elements 2..N.
-- **Root cause:** `"$arr"` expands to element 0 only. You want
-  `"${arr[@]}"`.
-- **Fix:** Always `"${arr[@]}"` for iteration, and `set -u` at the top of
-  every script so unset arrays fail loud.
-- **Reference:** PR #15827.
+- **Symptom:** Only the first element of a bash array is used where all
+  elements were intended.
+- **Root cause:** `"$arr"` expands to `${arr[0]}`, not the whole array. Must
+  be `"${arr[@]}"`.
+- **Fix:** Always use `"${arr[@]}"` for array expansion; add shellcheck to CI.
+- **PR:** #15827
 
 ### 6. Exit codes as proxy metrics vs. true resolution state
-
-- **Symptom:** A job reports success (exit 0) even though the underlying
-  work (e.g., "issue resolved") did not actually happen — because the
-  script only checked whether the *tool* ran, not whether the *outcome*
-  was achieved.
-- **Root cause:** Conflating "command completed without error" with
-  "business outcome achieved."
-- **Fix:** After the tool runs, re-query the source of truth (issue
-  state, PR merge status, label presence) and exit non-zero if the
-  desired end state is not observed. Exit codes must reflect *true
-  resolution state*, not just tool liveness.
-- **Reference:** PR #15826.
+- **Symptom:** Workflow reports success (exit 0) even though the underlying
+  issue was not actually resolved — agent moved on prematurely.
+- **Root cause:** Script exits 0 on "I finished running" instead of on "the
+  problem is fixed and verified."
+- **Fix:** Distinguish `ran-to-completion` from `resolved`. Exit non-zero if
+  the resolution assertion (test passes, label removed, PR merged) is not met.
+- **PR:** #15826
 
 ### 7. `nosemgrep` suppression comment adjacency
-
 - **Symptom:** Semgrep still flags a line that has a `# nosemgrep` comment
   "nearby."
-- **Root cause:** Semgrep requires the suppression comment to be on the
-  *same line* as the finding, or on the immediately preceding line — a
-  blank line or an intervening comment breaks the association.
-- **Fix:** Place `# nosemgrep: rule-id` directly on the offending line
-  (preferred) or on the line immediately above with no blank line between.
-  Always include the specific rule id, never a bare `# nosemgrep`.
-- **Reference:** PR #15825.
+- **Root cause:** `nosemgrep` must be on the **same line** as the finding or
+  the **immediately preceding line** — not two lines above, not after a
+  blank line.
+- **Fix:** Place the suppression comment directly above (no blank line) or
+  inline with the flagged code. Prefer rule-specific suppressions
+  (`# nosemgrep: rule-id`).
+- **PR:** #15825
 
 ### 8. Broken third-party GitHub Action failing every PR
-
-- **Symptom:** A required check (e.g., `saml-sso-registration.yml`) fails
-  on every PR with an error originating inside a third-party Action —
-  not in our code.
-- **Root cause:** The upstream Action shipped a breaking change under a
-  floating tag (`@v2` moved), or was archived/removed. Our workflow pinned
-  by tag, not by SHA.
-- **Fix:** (a) Immediate — pin to a known-good commit SHA. (b) Follow-up —
-  either replace the Action or vendor its logic. Add the Action to the
-  Dependabot config so future upstream moves surface as PRs, not outages.
-- **Reference:** PR #15828.
+- **Symptom:** Every PR has a red check from a workflow nobody touched
+  recently (e.g. `saml-sso-registration.yml`).
+- **Root cause:** A pinned third-party Action version was yanked / its
+  upstream broke; workflow runs on every PR and fails.
+- **Fix:** Pin third-party Actions by full commit SHA (not tag). If broken
+  and non-essential, disable the workflow or gate it behind a path filter.
+  If essential, fork and self-host.
+- **PR:** #15828
 
 ---
 
 ## Where the memory lives
 
-- **This file (`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`)** — the
-  *method* and the *fix-pattern catalog*. Update when a new recurring
-  pattern is identified (≥2 incidents).
-- **`learnings.md`** — the *incident log*. Every fix PR appends an entry;
-  entries here feed step 3 of the audit method above.
-- **`CLAUDE.md` "Recurring gotchas"** — the *hot list* for agents. Only
-  the top ~10 gotchas live there; anything longer belongs in this
-  playbook.
-- **`standards/GREEN_MAIN_STANDARD.md`** — the invariant this playbook
-  ultimately protects: `main` stays green.
+- **This file** — audit method + fix-pattern catalog (shapes of bugs and fixes).
+- **`learnings.md`** — chronological per-incident narrative (what happened,
+  when, who found it).
+- **`standards/GREEN_MAIN_STANDARD.md`** — the definition of "green" this
+  playbook defends.
+- **`CLAUDE.md` "Recurring gotchas"** — fast-lookup summary for agents mid-task.
+
+When you fix a new class of bug, add:
+1. A dated entry to `learnings.md`.
+2. A new numbered Symptom/Root Cause/Fix entry here.
+3. A gotcha bullet in `CLAUDE.md` if it's likely to recur in agent flows.


### PR DESCRIPTION
Automated code changes for
issue #15955.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15933.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15905.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15886.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15832.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
## Summary

Formalizes today's (2026-07-13) audit-and-fix session into a reusable, shared
reference, per an explicit user request: "can everybody save memory and
learnings in revvel-standards — how to perform audit — how to correct for self
healing." `learnings.md` already captures individual incidents after the fact;
this PR adds the piece that was missing — a repeatable **audit methodology**
and a fast-lookup **fix-pattern catalog** — so the next agent (human or AI)
doesn't have to rediscover either from scratch.

## Changes

- Add `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`:
  - `## How to Run an Audit` — the actual method used today: scope into
    parallel read-only research agents by category, demand file:line
    citations, cross-reference `learnings.md` for recurrence, **triage before
    fixing** (not every finding becomes an immediate PR), one fix per isolated
    worktree subagent with `npm ci && npm test` + regression tests, **watch
    live CI on your own in-flight PRs** (not just static findings — this is
    how the broken `saml-sso-registration.yml` third-party Action was actually
    caught), and targeted search (not enumeration) for stale "follow-up"/"Next
    Action" commitments in issue/PR history.
  - `## Self-Healing Correction Pattern Catalog` — 8 Symptom/Root
    Cause/Fix entries for patterns fixed today, each citing its PR:
    unguarded `removeLabel` race (#15821), missing `allowError` on internal
    API helpers (#15824), default `GITHUB_TOKEN` on agent-created PRs
    (#15823), secrets via argv vs. stdin (#15825), bash bare-array-variable
    bug (#15827), exit codes as proxy metrics vs. true resolution state
    (#15826), `nosemgrep` suppression comment adjacency (#15825), and a broken
    third-party GitHub Action failing every PR (#15828).
- Extend `CLAUDE.md`'s "Recurring gotchas" section with two new entries in the
  same style as #1-#5: gotcha #6 (exit codes must reflect true resolution
  state) and gotcha #7 (`nosemgrep` suppression comment adjacency), plus a
  pointer to the new playbook near the existing gotcha list.

Doc structure and tone mirror `standards/GREEN_MAIN_STANDARD.md` (Status/Case
evidence header, numbered rules, "Where the memory lives" closing section).

## Validation

`npm ci && npm test` — 558/558 tests pass, no code changes (docs only).
`npx markdownlint-cli2` run directly against both changed files (the new
playbook and `CLAUDE.md`) — 0 errors after fixing one MD018 false-positive
(a line starting with `#15825)` was misread as an ATX heading; reworded).

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

<!-- No source issue number for this PR — it formalizes a same-session user request rather than an existing tracked issue/WR. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR formalizes an audit methodology and fix-pattern catalog into a new playbook document (`AUDIT_AND_SELF_HEALING_PLAYBOOK.md`) that captures the repeatable process used during a 2026-07-13 audit session. The playbook documents how to run parallel read-only research agents, triage findings, and apply fixes in isolation, plus catalogs eight common bug patterns (unguarded `removeLabel` races, missing `allowError` on API helpers, default `GITHUB_TOKEN` on agent PRs, secrets via argv vs stdin, bash array bugs, exit code proxy metrics, `nosemgrep` suppression comment adjacency, and broken third-party GitHub Actions) with symptom/root-cause/fix entries citing their respective PRs. It also extends `CLAUDE.md` with two new gotcha entries (exit codes and `nosemgrep` adjacency) and adds a pointer to the new playbook for future reference.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` |
| 2 | `CLAUDE.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

Closes #15832

Closes #15886

Closes #15905

Closes #15933

Closes #15955
closes #15955