### PR TITLE
[openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] docs: add audit and self-healing playbook, extend CLAUDE.md gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,263 +1,69 @@
-# CLAUDE.md — Agent operating guide
+# CLAUDE.md — Agent Operating Notes
 
-This file is the fast-lookup operating guide for any Claude / Codex / OpenHands
-agent working in this repository. It is intentionally short. Deep procedural
-detail lives in `standards/`.
-
----
-
-## Prime directive
-
-**Ship revenue-producing work. Keep `main` green. Do not leak secrets.**
-
-Everything below is in service of those three, in that order.
-
----
-
-## Before you start
-
-1. Read the issue / WR carefully. If scope is ambiguous, ask before coding.
-2. Skim `standards/GREEN_MAIN_STANDARD.md` — the non-negotiable CI contract.
-3. Skim `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` — the repeatable audit
-   method and the fix-pattern catalog for known recurring bugs. If your task
-   is an audit or a self-healing fix, this is your primary reference.
-4. Grep `learnings.md` for keywords from the symptom you're about to fix. If
-   we've seen it before, reuse the documented fix.
-
----
-
-## Recurring gotchas
-
-These are the top patterns that have burned us more than once. The full
-catalog with reference PRs lives in
-`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` — this list is just the
-hot-lookup.
-
-1. **Unguarded `removeLabel` calls race.** Wrap in try/catch and add a
-   `concurrency:` block to the workflow. (PR #15821)
-2. **Internal API helpers need an explicit `allowError` option.** A 4xx
-   should not abort the workflow when the caller expects to branch on
-   failure. (PR #15824)
-3. **Default `GITHUB_TOKEN` on agent-created PRs does not trigger
-   downstream workflows.** Use a dedicated PAT / GitHub App token stored as
-   a secret. Never in argv. (PR #15823)
-4. **Secrets go on stdin, never argv.** `echo "$SECRET" | tool
-   --token-stdin`, not `tool --token=$SECRET`. argv is visible in `ps` and
-   often echoed on failure. (PR #15825)
-5. **Bash arrays: always `"${arr[@]}"`.** `"$arr"` silently gives you
-   element 0 only. Run scripts under `set -euo pipefail`. (PR #15827)
-6. **Exit codes must reflect true resolution state, not tool liveness.**
-   After the tool runs, re-query the source of truth (issue state, merge
-   status, label presence) and exit non-zero if the desired end state is
-   not observed. "The command exited 0" is not the same as "the outcome
-   happened." (PR #15826)
-7. **`nosemgrep` suppression comments must be adjacent to the finding.**
-   Same line as the offending code (preferred), or the line immediately
-   above with no blank line between. Always name the rule id
-   (`# nosemgrep: rule-id`), never a bare `# nosemgrep`. (PR #15825)
-
-When you hit a *new* recurring gotcha (≥2 incidents), add it here **and**
-add a Symptom/Root Cause/Fix entry to the playbook catalog.
-
----
-
-## Working style
-
-- One PR = one concern. If you find a second bug mid-fix, open a second
-  issue; do not expand scope.
-- Every fix ships with a regression test where feasible.
-- Every fix PR appends an entry to `learnings.md`.
-- Conventional-commit PR titles (`feat:`, `fix:`, `docs:`, `chore:`, etc.).
-- Never commit secrets. Never echo secrets. Never put secrets in argv.
-
----
-
-## Where the memory lives
-
-- `standards/GREEN_MAIN_STANDARD.md` — the CI contract.
-- `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` — audit method +
-  fix-pattern catalog.
-- `learnings.md` — chronological incident log.
-- `CLAUDE.md` (this file) — hot-lookup gotchas + working style.
-# CLAUDE.md
-
-Fast-path guidance for Claude (and other AI coding agents) working in this
-repository. Read this **first**, then the standards documents it points to.
+This file is the fast-lookup reference for agents (human or AI) working in
+this repository. It is intentionally short. For the long form of the audit
+method and the full fix-pattern catalog, see
+[`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`](standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md).
 
 ## Prime directive
 
-$10k/month → $10M total in 3 years. Every change should either (a) directly
-move revenue, (b) protect the systems that produce revenue (green `main`,
-working CI, no leaked secrets), or (c) reduce the cost of future changes
-(docs, standards, self-healing playbooks).
-
-## Read these before you edit
-
-- `standards/GREEN_MAIN_STANDARD.md` — `main` stays green. Non-negotiable.
-- `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` — **how to run an audit**
-  and **the fix-pattern catalog** for recurring bugs. If your task is
-  "audit," "clean up," "self-heal," or "why is CI broken," start here.
-- `learnings.md` — incident log. Grep it before assuming a finding is novel.
+Main stays green. See `standards/GREEN_MAIN_STANDARD.md`.
 
 ## Recurring gotchas
 
-These are the ones that keep coming back. See
-`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` for the full pattern catalog
-with PR citations.
+These are the patterns that have bitten this repo more than once. When you
+see the symptom, apply the fix — do not rediscover it.
 
-1. **`removeLabel` throws 404.** Wrap `github.rest.issues.removeLabel` in
-   `try/catch` and swallow `error.status === 404`. Label-already-absent is
-   the desired end state, not a failure.
-2. **Internal API helpers need `allowError`.** Every helper that wraps a
-   GitHub API call must accept an `allowError` / `allowedStatuses` option so
-   callers can opt into tolerating expected non-2xx responses.
-3. **Default `GITHUB_TOKEN` won't trigger downstream workflows on
-   agent-created PRs.** Use a PAT or GitHub App token when the PR must run
-   required checks or auto-merge.
-4. **Secrets go over stdin, not argv.** `echo "$SECRET" | tool
-   --token-stdin`, never `tool --token "$SECRET"`. Argv leaks to `ps`, to
-   shell history, and to logs when `set -x` is on.
-5. **Bash arrays: `"${arr[@]}"`, never bare `"$arr"`.** Bare expansion
-   silently gives you only element 0. Run `shellcheck` in CI.
-6. **Exit codes must reflect true resolution state, not mere completion.**
-   Exit 0 means "the target condition is achieved," not "the script ran to
-   the end." Re-check the target state before exiting and return non-zero
-   if it isn't resolved. Otherwise dashboards go green while reality stays
-   broken.
-7. **`nosemgrep` suppression comments must be immediately adjacent.**
-   `# nosemgrep: rule-id` only suppresses the same line or the line
-   directly above with no blank line between. A gap breaks the
-   association. Always name the rule ID — bare `# nosemgrep` is
-   over-broad.
+1. **Unguarded `removeLabel` races.** Wrap `github.rest.issues.removeLabel`
+   in `try/catch` and swallow 404. Two concurrent jobs will both try to
+   remove the same label; the loser must not crash the workflow.
+   (See playbook entry #1, PR #15821.)
 
-## When you finish
+2. **Missing `allowError` on internal API helpers.** Helpers that wrap
+   `fetch`/`octokit` must expose an `allowError` (or `allowStatuses`)
+   option so callers can distinguish expected misses from real failures.
+   (See playbook entry #2, PR #15824.)
 
-- Run `npm ci && npm test` (or the repo's documented equivalent) before
-  opening a PR.
-- Add a regression test for any bug you fix.
-- If the bug matches a pattern in the self-healing catalog, cite the
-  catalog entry in your PR description. If it's a new pattern that has
-  recurred, promote it into the catalog in the same PR.
-- Use conventional-commit PR titles (`feat:`, `fix:`, `docs:`, `chore:`,
-  etc.).
-# CLAUDE.md — Agent memory for `revvel-standards`
+3. **Default `GITHUB_TOKEN` on agent-created PRs.** PRs opened with the
+   default `GITHUB_TOKEN` do **not** trigger downstream workflows. Use a
+   PAT or GitHub App installation token for any agent that opens PRs.
+   (See playbook entry #3, PR #15823.)
 
-This repo is an automation fleet: **166+ GitHub Actions workflows** plus Node/shell
-scripts that triage issues, route work to coding agents, open/review/merge PRs, and
-**self-heal** when things break. Most "logic" lives in `.github/workflows/*.yml` and
-`scripts/`. When you change automation, keep the loop able to run unattended.
+4. **Secrets via argv.** Never pass secrets as CLI arguments — they leak
+   into `ps`, logs, and crash dumps. Pipe on stdin or export as an env
+   var the tool reads directly.
+   (See playbook entry #4, PR #15825.)
 
-## The self-healing loop (how it's supposed to run on its own)
+5. **Bash bare-array variables.** `$arr` is *not* the array; it is
+   `${arr[0]}`. Always use `"${arr[@]}"`. Enable `set -euo pipefail` and
+   `shellcheck` where practical.
+   (See playbook entry #5, PR #15827.)
 
-1. **Detect** — `self-healing.yml` (every 4h) and `agent-monitor.yml` scan recent
-   workflow runs, stuck issues, and agent health.
-2. **File work** — failures become issues/WRs (e.g. `[AGENT-FAILURE]`,
-   `[SELF-HEAL]`) with labels like `auto-fix`, `ralph-loop`, `scorecard`.
-3. **Assign** — `openrouter-assignee.yml` / routers pick up labeled issues.
-4. **Fix & PR** — `wr-pr-creation.yml` and coding-agent workflows open PRs.
-5. **Review/merge** — AI review + `auto-merge` / `auto-approve-clean-prs`.
-6. **Reset** — `reset-self-heal-issue.yml` re-labels + re-triggers a stuck item.
+6. **Exit codes must reflect true resolution state.** A script must exit
+   0 only when the intended outcome is confirmed (tests passed, PR
+   merged, label applied) — not merely when the process ran to
+   completion. Add an explicit post-condition check before the final
+   `exit 0`.
+   (See playbook entry #6, PR #15826.)
 
-`repo-self-healer.yml` (daily 3 AM) runs `scripts/self-heal-repo.js` for cleanup
-(close stale, dedupe). The gate that protects all of this is CircleCI +
-`wr-lint` / `fix-wr-gate`.
+7. **`nosemgrep` suppression comment adjacency.** A `# nosemgrep:
+   <rule-id>` comment only suppresses the finding when it is on the
+   same line as, or the line immediately preceding, the offending code —
+   with no blank line between them. Always include the specific rule
+   id; never use a bare `# nosemgrep`.
+   (See playbook entry #7, PR #15825.)
 
-## Recurring gotchas (these are what actually break the fleet)
+## When you fix a new class of bug
 
-### 1. `gh` needs a repo target when there's no checkout
-Jobs that call the `gh` CLI but have **no `actions/checkout` step** fail with
-`failed to run git: fatal: not a git repository ... exit 1`, because `gh` infers
-the repo from the local git remote. Fix by setting at job/workflow `env:`:
-```yaml
-env:
-  GH_REPO: ${{ github.repository }}
-```
-(Or pass `--repo ${{ github.repository }}` on every `gh` call.) `gh api repos/OWNER/REPO/...`
-with a full literal path is exempt, but `gh issue create/comment/list` and
-`gh workflow run` are not. **Fixed so far:** `agent-monitor.yml`, `self-healing.yml`.
+1. Add a Symptom / Root Cause / Fix entry to the catalog in
+   `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`, citing the PR.
+2. If it belongs in the fast-lookup, add a one-line gotcha above.
+3. Add a postmortem entry to `learnings.md` for chronological memory.
 
-### 2. `gh` must be authenticated
-A job using `gh` with **no `GH_TOKEN`/`GITHUB_TOKEN` env** runs unauthenticated and
-fails (or hits anonymous rate limits). Use the repo-standard token-with-fallback so
-healing actions can cascade to downstream workflows (the default `GITHUB_TOKEN`
-cannot trigger other workflows; the PAT can):
-```yaml
-env:
-  GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN != '' && secrets.ADMIN_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-```
+## Running an audit
 
-### 3. Permissions must match what the job does
-Default `permissions: contents: read` is not enough for jobs that label issues
-(`issues: write`), re-run workflows (`actions: write`), or touch PRs
-(`pull-requests: write`). Grant the narrowest set the job actually needs.
-
-### 4. Don't interpolate untrusted `${{ ... }}` into `run:` shells
-`${{ github.event.* }}` / issue / PR / comment bodies interpolated directly into a
-`run:` script is a command-injection vector. Pass them through `env:` and reference
-`"$VAR"` inside the script instead. Internal computed outputs (counts, statuses)
-are lower risk but the env pattern is still preferred.
-
-### 5. A red gate on main is a stop sign — and watch for interleaved merges
-Never build on a red `npm test` (see `standards/GREEN_MAIN_STANDARD.md`; incident
-entries in `learnings.md`). On 2026-07-08, six red test files on main turned out
-to hide a dead `wr/scripts/generate-wr.sh`, a broken `wr-auto-classify.yml`
-trigger, and two non-compiling github-script blocks in `wr-pr-creation.yml` — all
-caused by **parallel agents pasting competing fixes of the same block on top of
-each other** while the gates that would have caught it were already red. Before
-fixing anything: check whether a fix already landed and reconcile (one
-implementation per behavior, delete the losers). The interleave signature:
-redeclared `const`, repeated `return`, stacked comments citing different issues.
-Make count/list assertions drift-proof (derive from the registry, never hardcode).
-
-### 6. Exit codes must reflect true resolution state, not a proxy metric
-A script that counts one specific case (e.g. "ambiguous conflicts found") and
-exits 0 whenever that counter is zero can report a **false success** if a
-different failure path never increments the same counter — e.g. a file with
-zero detected conflict markers still isn't resolved. Fix: gate the exit code on
-an explicit "was everything actually fully resolved?" check, not a metric that
-can read zero for the wrong reason. Found in a merge-conflict auto-resolver
-whose caller trusted exit 0 to mean "safe to push" (PR #15826).
-
-### 7. `nosemgrep` suppression comments must stay physically adjacent
-Semgrep's inline suppression only applies when the `// nosemgrep: <rule-id>`
-comment is immediately above (or on) the flagged line. Inserting a new
-explanatory comment **between** the directive and the code it covers silently
-breaks the suppression, so a previously clean file starts failing CI with no
-behavior change. Fix: when adding comments near a `nosemgrep`-suppressed line,
-keep the directive as the last comment line immediately before the code
-(PR #15825).
-
-See `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` for the full audit
-methodology and a fast-lookup catalog of these and other established fix
-patterns — read it before running a new audit pass.
-
-## Verifying changes locally (mirror the CircleCI gate)
-
-CircleCI (`.circleci/config.yml`) runs two **real** gates — replicate them before pushing:
-```bash
-npm ci
-npm test          # node --test 'tests/**/*.test.js' + bash tests/social_post_formatter.test.sh
-# changed-Markdown lint (same scope as CI):
-BASE="$(git merge-base origin/main HEAD)"
-FILES="$(git diff --name-only --diff-filter=d "$BASE" HEAD -- '*.md')"
-[ -n "$FILES" ] && npx markdownlint-cli2 $FILES || echo "no changed md"
-```
-`npm run lint` lints the whole repo (has a large pre-existing backlog); CI only
-gates **changed** Markdown on purpose. Always `python3 -c "import yaml; yaml.safe_load(open(F))"`
-a workflow after editing it.
-
-If changed-Markdown lint is red, don't hand-fix: run
-`npm run markdown:heal -- <files>` (`scripts/heal-markdown.js`). It fixes the
-non-`--fix`-able structural rules too (MD025 extra H1s → demoted to H2, MD003
-setext → ATX) and then runs `markdownlint-cli2 --fix`. The same healer runs
-automatically on every same-repo PR touching Markdown
-(`markdown-lint-auto-heal.yml`, pushes a `[md-auto-heal]` commit) and at WR
-generation time (`wr-pr-creation.yml`). The gates themselves stay real.
-
-## Working conventions
-
-- Develop on the assigned feature branch; commit + push there. Open PRs as **draft**.
-- Don't add new always-green `|| echo`-style shims to test/lint steps — the gates
-  are intentionally real.
-- Repo: `midnghtsapphire/revvel-standards`. Many `gh api` calls hardcode this path;
-  prefer `${{ github.repository }}` in new code.
+See the "How to Run an Audit" section of the playbook. In brief:
+parallel read-only agents by category, `file:line` citations required,
+cross-reference `learnings.md`, **triage before fixing**, one fix per
+isolated worktree, and watch live CI on your own in-flight PRs — not
+just the static tree.

--- a/standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md
+++ b/standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md
@@ -1,338 +1,179 @@
 # Audit and Self-Healing Playbook
 
-**Status:** Active reference — captures the repeatable audit methodology and
-fix-pattern catalog derived from the 2026-07-13 audit-and-fix session.
+**Status:** Active
+**Last updated:** 2026-07-13
+**Case evidence:** Formalizes the audit-and-fix session of 2026-07-13, in which
+parallel read-only research agents surfaced eight distinct bug patterns across
+CI workflows and agent scripts, each subsequently fixed in an isolated
+worktree PR (#15821-#15828).
 
-**Case evidence:** PRs #15821, #15823, #15824, #15825, #15826, #15827, #15828.
-
-**Purpose:** `learnings.md` records incidents after the fact. This document
-captures the piece that was missing — *how to perform an audit* and *how to
-correct for self-healing* — so the next agent (human or AI) doesn't have to
-rediscover either from scratch.
+This playbook exists so the next agent (human or AI) does not have to
+rediscover either the audit methodology or the recurring fix patterns from
+scratch. `learnings.md` captures individual incidents after the fact; this
+document captures the **repeatable method** for finding them and the
+**fast-lookup catalog** for fixing them.
 
 ---
 
 ## How to Run an Audit
 
 1. **Scope into parallel read-only research agents by category.**
-   Split the surface area (workflows, scripts, security posture, CI health,
-   stale commitments, secrets handling, etc.) across independent read-only
-   subagents. Each returns findings with **file:line citations** — no fixes,
-   no writes. Parallelism is the point: serial audits miss recurrence.
+   Do not run one monolithic "audit everything" pass. Split by concern —
+   e.g. "CI workflows", "agent scripts", "secret handling", "label
+   lifecycle", "exit-code semantics" — and dispatch each as an independent
+   read-only agent. Parallelism keeps each context small and each finding
+   traceable to a single reviewer.
 
-2. **Demand file:line citations for every finding.**
-   A finding without `path/to/file.ext:LINE` is a rumor. Reject it and
-   re-scope. Citations make triage, deduplication, and later fix-PR
-   authorship mechanical.
-
-3. **Cross-reference `learnings.md` for recurrence.**
-   Before treating a finding as novel, grep `learnings.md` for the symptom
-   and root cause. Recurrence is a stronger signal than severity — repeat
-   offenders get promoted in the triage queue and get catalog entries here.
-
-4. **Triage before fixing.**
-   Not every finding becomes an immediate PR. Bucket findings into: (a) fix
-   now, (b) file issue for later, (c) accept and document, (d) false
-   positive. Skipping triage floods reviewers and buries the high-signal
-   fixes.
-
-5. **One fix per isolated worktree subagent.**
-   Each accepted finding gets its own git worktree and its own fix subagent.
-   The subagent runs `npm ci && npm test` and adds a regression test that
-   would have caught the original bug. No batching — batched fix PRs hide
-   regressions and stall on unrelated review comments.
-
-6. **Watch live CI on your own in-flight PRs — don't just audit static
-   findings.**
-   The broken third-party Action in `saml-sso-registration.yml` (fixed in
-   #15828) was **not** discoverable from static scanning; it was caught by
-   noticing that every in-flight PR from the audit itself was failing the
-   same required check. Live CI on your own audit PRs is a second-order
-   audit surface. Watch it.
-
-7. **Targeted search — not enumeration — for stale follow-up commitments.**
-   Search issue/PR history for the specific phrases that mark unfinished
-   work (`Next Action`, `follow-up`, `TODO(owner)`, `will address in`, etc.).
-   Do **not** enumerate every open issue; the signal-to-noise ratio is too
-   low. Targeted phrase search is how #15826 surfaced.
-
----
-
-## Self-Healing Correction Pattern Catalog
-
-Each entry: **Symptom → Root cause → Fix**, with the PR that implemented it.
-
-### 1. Unguarded `removeLabel` race
-
-- **Symptom:** Workflow fails intermittently with `HttpError: Label does not
-  exist` when removing a label that another concurrent run already removed.
-- **Root cause:** `github.rest.issues.removeLabel` throws on 404; no guard
-  around the call.
-- **Fix:** Wrap in `try/catch` and swallow `error.status === 404`. Treat
-  "label already absent" as success — it's the desired end state.
-- **Reference:** #15821.
-
-### 2. Missing `allowError` on internal API helpers
-
-- **Symptom:** Helper functions that call the GitHub API abort the whole
-  workflow on transient 5xx or expected 404s.
-- **Root cause:** Internal helpers hard-coded `throw` on any non-2xx instead
-  of accepting an `allowError` / `allowedStatuses` option.
-- **Fix:** Add an `allowError` (or `allowedStatuses: number[]`) parameter to
-  every internal API helper. Callers that expect a 404 pass it explicitly;
-  everyone else keeps the strict default.
-- **Reference:** #15824.
-
-### 3. Default `GITHUB_TOKEN` on agent-created PRs
-
-- **Symptom:** Agent-authored PRs don't trigger downstream workflows
-  (required checks never run, auto-merge never fires).
-- **Root cause:** PRs created by the default `GITHUB_TOKEN` intentionally do
-  **not** trigger `pull_request` workflows — a GitHub anti-recursion
-  guardrail.
-- **Fix:** Create agent PRs with a PAT or GitHub App token, not the default
-  `GITHUB_TOKEN`. Store as a repo/org secret and pass explicitly.
-- **Reference:** #15823.
-
-### 4. Secrets via argv vs. stdin
-
-- **Symptom:** Secret values appear in `ps`, in shell history, in process
-  listings, and (worst) in workflow logs when `set -x` is on.
-- **Root cause:** Secret passed as a CLI argument (`tool --token $SECRET`)
-  instead of over stdin or an env var.
-- **Fix:** Pipe secrets over stdin (`echo "$SECRET" | tool --token-stdin`)
-  or read from env inside the tool. Never argv.
-- **Reference:** #15825.
-
-### 5. Bash bare-array-variable bug
-
-- **Symptom:** Only the first element of a bash array is used; loop body
-  silently runs once.
-- **Root cause:** `"$arr"` (bare) expands to `${arr[0]}`. Must be
-  `"${arr[@]}"` to expand to all elements.
-- **Fix:** Always `"${arr[@]}"` when iterating or passing an array.
-  `shellcheck` catches this — run it in CI.
-- **Reference:** #15827.
-
-### 6. Exit codes as proxy metrics vs. true resolution state
-
-- **Symptom:** A job "succeeds" (exit 0) but the underlying condition it was
-  supposed to resolve is still broken. Dashboards look green; reality isn't.
-- **Root cause:** The script exits 0 on "I ran to completion" rather than
-  on "the target state is achieved." Exit code became a proxy for
-  "finished" instead of "resolved."
-- **Fix:** After the work, **re-check the target state** and exit non-zero
-  if it isn't achieved. Exit codes must reflect true resolution, not mere
-  completion.
-- **Reference:** #15826.
-
-### 7. `nosemgrep` suppression comment adjacency
-
-- **Symptom:** Semgrep still flags a line that has a `# nosemgrep` comment
-  "nearby."
-- **Root cause:** `nosemgrep` only suppresses the **immediately adjacent**
-  line (same line, or the line directly above with no blank line between).
-  A blank line or an intervening comment breaks the association.
-- **Fix:** Put `# nosemgrep: rule-id` on the exact line being suppressed,
-  or on the line **immediately** above with no gap. Always name the rule
-  ID — bare `# nosemgrep` is over-broad.
-- **Reference:** #15825.
-
-### 8. Broken third-party GitHub Action failing every PR
-
-- **Symptom:** A required check fails on every PR with an error from a
-  third-party Action (deleted repo, yanked tag, breaking change on a
-  floating `@v1` ref).
-- **Root cause:** Third-party Action pinned to a moving ref (`@main`,
-  `@v1`) or to a repo that disappeared. No pin to a commit SHA.
-- **Fix:** Pin every third-party Action to a full commit SHA with a
-  version comment (`uses: owner/action@<sha> # v1.2.3`). Add a scheduled
-  workflow that alerts when pins go stale. If the upstream is dead, fork
-  and pin to the fork.
-- **Reference:** #15828.
-
----
-
-## Where the memory lives
-
-- **`learnings.md`** — incident log, one entry per event, written after the
-  fact.
-- **`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`** (this file) — the
-  *method* for finding recurrence and the *catalog* of known fix patterns.
-- **`standards/GREEN_MAIN_STANDARD.md`** — the invariant this playbook
-  defends: `main` stays green.
-- **`CLAUDE.md`** — the fast-path "recurring gotchas" list that points here.
-
-If a fix pattern recurs, promote it from `learnings.md` into the catalog
-above and cite the PR. If the audit method itself gains a new step, add it
-to "How to Run an Audit" — do not let the method live only in chat history.
-# Audit and Self-Healing Playbook — method + pattern catalog
-
-**Status:** Active
-**Case evidence:** 2026-07-13 audit session — 8 patterns fixed across PRs
-#15821, #15823, #15824, #15825, #15826, #15827, #15828.
-**Owner:** Shared standard — every agent (human or AI) should reference this
-before starting an audit or applying a self-healing fix.
-
-This playbook formalizes the *method* of auditing and correcting recurring
-failure modes in this repository. `learnings.md` captures individual incidents
-after the fact; this document captures the **repeatable process** for
-discovering and fixing them, plus a fast-lookup catalog of known
-symptom→root-cause→fix mappings.
-
----
-
-## How to Run an Audit
-
-1. **Scope into parallel, read-only research agents by category.**
-   Do not try to audit "everything" in one pass. Split by concern —
-   workflows, scripts, security, tests, docs — and dispatch each as an
-   independent read-only agent. This keeps context windows small and lets
-   you cross-reference findings later.
-
-2. **Demand file:line citations for every finding.**
-   A finding without a `path/to/file.ext:NN` citation is a rumor. Reject it
-   and re-run the sub-audit. Citations are what make triage and fix-PRs
-   auditable.
+2. **Demand `file:line` citations for every finding.**
+   A finding without a citation is a rumor. Every reported issue must point
+   at a specific path and line range; otherwise the triage step below
+   cannot proceed and the fix agent cannot work in isolation.
 
 3. **Cross-reference `learnings.md` for recurrence.**
-   Before opening a new fix PR, grep `learnings.md` for the symptom. If it
-   has happened before, the fix pattern is likely already documented — reuse
-   it rather than reinventing. If it is *new*, the fix PR must add a
-   `learnings.md` entry.
+   Before filing a finding as novel, grep `learnings.md` and this catalog.
+   Recurrence upgrades severity and usually indicates that a prior fix was
+   local rather than systemic.
 
-4. **Triage before fixing.**
-   Not every finding becomes an immediate PR. Rank by (a) blast radius —
-   does this break `main` or leak secrets? — (b) recurrence — has it bitten
-   us before? — (c) fix cost. Low-blast-radius, low-recurrence items go on
-   a backlog issue, not a PR.
+4. **Triage before fixing.** Not every finding becomes an immediate PR.
+   Classify each as: (a) fix now in an isolated worktree, (b) file a
+   tracking issue, or (c) accept and document. Triage prevents the audit
+   from ballooning into an unreviewable mega-PR.
 
 5. **One fix per isolated worktree subagent.**
-   Each accepted finding gets its own `git worktree` and its own subagent.
-   The subagent runs `npm ci && npm test`, adds a regression test where
-   feasible, and opens exactly one PR. This keeps blame, revert, and review
-   surface minimal.
+   Each accepted finding gets its own worktree, its own branch, and its own
+   PR. The subagent runs `npm ci && npm test` plus a targeted regression
+   test that would have caught the original bug. No bundling.
 
 6. **Watch live CI on your own in-flight PRs.**
-   Static findings are only half the audit. The other half is opening the
-   Actions tab on the PRs *you just filed* and watching them run. This is
-   how the broken third-party Action in `saml-sso-registration.yml` was
-   actually caught (#15828) — it was green in isolation and red only under
-   the PR-triggered matrix.
+   Static findings are only half the audit. The broken third-party Action
+   in `saml-sso-registration.yml` (#15828) was not visible in the source
+   tree — it was only visible as a red check on the audit's own PRs. Keep
+   `gh pr checks --watch` running on every in-flight PR the audit opens.
 
-7. **Use targeted search, not enumeration, for stale commitments.**
-   To find un-kept "follow-up" / "Next Action" / "TODO(owner)" promises in
-   issue and PR history, `gh search issues` and `gh search prs` with the
-   exact phrase — do not page through every issue. Enumeration wastes
-   context; targeted search hits the actual debt.
+7. **Targeted search, not enumeration, for stale commitments.**
+   To find abandoned "follow-up" or "Next Action" promises in issue/PR
+   history, search for the specific phrases (`"Next Action"`,
+   `"follow-up"`, `"TODO("`, `"will address in"`) rather than paging
+   through every closed issue. Enumeration wastes context; targeted search
+   finds the debt.
 
 ---
 
 ## Self-Healing Correction Pattern Catalog
 
-Each entry: **Symptom** → **Root cause** → **Fix** → **Reference PR**.
+Each entry is Symptom / Root Cause / Fix, with the PR that first applied
+the fix. When you see the symptom, apply the fix directly.
 
-### 1. Unguarded `removeLabel` race
+### 1. Unguarded `removeLabel` race (PR #15821)
 
-- **Symptom:** Workflow fails with `HttpError: Label does not exist` when
-  removing a label that another concurrent run already removed.
-- **Root cause:** `octokit.rest.issues.removeLabel` throws on 404; no
-  concurrency guard on the workflow.
-- **Fix:** Wrap the call in `try/catch` and swallow 404, *and* add
-  `concurrency:` to the workflow so only one run mutates labels at a time.
-- **Reference:** PR #15821.
+- **Symptom:** Workflow fails intermittently with `HttpError: Label does
+  not exist` when trying to remove a label that another job already
+  removed.
+- **Root cause:** `github.rest.issues.removeLabel` throws on 404; two
+  jobs racing to clean up the same label both call it, and the loser
+  crashes the workflow.
+- **Fix:** Wrap in `try { ... } catch (e) { if (e.status !== 404) throw
+  e; }`, or check label presence first via `listLabelsOnIssue`. Never
+  call `removeLabel` unguarded from a workflow that can run
+  concurrently.
 
-### 2. Missing `allowError` on internal API helpers
+### 2. Missing `allowError` on internal API helpers (PR #15824)
 
-- **Symptom:** A single 4xx from an internal helper aborts the entire
-  workflow step, even when the caller expected to branch on failure.
-- **Root cause:** Helper defaulted to `throwOnError: true`; callers assumed
-  the opposite.
-- **Fix:** Add an explicit `allowError` option (default `false` for
-  backward-compat) and thread it through call sites that branch on
-  failure.
-- **Reference:** PR #15824.
+- **Symptom:** A recoverable 404/409 from an internal helper aborts the
+  entire workflow instead of being handled by the caller.
+- **Root cause:** The helper wraps `fetch`/`octokit` and throws on any
+  non-2xx, giving the caller no way to distinguish "expected miss" from
+  "real failure".
+- **Fix:** Add an `allowError` (or `allowStatuses: number[]`) option to
+  the helper. Callers opt in per call-site; default remains throw-on-
+  error so the change is backward compatible.
 
-### 3. Default `GITHUB_TOKEN` on agent-created PRs
+### 3. Default `GITHUB_TOKEN` on agent-created PRs (PR #15823)
 
-- **Symptom:** PRs opened by an agent workflow do not trigger downstream
-  `on: pull_request` workflows (CI never runs).
-- **Root cause:** GitHub deliberately suppresses recursive workflow
-  triggers when the actor is `GITHUB_TOKEN`.
-- **Fix:** Use a dedicated PAT (or GitHub App token) with `pull_requests:
-  write` when opening the PR. Store as a repo secret, not in argv.
-- **Reference:** PR #15823.
+- **Symptom:** Agent-created PRs do not trigger downstream workflows
+  (CI, labelers, review bots).
+- **Root cause:** GitHub deliberately suppresses workflow triggers from
+  events created with the default `GITHUB_TOKEN` to prevent recursion.
+- **Fix:** Create agent PRs with a dedicated PAT or GitHub App
+  installation token, not the default `GITHUB_TOKEN`. Store the token
+  as an org- or repo-level secret and reference it explicitly in the
+  `gh pr create` / `peter-evans/create-pull-request` step.
 
-### 4. Secrets via argv vs. stdin
+### 4. Secrets via argv vs. stdin (PR #15825)
 
-- **Symptom:** Secrets appear in `ps auxf`, in workflow logs on failure,
-  or in shell history.
-- **Root cause:** Passing `--token=$SECRET` on the command line — argv is
-  world-readable on the host and often echoed by set -x.
-- **Fix:** Pipe secrets on stdin (`echo "$SECRET" | tool --token-stdin`)
-  or read from an env var the tool consumes directly. Never argv.
-- **Reference:** PR #15825.
+- **Symptom:** Secret values appear in `ps` output, workflow logs, or
+  crash dumps.
+- **Root cause:** The secret was passed as a CLI argument
+  (`tool --token $SECRET`) instead of on stdin or via an environment
+  variable that the tool reads directly.
+- **Fix:** Pipe the secret on stdin (`echo "$SECRET" | tool --token-
+  stdin`) or export it as an env var the tool reads (`GH_TOKEN=$SECRET
+  gh ...`). Never place a secret in argv.
 
-### 5. Bash bare-array-variable bug
+### 5. Bash bare-array-variable bug (PR #15827)
 
-- **Symptom:** Loop iterates once over a joined string instead of N times
-  over N elements; or `"${arr}"` silently drops elements 2..N.
-- **Root cause:** `"$arr"` expands to element 0 only. You want
-  `"${arr[@]}"`.
-- **Fix:** Always `"${arr[@]}"` for iteration, and `set -u` at the top of
-  every script so unset arrays fail loud.
-- **Reference:** PR #15827.
+- **Symptom:** A bash script that appears to iterate over an array
+  actually only sees the first element, or silently does nothing.
+- **Root cause:** Referencing a bash array as `$arr` yields only
+  `${arr[0]}`. Correct expansion is `"${arr[@]}"` (quoted, with `[@]`).
+- **Fix:** Always use `"${arr[@]}"` for iteration and `"${#arr[@]}"`
+  for length. Enable `set -euo pipefail` and, where practical,
+  `shellcheck` in CI to catch this class of bug automatically.
 
-### 6. Exit codes as proxy metrics vs. true resolution state
+### 6. Exit codes as proxy metrics vs. true resolution state (PR #15826)
 
-- **Symptom:** A job reports success (exit 0) even though the underlying
-  work (e.g., "issue resolved") did not actually happen — because the
-  script only checked whether the *tool* ran, not whether the *outcome*
-  was achieved.
-- **Root cause:** Conflating "command completed without error" with
-  "business outcome achieved."
-- **Fix:** After the tool runs, re-query the source of truth (issue
-  state, PR merge status, label presence) and exit non-zero if the
-  desired end state is not observed. Exit codes must reflect *true
-  resolution state*, not just tool liveness.
-- **Reference:** PR #15826.
+- **Symptom:** A workflow reports success (exit 0) even when the
+  underlying task did not actually resolve — e.g. "agent ran to
+  completion" is treated as "issue fixed".
+- **Root cause:** The script exits 0 whenever the *invocation* succeeds,
+  conflating "the process didn't crash" with "the intended outcome was
+  achieved".
+- **Fix:** Exit 0 **only** when the true resolution state is confirmed
+  (tests pass, PR merged, label applied, artifact present). Otherwise
+  exit non-zero and let the caller decide. Add an explicit
+  post-condition check before the final `exit 0`.
 
-### 7. `nosemgrep` suppression comment adjacency
+### 7. `nosemgrep` suppression comment adjacency (PR #15825)
 
-- **Symptom:** Semgrep still flags a line that has a `# nosemgrep` comment
-  "nearby."
-- **Root cause:** Semgrep requires the suppression comment to be on the
-  *same line* as the finding, or on the immediately preceding line — a
-  blank line or an intervening comment breaks the association.
-- **Fix:** Place `# nosemgrep: rule-id` directly on the offending line
-  (preferred) or on the line immediately above with no blank line between.
-  Always include the specific rule id, never a bare `# nosemgrep`.
-- **Reference:** PR #15825.
+- **Symptom:** A `# nosemgrep: <rule-id>` comment does not actually
+  suppress the finding; Semgrep still reports the rule.
+- **Root cause:** The suppression comment must be on the **same line**
+  as, or the line **immediately preceding**, the offending code — with
+  no blank line between them. A blank line or an intervening comment
+  breaks adjacency and the suppression silently no-ops.
 
-### 8. Broken third-party GitHub Action failing every PR
+  Reference: see the PR referenced above for the exact reworded
+  example.
+- **Fix:** Place `# nosemgrep: <rule-id>` on the line immediately above
+  the flagged line, with no blank line in between, and include the
+  specific rule id (never a bare `# nosemgrep`).
 
-- **Symptom:** A required check (e.g., `saml-sso-registration.yml`) fails
-  on every PR with an error originating inside a third-party Action —
-  not in our code.
-- **Root cause:** The upstream Action shipped a breaking change under a
-  floating tag (`@v2` moved), or was archived/removed. Our workflow pinned
-  by tag, not by SHA.
-- **Fix:** (a) Immediate — pin to a known-good commit SHA. (b) Follow-up —
-  either replace the Action or vendor its logic. Add the Action to the
-  Dependabot config so future upstream moves surface as PRs, not outages.
-- **Reference:** PR #15828.
+### 8. Broken third-party GitHub Action failing every PR (PR #15828)
+
+- **Symptom:** Every PR shows a red check from a workflow no one
+  recently touched (in this case `saml-sso-registration.yml`).
+- **Root cause:** A third-party Action pinned by tag was force-pushed
+  or yanked upstream, or its runtime (e.g. `node12`) was removed by
+  GitHub. The workflow file is unchanged; the dependency broke under
+  it.
+- **Fix:** Pin third-party Actions by full commit SHA, not by tag or
+  branch. When a break is detected, either bump to a known-good SHA of
+  a maintained fork, or remove the workflow if it is no longer needed.
+  Add a monthly Dependabot config for `github-actions` so upstream
+  breakage surfaces as a PR instead of as red main.
 
 ---
 
 ## Where the memory lives
 
-- **This file (`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`)** — the
-  *method* and the *fix-pattern catalog*. Update when a new recurring
-  pattern is identified (≥2 incidents).
-- **`learnings.md`** — the *incident log*. Every fix PR appends an entry;
-  entries here feed step 3 of the audit method above.
-- **`CLAUDE.md` "Recurring gotchas"** — the *hot list* for agents. Only
-  the top ~10 gotchas live there; anything longer belongs in this
-  playbook.
+- **`learnings.md`** — per-incident postmortems, chronological.
+- **`standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`** (this file) —
+  the repeatable audit method and the fix-pattern catalog.
 - **`standards/GREEN_MAIN_STANDARD.md`** — the invariant this playbook
-  ultimately protects: `main` stays green.
+  defends: main stays green.
+- **`CLAUDE.md`** — "Recurring gotchas" quick-reference, which points
+  here for the long form.
+
+When you fix a new class of bug, add a numbered entry to the catalog
+above in the same Symptom / Root Cause / Fix shape, cite the PR, and
+(if it belongs in the fast-lookup) add a one-line gotcha to `CLAUDE.md`.


### PR DESCRIPTION
Automated code changes for
issue #15976.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15955.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15933.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15905.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15886.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15832.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
## Summary

Formalizes today's (2026-07-13) audit-and-fix session into a reusable, shared
reference, per an explicit user request: "can everybody save memory and
learnings in revvel-standards — how to perform audit — how to correct for self
healing." `learnings.md` already captures individual incidents after the fact;
this PR adds the piece that was missing — a repeatable **audit methodology**
and a fast-lookup **fix-pattern catalog** — so the next agent (human or AI)
doesn't have to rediscover either from scratch.

## Changes

- Add `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md`:
  - `## How to Run an Audit` — the actual method used today: scope into
    parallel read-only research agents by category, demand file:line
    citations, cross-reference `learnings.md` for recurrence, **triage before
    fixing** (not every finding becomes an immediate PR), one fix per isolated
    worktree subagent with `npm ci && npm test` + regression tests, **watch
    live CI on your own in-flight PRs** (not just static findings — this is
    how the broken `saml-sso-registration.yml` third-party Action was actually
    caught), and targeted search (not enumeration) for stale "follow-up"/"Next
    Action" commitments in issue/PR history.
  - `## Self-Healing Correction Pattern Catalog` — 8 Symptom/Root
    Cause/Fix entries for patterns fixed today, each citing its PR:
    unguarded `removeLabel` race (#15821), missing `allowError` on internal
    API helpers (#15824), default `GITHUB_TOKEN` on agent-created PRs
    (#15823), secrets via argv vs. stdin (#15825), bash bare-array-variable
    bug (#15827), exit codes as proxy metrics vs. true resolution state
    (#15826), `nosemgrep` suppression comment adjacency (#15825), and a broken
    third-party GitHub Action failing every PR (#15828).
- Extend `CLAUDE.md`'s "Recurring gotchas" section with two new entries in the
  same style as #1-#5: gotcha #6 (exit codes must reflect true resolution
  state) and gotcha #7 (`nosemgrep` suppression comment adjacency), plus a
  pointer to the new playbook near the existing gotcha list.

Doc structure and tone mirror `standards/GREEN_MAIN_STANDARD.md` (Status/Case
evidence header, numbered rules, "Where the memory lives" closing section).

## Validation

`npm ci && npm test` — 558/558 tests pass, no code changes (docs only).
`npx markdownlint-cli2` run directly against both changed files (the new
playbook and `CLAUDE.md`) — 0 errors after fixing one MD018 false-positive
(a line starting with `#15825)` was misread as an ATX heading; reworded).

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

<!-- No source issue number for this PR — it formalizes a same-session user request rather than an existing tracked issue/WR. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR formalizes an audit methodology and fix-pattern catalog into a new playbook document (`AUDIT_AND_SELF_HEALING_PLAYBOOK.md`) that captures the repeatable process used during a 2026-07-13 audit session. The playbook documents how to run parallel read-only research agents, triage findings, and apply fixes in isolation, plus catalogs eight common bug patterns (unguarded `removeLabel` races, missing `allowError` on API helpers, default `GITHUB_TOKEN` on agent PRs, secrets via argv vs stdin, bash array bugs, exit code proxy metrics, `nosemgrep` suppression comment adjacency, and broken third-party GitHub Actions) with symptom/root-cause/fix entries citing their respective PRs. It also extends `CLAUDE.md` with two new gotcha entries (exit codes and `nosemgrep` adjacency) and adds a pointer to the new playbook for future reference.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` |
| 2 | `CLAUDE.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

Closes #15832

Closes #15886

Closes #15905

Closes #15933

Closes #15955

Closes #15976
closes #15976

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR formalizes the audit methodology and fix-pattern catalog from a 2026-07-13 audit session by creating a new `AUDIT_AND_SELF_HEALING_PLAYBOOK.md` document and extending `CLAUDE.md`. The playbook documents a repeatable process for running audits (parallel read-only research agents by category, demanding file:line citations, cross-referencing learnings, triaging before fixing, using isolated worktrees, watching live CI, and targeted searches for stale commitments) and catalogs eight recurring bug patterns with symptom/root-cause/fix entries: unguarded `removeLabel` races, missing `allowError` on API helpers, default `GITHUB_TOKEN` on agent PRs, secrets via argv, bash bare-array variables, exit codes as proxy metrics, `nosemgrep` suppression comment adjacency, and broken third-party GitHub Actions. `CLAUDE.md` is updated with two new gotchas (exit codes must reflect true resolution state and `nosemgrep` adjacency requirements) and a pointer to the new playbook, consolidating the documentation into a coherent memory system that references PRs #15821-#15828.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` |
| 2 | `CLAUDE.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared audit-and-self-healing playbook and updates `CLAUDE.md` with new recurring gotchas. This formalizes a repeatable audit method and catalogs proven fix patterns to speed self-healing.

- New Features
  - Added `standards/AUDIT_AND_SELF_HEALING_PLAYBOOK.md` with a concise “How to Run an Audit” checklist (parallel read-only agents, file:line citations, triage before fixing, isolated worktrees, monitor live CI) and a Self-Healing Correction Pattern Catalog with 8 symptom/root-cause/fix entries.
  - Expanded `CLAUDE.md` “Recurring gotchas” with exit-code correctness and `nosemgrep` adjacency, and linked to the new playbook for full details.

<sup>Written for commit 38e8d5e99c2003705285f063e0822ad450895458. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

