### PR TITLE
[openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] feat: route checked Follow-up checklist items to tracked WR issues

### DIFF
--- a/scripts/checkbox-diff.js
+++ b/scripts/checkbox-diff.js
@@ -3,131 +3,126 @@
 /**
  * checkbox-diff.js
  *
- * Diffs two markdown bodies (an issue's or PR's `body` before/after an edit)
- * to find task-list ("- [ ]" / "- [x]") lines that were newly checked in
- * this edit AND match the `Follow-up:` convention documented in
- * `.github/workflows/followup-checkbox-router.yml`:
+ * Pure utility for detecting newly-checked "Follow-up:" checklist items
+ * between two markdown bodies (e.g. an issue/PR body before and after an edit).
  *
- *   - [ ] Follow-up: <free text description of what needs tracking later>
- *
- * When a maintainer/agent edits the body and flips that box from unchecked
- * to checked, it is the trigger signal to spin the follow-up out into a
- * tracked WR issue. This module is the pure-logic half of that feature — it
- * has no GitHub API / network dependency so it can be unit tested directly.
+ * No network / GitHub dependency, so it is fully unit-testable.
  */
-
-// Matches a markdown task-list line, e.g.:
-//   - [ ] Follow-up: do the thing
-//   * [x] some other item
-//   +   [X]   spaced out item
-const TASK_LINE_RE = /^[ \t]*[-*+][ \t]+\[([ xX])\][ \t]+(.+?)[ \t]*$/;
-
-// Matches the "Follow-up:" prefix (case-insensitive, optional hyphen,
-// optional colon, tolerant of trailing whitespace) that marks a checklist
-// item as a trackable follow-up commitment. Covers "Follow-up:", "Followup:",
-// "FOLLOWUP". (Does not match "Follow up:" with a bare space — the
-// convention documented in followup-checkbox-router.yml is "Follow-up:".)
-const FOLLOWUP_PREFIX_RE = /^follow-?up:?\s*/i;
 
 /**
- * Parse every markdown task-list line out of a body.
- * @param {string|null|undefined} body
- * @returns {Array<{ text: string, checked: boolean }>}
+ * Matches a markdown task-list line, capturing:
+ *   1: the checkbox state character (space, x, or X)
+ *   2: the remaining text after the checkbox
+ *
+ * Tolerates leading whitespace and optional list-marker variants.
  */
-function parseTaskItems(body) {
-  if (!body) return [];
-  const items = [];
+const TASK_LINE_RE = /^\s*[-*+]\s+\[([ xX])\]\s?(.*)$/;
+
+/**
+ * Matches a "Follow-up:" prefix, case-insensitive, tolerating:
+ *   - Follow-up:
+ *   - Follow up:
+ *   - Followup:
+ *   - Extra whitespace around the hyphen/space
+ */
+const FOLLOW_UP_PREFIX_RE = /^\s*follow[\s-]?up\s*:\s*(.*)$/i;
+
+/**
+ * Normalize a follow-up description for matching between old and new bodies.
+ * We match by content so reordering / unrelated edits don't break detection.
+ */
+function normalizeText(text) {
+  if (text == null) return '';
+  return String(text)
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Parse a body into an array of follow-up task-list entries.
+ *
+ * Returns entries of the form:
+ *   { checked: boolean, description: string, normalized: string, raw: string }
+ *
+ * Only lines whose task-text starts with a "Follow-up:" prefix are returned.
+ */
+function parseFollowUpTasks(body) {
+  if (body == null) return [];
   const lines = String(body).split(/\r?\n/);
+  const out = [];
   for (const line of lines) {
-    const match = TASK_LINE_RE.exec(line);
-    if (!match) continue;
-    items.push({
-      checked: match[1].toLowerCase() === 'x',
-      text: match[2].trim(),
+    const m = TASK_LINE_RE.exec(line);
+    if (!m) continue;
+    const state = m[1];
+    const rest = m[2] || '';
+    const fu = FOLLOW_UP_PREFIX_RE.exec(rest);
+    if (!fu) continue;
+    const description = (fu[1] || '').trim();
+    out.push({
+      checked: state === 'x' || state === 'X',
+      description,
+      normalized: normalizeText(description),
+      raw: line,
     });
   }
-  return items;
+  return out;
 }
 
 /**
- * Normalize task-item text into a matching key. Minor whitespace variation
- * (extra spaces, tabs) should not prevent a line from being matched between
- * the old and new body; case is folded too since "Follow-up" items are
- * matched case-insensitively everywhere else in this module.
- * @param {string} text
- * @returns {string}
- */
-function normalizeKey(text) {
-  return text.trim().toLowerCase().replace(/\s+/g, ' ');
-}
-
-/**
- * Find follow-up checklist items that transitioned from unchecked to
- * checked between `oldBody` and `newBody`.
+ * Find follow-up items that transitioned from unchecked (in oldBody) to
+ * checked (in newBody).
  *
- * Matching strategy: items are matched by normalized text content (not by
- * line position), so a line can be correctly identified as "the same item"
- * even if unrelated lines above/below it were added, removed, or reordered
- * in the same edit. Only an item that (a) existed in `oldBody` as unchecked
- * and (b) exists in `newBody` as checked counts as "newly checked" — an
- * item that is brand new in `newBody` (no matching text in `oldBody` at
- * all) is not reported, since there is no unchecked->checked transition to
- * observe for it.
+ * Rules:
+ *   - If oldBody is null/undefined, nothing is "newly checked" — we have no
+ *     prior state to compare against, so we avoid over-firing.
+ *   - If newBody is null/undefined, returns [].
+ *   - Matching is by normalized description text, not line position.
+ *   - An item checked in newBody but NOT present at all in oldBody is NOT
+ *     considered newly checked (added-and-checked in the same edit is a no-op).
+ *   - An item that was already checked in oldBody is NOT re-reported.
  *
- * @param {string|null|undefined} oldBody - body before the edit
- *   (`github.event.changes.body.from`). May be null/undefined, e.g. when
- *   the issue/PR was just created and there is no prior body to diff
- *   against, or when the edit didn't touch the body field at all.
- * @param {string|null|undefined} newBody - body after the edit (current
- *   `issue.body` / `pull_request.body`).
- * @returns {string[]} the free-text description of each newly-checked
- *   follow-up item, with the `Follow-up:` prefix stripped and trimmed. If
- *   multiple follow-up items were checked in the same edit, all of them are
- *   returned, in the order they appear in `newBody`.
+ * @param {string|null|undefined} oldBody
+ * @param {string|null|undefined} newBody
+ * @returns {Array<{description: string, normalized: string}>}
  */
 function findNewlyCheckedFollowUps(oldBody, newBody) {
-  if (!oldBody || !newBody) return [];
+  if (oldBody == null || newBody == null) return [];
 
-  const oldItems = parseTaskItems(oldBody);
-  const newItems = parseTaskItems(newBody);
-  if (oldItems.length === 0 || newItems.length === 0) return [];
+  const oldTasks = parseFollowUpTasks(oldBody);
+  const newTasks = parseFollowUpTasks(newBody);
 
-  // Bucket old items by normalized text into per-key queues so duplicate
-  // line text (rare, but possible) is matched one-to-one in document order
-  // rather than every duplicate matching the first old entry.
-  const oldByKey = new Map();
-  for (const item of oldItems) {
-    const key = normalizeKey(item.text);
-    if (!oldByKey.has(key)) oldByKey.set(key, []);
-    oldByKey.get(key).push(item);
+  // Index old tasks by normalized text. If duplicates exist, prefer the
+  // "unchecked" state so a subsequent check on any duplicate is detectable.
+  const oldByText = new Map();
+  for (const t of oldTasks) {
+    if (!t.normalized) continue;
+    const existing = oldByText.get(t.normalized);
+    if (!existing || (existing.checked && !t.checked)) {
+      oldByText.set(t.normalized, t);
+    }
   }
 
   const results = [];
-  for (const newItem of newItems) {
-    if (!newItem.checked) continue;
-
-    const key = normalizeKey(newItem.text);
-    const queue = oldByKey.get(key);
-    if (!queue || queue.length === 0) continue; // no matching prior line found
-    const oldItem = queue.shift();
-    if (oldItem.checked) continue; // already checked before this edit
-
-    const followUpMatch = FOLLOWUP_PREFIX_RE.exec(newItem.text);
-    if (!followUpMatch) continue; // checked, but not a "Follow-up:" item
-
-    const description = newItem.text.slice(followUpMatch[0].length).trim();
-    if (!description) continue; // "Follow-up:" with no description — nothing to track
-
-    results.push(description);
+  const seen = new Set();
+  for (const t of newTasks) {
+    if (!t.checked) continue;
+    if (!t.normalized) continue;
+    if (seen.has(t.normalized)) continue;
+    const prior = oldByText.get(t.normalized);
+    if (!prior) continue; // added-and-checked in same edit — skip
+    if (prior.checked) continue; // already checked before
+    seen.add(t.normalized);
+    results.push({
+      description: t.description,
+      normalized: t.normalized,
+    });
   }
-
   return results;
 }
 
 module.exports = {
   findNewlyCheckedFollowUps,
-  parseTaskItems,
-  normalizeKey,
-  TASK_LINE_RE,
-  FOLLOWUP_PREFIX_RE,
+  parseFollowUpTasks,
+  normalizeText,
 };

--- a/tests/checkbox-diff.test.js
+++ b/tests/checkbox-diff.test.js
@@ -1,185 +1,170 @@
 'use strict';
 
 const test = require('node:test');
-const assert = require('node:assert');
+const assert = require('node:assert/strict');
 
 const {
   findNewlyCheckedFollowUps,
-  parseTaskItems,
-  normalizeKey,
+  parseFollowUpTasks,
+  normalizeText,
 } = require('../scripts/checkbox-diff');
 
-// ── findNewlyCheckedFollowUps ───────────────────────────────────────────────
-
-test('reports a single follow-up item checked in this edit', () => {
-  const oldBody = [
-    '## Summary',
-    '',
-    '- [ ] Follow-up: circle back on the flaky retry logic',
-  ].join('\n');
-  const newBody = [
-    '## Summary',
-    '',
-    '- [x] Follow-up: circle back on the flaky retry logic',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['circle back on the flaky retry logic']);
+test('single follow-up item checked', () => {
+  const oldBody = '- [ ] Follow-up: refactor the router';
+  const newBody = '- [x] Follow-up: refactor the router';
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.equal(res.length, 1);
+  assert.equal(res[0].description, 'refactor the router');
 });
 
-test('reports multiple follow-up items checked in the same edit', () => {
+test('multiple items checked in one edit', () => {
   const oldBody = [
     '- [ ] Follow-up: item one',
     '- [ ] Follow-up: item two',
-    '- [ ] some unrelated task',
+    '- [ ] Follow-up: item three',
   ].join('\n');
   const newBody = [
     '- [x] Follow-up: item one',
-    '- [x] Follow-up: item two',
-    '- [x] some unrelated task',
+    '- [ ] Follow-up: item two',
+    '- [X] Follow-up: item three',
   ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['item one', 'item two']);
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.equal(res.length, 2);
+  const descs = res.map((r) => r.description).sort();
+  assert.deepEqual(descs, ['item one', 'item three']);
 });
 
-test('does not match a checked box whose text is not a follow-up item', () => {
-  const oldBody = '- [ ] Deploy to staging';
-  const newBody = '- [x] Deploy to staging';
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, []);
-});
-
-test('does not re-report a follow-up that was already checked before this edit', () => {
+test('unrelated (non-follow-up) checkbox checked is ignored', () => {
   const oldBody = [
-    '- [x] Follow-up: already tracked, do not refire',
-    '- [ ] Follow-up: newly checked this time',
+    '- [ ] Some random task',
+    '- [ ] Follow-up: not touched',
   ].join('\n');
   const newBody = [
-    '- [x] Follow-up: already tracked, do not refire',
-    '- [x] Follow-up: newly checked this time',
+    '- [x] Some random task',
+    '- [ ] Follow-up: not touched',
   ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['newly checked this time']);
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepEqual(res, []);
 });
 
-test('returns an empty array when oldBody is missing/null (e.g. issue just created)', () => {
-  const newBody = '- [x] Follow-up: brand new item checked on creation';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(null, newBody), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(undefined, newBody), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps('', newBody), []);
+test('already-checked item is not re-reported', () => {
+  const oldBody = '- [x] Follow-up: already done';
+  const newBody = '- [x] Follow-up: already done';
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepEqual(res, []);
 });
 
-test('returns an empty array when newBody is missing/null', () => {
-  const oldBody = '- [ ] Follow-up: something';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, null), []);
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, undefined), []);
+test('null oldBody returns empty (no prior state to compare)', () => {
+  const res = findNewlyCheckedFollowUps(null, '- [x] Follow-up: whatever');
+  assert.deepEqual(res, []);
 });
 
-test('returns an empty array when there are no task-list lines at all', () => {
-  const oldBody = 'Just a plain description with no checkboxes.';
-  const newBody = 'Just a plain description with no checkboxes, edited.';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
+test('undefined oldBody returns empty', () => {
+  const res = findNewlyCheckedFollowUps(undefined, '- [x] Follow-up: whatever');
+  assert.deepEqual(res, []);
 });
 
-test('ignores an item newly added and checked in the same edit (no prior unchecked state to transition from)', () => {
+test('null newBody returns empty', () => {
+  const res = findNewlyCheckedFollowUps('- [ ] Follow-up: whatever', null);
+  assert.deepEqual(res, []);
+});
+
+test('undefined newBody returns empty', () => {
+  const res = findNewlyCheckedFollowUps('- [ ] Follow-up: whatever', undefined);
+  assert.deepEqual(res, []);
+});
+
+test('reordered lines still match by content', () => {
+  const oldBody = [
+    '- [ ] Follow-up: alpha',
+    '- [ ] Follow-up: beta',
+  ].join('\n');
+  const newBody = [
+    '- [ ] Follow-up: beta',
+    '- [x] Follow-up: alpha',
+  ].join('\n');
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.equal(res.length, 1);
+  assert.equal(res[0].description, 'alpha');
+});
+
+test('prefix case variants: Follow-up / follow-up / FOLLOW-UP', () => {
+  const oldBody = [
+    '- [ ] follow-up: lower case',
+    '- [ ] FOLLOW-UP: upper case',
+    '- [ ] Follow-Up: mixed case',
+  ].join('\n');
+  const newBody = [
+    '- [x] follow-up: lower case',
+    '- [x] FOLLOW-UP: upper case',
+    '- [x] Follow-Up: mixed case',
+  ].join('\n');
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.equal(res.length, 3);
+});
+
+test('prefix whitespace/hyphen tolerance: "Follow up:" and "Followup:"', () => {
+  const oldBody = [
+    '- [ ] Follow up: with space',
+    '- [ ] Followup: no separator',
+  ].join('\n');
+  const newBody = [
+    '- [x] Follow up: with space',
+    '- [x] Followup: no separator',
+  ].join('\n');
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.equal(res.length, 2);
+});
+
+test('item added-and-checked in same edit is not fired', () => {
   const oldBody = '- [ ] Follow-up: existing item';
   const newBody = [
     '- [ ] Follow-up: existing item',
-    '- [x] Follow-up: item that appeared already checked',
+    '- [x] Follow-up: brand new item',
   ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, []);
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepEqual(res, []);
 });
 
-test('matches follow-up items by text even when unrelated lines are reordered', () => {
-  const oldBody = [
-    '- [ ] alpha task',
-    '- [ ] Follow-up: track the migration cleanup',
-    '- [ ] beta task',
-  ].join('\n');
-  const newBody = [
-    '- [x] beta task',
-    '- [x] Follow-up: track the migration cleanup',
-    '- [ ] alpha task',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['track the migration cleanup']);
-});
-
-test('handles case-insensitive and hyphen/colon variations of the Follow-up prefix', () => {
-  const oldBody = [
-    '- [ ] FOLLOWUP no colon or hyphen',
-    '- [ ] followup: no hyphen, with colon',
-    '- [ ] Follow-Up:  extra   spacing',
-  ].join('\n');
-  const newBody = [
-    '- [x] FOLLOWUP no colon or hyphen',
-    '- [x] followup: no hyphen, with colon',
-    '- [x] Follow-Up:  extra   spacing',
-  ].join('\n');
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, [
-    'no colon or hyphen',
-    'no hyphen, with colon',
-    'extra   spacing',
-  ]);
-});
-
-test('does not match "Follow up:" with a bare space (convention requires the hyphenated form)', () => {
-  const oldBody = '- [ ] Follow up: with a bare space';
-  const newBody = '- [x] Follow up: with a bare space';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
-});
-
-test('tolerates minor whitespace differences between old and new line text when matching', () => {
-  const oldBody = '- [ ]   Follow-up:   trim me   ';
-  const newBody = '- [x] Follow-up:   trim me';
-
-  const result = findNewlyCheckedFollowUps(oldBody, newBody);
-  assert.deepStrictEqual(result, ['trim me']);
-});
-
-test('drops a Follow-up item with no description text', () => {
+test('empty description follow-up is skipped', () => {
   const oldBody = '- [ ] Follow-up:';
   const newBody = '- [x] Follow-up:';
-  assert.deepStrictEqual(findNewlyCheckedFollowUps(oldBody, newBody), []);
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.deepEqual(res, []);
 });
 
-// ── parseTaskItems ───────────────────────────────────────────────────────
-
-test('parseTaskItems parses checked/unchecked markers and strips marker syntax', () => {
+test('parseFollowUpTasks extracts checked state and description', () => {
   const body = [
-    '- [ ] unchecked item',
-    '- [x] checked lowercase',
-    '- [X] checked uppercase',
-    '* [x] asterisk bullet',
-    '+ [x] plus bullet',
-    'not a task line',
+    '- [ ] Follow-up: one',
+    '- [x] Follow-up: two',
+    '- [X] Follow-up: three',
+    '- [ ] not a follow-up',
+    'random text',
   ].join('\n');
-
-  assert.deepStrictEqual(parseTaskItems(body), [
-    { checked: false, text: 'unchecked item' },
-    { checked: true, text: 'checked lowercase' },
-    { checked: true, text: 'checked uppercase' },
-    { checked: true, text: 'asterisk bullet' },
-    { checked: true, text: 'plus bullet' },
-  ]);
+  const tasks = parseFollowUpTasks(body);
+  assert.equal(tasks.length, 3);
+  assert.equal(tasks[0].checked, false);
+  assert.equal(tasks[1].checked, true);
+  assert.equal(tasks[2].checked, true);
+  assert.equal(tasks[0].description, 'one');
 });
 
-test('parseTaskItems returns an empty array for null/undefined/empty input', () => {
-  assert.deepStrictEqual(parseTaskItems(null), []);
-  assert.deepStrictEqual(parseTaskItems(undefined), []);
-  assert.deepStrictEqual(parseTaskItems(''), []);
+test('normalizeText collapses whitespace and lowercases', () => {
+  assert.equal(normalizeText('  Hello   World  '), 'hello world');
+  assert.equal(normalizeText(null), '');
+  assert.equal(normalizeText(undefined), '');
 });
 
-// ── normalizeKey ─────────────────────────────────────────────────────────
-
-test('normalizeKey folds case and collapses whitespace', () => {
-  assert.strictEqual(normalizeKey('  Follow-Up:   Do The Thing  '), 'follow-up: do the thing');
+test('duplicate follow-up text: only reported once when checked', () => {
+  const oldBody = [
+    '- [ ] Follow-up: same thing',
+    '- [ ] Follow-up: same thing',
+  ].join('\n');
+  const newBody = [
+    '- [x] Follow-up: same thing',
+    '- [x] Follow-up: same thing',
+  ].join('\n');
+  const res = findNewlyCheckedFollowUps(oldBody, newBody);
+  assert.equal(res.length, 1);
+  assert.equal(res[0].description, 'same thing');
 });


### PR DESCRIPTION
Automated code changes for
issue #15984.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15967.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15946.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15924.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15898.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15879.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #15834.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
## Summary

Adds a checkbox convention that turns follow-up commitments left in PR/issue bodies into tracked work automatically, closing the gap where those commitments get silently dropped. Motivating case: a recon on #13978 (an 8-item follow-up tracking WR) found several items were never actually followed up on — there was no mechanism to notice when someone checked a "we'll come back to this" box.

**The convention:** anywhere in a PR or issue body (including WR issues themselves), a checklist line of the form

```
- [ ] Follow-up: 
```

can be added. When a maintainer or agent **edits the body and checks that box** (`- [ ]` → `- [x]`/`- [X]`, matched case-insensitively with minor whitespace/hyphen tolerance on the `Follow-up:` prefix), that transition is the trigger signal: "yes, spin this out into a tracked WR." A new `[WR]` issue is filed automatically, linked back to the source, and the source gets a comment linking to the new WR — a two-way link so neither side goes stale.

Nothing happens if the box is added and checked in the *same* edit (no prior unchecked state to transition from — avoids over-firing), if a different box is checked, or if the box was already checked before.

## Changes

- `scripts/checkbox-diff.js` — new pure utility, `findNewlyCheckedFollowUps(oldBody, newBody)`. Parses markdown task-list lines from both bodies and matches them **by normalized text content** (not line position), so reordering or unrelated edits in the same diff don't break detection. No network/GitHub dependency, so it's fully unit-testable.
- `tests/checkbox-diff.test.js` — 16 cases: single item checked, multiple items checked in one edit, unrelated (non-follow-up) checkbox checked, already-checked item not re-reported, missing/null `oldBody`/`newBody`, reordered lines, prefix-casing/whitespace variants, no-description edge case.
- `.github/workflows/followup-checkbox-router.yml` — new workflow, triggers on `pull_request: [edited]` and `issues: [edited]`. Diffs `github.event.changes.body?.from` against the current body via `checkbox-diff.js` (guards for `changes.body` being absent, e.g. a title-only edit). For each newly-checked follow-up: classifies BASIC vs FULL using the same spirit as `wr-pr-creation.yml`'s title-regex heuristic (short one-liner → BASIC by default; long/multi-clause → FULL), renders the chosen WR template with the follow-up's link + description in `## Issue Context` and `## Learnings — What & Why`, creates the WR issue (`work-request`, `auto-generated-followup` labels; assignee `oaudrey`), and comments back on the source PR/issue with the new WR link.
- `wr/WR_TEMPLATE_FULL.md`, `wr/WR_TEMPLATE_BASIC.md` — new `## Learnings — What & Why` section. Ships as a generic guidance placeholder for normal WRs ("agents completing other WR types should fill this in themselves once done..."); for follow-up-generated WRs the router populates it with the concrete follow-up text, a link to the source PR/issue, and — if the source itself carries a `sourced from #N` marker — a note that this is a chained follow-up (kept simple for v1, no full chain-walking).
- `.github/labels.yml` — registers `auto-generated-followup` so it syncs via `sync-labels.yml`.
- `docs/SECRETS_MAP.md` — regenerated (`npm run secrets:map`) to include the new workflow's `ADMIN_GITHUB_TOKEN`/`GITHUB_TOKEN` references; this is what made `tests/secrets-map.test.js` go red until regenerated.

Permissions on the new workflow are `contents: read` (checkout only — no commits), `issues: write`, `pull-requests: write` — narrowest set the job needs, using the repo-standard `ADMIN_GITHUB_TOKEN`-with-fallback token pattern so the new WR issue can trigger downstream WR-processing workflows (CLAUDE.md gotchas #2/#3).

## Design decisions / judgment calls

- **BASIC vs FULL classification**: mirrors `wr-pr-creation.yml`'s spirit rather than reusing its exact regex, since follow-up descriptions are free text, not titles with `fix`/`bug`/`chore` keywords. Heuristic: length > 180 chars or multi-clause phrasing (`;`/`:` mid-sentence, "then"/"also") → FULL; otherwise BASIC.
- **Chained follow-ups**: kept intentionally simple per the task brief — if the source body contains `sourced from #N`, the new WR's Learnings section just notes that ancestry once. No recursive chain-walking.
- **Known nesting limitation (flagged, not fixed here)**: the router builds a *fully rendered* WR-shaped issue body (its own populated `Issue Context` + `Learnings` sections) rather than a bare description, per the "mirror wr-pr-creation.yml's inline template-selection + token-substitution approach" instruction. Because the new issue also carries the `work-request` label, it will *also* flow through the existing `wr-pr-creation.yml` pipeline (triggered on `opened`), which independently classifies the title and generates its own WR file, nesting this pre-rendered body inside a fresh template's `Issue Context` — so the final committed `wr/issues/*.md` may show the populated `Learnings` content nested one level down rather than promoted to the file's own top-level section. I deliberately did **not** patch `wr-pr-creation.yml` to special-case the `auto-generated-followup` label and lift that content, per CLAUDE.md's explicit warning that this file is fragile and has broken before from stacked edits (2026-07-08 incident). Tracking this as a follow-up itself:
  - [ ] Follow-up: consider having `wr-pr-creation.yml` special-case the `auto-generated-followup` label to promote the router's pre-rendered `Learnings — What & Why` content to the top level instead of leaving it nested under `Issue Context`.

## Validation

- `npm ci && npm test` — 574/574 passing, including the new `tests/checkbox-diff.test.js` (16 cases).
- `python3 -c "import yaml; yaml.safe_load(open(F))"` on both changed YAML files (`followup-checkbox-router.yml`, `labels.yml`) — clean.
- Changed-Markdown gate (`npx markdownlint-cli2` scoped to files changed vs. `origin/main`) — 0 errors.
- Manually simulated the workflow's template-rendering logic against the real `wr/WR_TEMPLATE_BASIC.md`/`FULL.md` files with sample short and long/chained follow-up descriptions — confirmed no leftover `{TOKEN}` placeholders and no strings that would trip `wr-lint`'s deferral-placeholder rule (no `TBD`/`TODO`/`N/A — pending ...`).

**Limitation:** this workflow's live trigger path (`issues: edited` / `pull_request: edited` with a real checkbox transition) **cannot be exercised end-to-end from this sandboxed session** — there's no way to fire a real GitHub webhook event here. The pure-logic half (`checkbox-diff.js`, the part that's actually verifiable without live GitHub state) has thorough unit coverage; the workflow YAML and its GitHub-API calls are unverified beyond YAML validity, the manual template-render simulation above, and careful reading against this repo's established patterns (`pdf-work-request-router.yml`'s `require(process.env.GITHUB_WORKSPACE + ...)` + token-fallback pattern, `wr-pr-creation.yml`'s classification/substitution approach). Recommend a maintainer exercises it live on a throwaway issue before relying on it.

`docs-freshness: checked both paired-doc targets -- docs/SYSTEM_MAP.md does not exist in this repo, and docs/AUTOMATION_AUDIT.md is a stale point-in-time audit snapshot (already lists "58 total" workflows against an actual count of 166+, and names workflows like openrouter-triage.yml that don't match the current tree). Adding one entry to an already-drifted historical doc wouldn't restore freshness, just add false confidence to it -- refreshing that doc is a separate, larger effort outside this PR's scope.`

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above




---
_Generated by [Claude Code](https://claude.ai/code/session_012jSpwZEwtZ3zw39wnujTcK)_


## High-level PR Summary
This PR introduces an automated mechanism to convert checked follow-up checklist items in PR/issue bodies into tracked Work Request (WR) issues. When a maintainer checks a box with the format `- [ ] Follow-up: `, a new workflow automatically creates a corresponding WR issue with appropriate templates, labels, and links back to the source. The implementation includes a pure-logic checkbox diff utility (`checkbox-diff.js`) with comprehensive unit tests, a new GitHub Actions workflow (`followup-checkbox-router.yml`) that triggers on issue/PR edits, and updates to WR templates to include a **Learnings — What & Why** section that gets populated automatically for follow-up-generated WRs.

⏱️ Estimated Review Time: 30-90 minutes


💡 Review Order Suggestion

| Order | File Path |
|-------|-----------|
| 1 | `scripts/checkbox-diff.js` |
| 2 | `tests/checkbox-diff.test.js` |
| 3 | `.github/workflows/followup-checkbox-router.yml` |
| 4 | `wr/WR_TEMPLATE_BASIC.md` |
| 5 | `wr/WR_TEMPLATE_FULL.md` |
| 6 | `.github/labels.yml` |
| 7 | `docs/SECRETS_MAP.md` |




[[Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)




---
## Summary by cubic
Automatically turns checked "Follow-up:" checklist items in PR/issue bodies into tracked WR issues to prevent dropped commitments. Detects unchecked→checked transitions and creates a new `[WR]` with two‑way links.

- **New Features**
  - Added `followup-checkbox-router.yml` to handle `pull_request.edited` / `issues.edited`: diffs `body`, creates a `[WR]` per newly checked `Follow-up:` item, labels `work-request` + `auto-generated-followup`, assigns `oaudrey`, and comments back with the link.
  - Introduced `scripts/checkbox-diff.js` with `tests/checkbox-diff.test.js` to find newly checked follow-ups by normalized text; ignores brand‑new or already‑checked boxes and handles reordering/casing/whitespace.
  - Added "Learnings — What & Why" to `wr/WR_TEMPLATE_BASIC.md` and `wr/WR_TEMPLATE_FULL.md`; router fills it with the follow-up text and source link; BASIC vs FULL chosen by a simple length/multi‑clause heuristic.
  - Registered the `auto-generated-followup` label and updated `docs/SECRETS_MAP.md` to include `followup-checkbox-router.yml` token references.

<sup>Written for commit f11a051100687f3ac45e6e5c4d1de679ba58421d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/15834?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>

Closes #15834

Closes #15879

Closes #15898

Closes #15924

Closes #15946

Closes #15967

Closes #15984
closes #15984