### PR TITLE
Chore/fix credential refs

### DIFF
--- a/.github/workflows/auto-bootstrap.yml
+++ b/.github/workflows/auto-bootstrap.yml
@@ -24,7 +24,6 @@ jobs:
           repository: midnghtsapphire/revvel-standards
           path: standards
           sparse-checkout: |
-            scripts/sync-secrets.js
             docs/SECRETS_MANAGEMENT.md
             .env.example
 
@@ -33,33 +32,6 @@ jobs:
         run: |
           REPO="${{ github.event.inputs.repo || github.event.repository.full_name }}"
           echo "target_repo=$REPO" >> $GITHUB_OUTPUT
-
-      - name: Sync secrets template
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          cd standards
-          TARGET_REPO="${{ steps.target.outputs.target_repo }}"
-          TMP_ENV_FILE="/tmp/${TARGET_REPO//\//-}.env.example"
-
-          node scripts/sync-secrets.js --repo="$TARGET_REPO" || {
-            echo "::warning::Secrets sync failed - this is OK if no .env file"
-          }
-          
-          # Copy to target repo if file exists
-          if [ -f "$TMP_ENV_FILE" ]; then
-            echo "Would copy secrets template to ${{ steps.target.outputs.target_repo }}"
-          fi
-
-      - name: Run secrets health check
-        env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
-        run: |
-          gh workflow run secrets-health-check.yml \
-            --repo "${{ steps.target.outputs.target_repo }}" \
-            --ref main || {
-            echo "::warning::Health check workflow not found in target"
-          }
 
       - name: Enable error handling standard
         run: |

--- a/.github/workflows/stuck-label-automation.yml
+++ b/.github/workflows/stuck-label-automation.yml
@@ -245,24 +245,6 @@ jobs:
                   }
                   break;
 
-                case 'recheck-credentials':
-                  comment_body += `Credentials have been marked missing for over 48 hours.\n\n`;
-                  comment_body += `**Auto-action:** Re-triggering credential gatekeeper to check current state.\n`;
-
-                  if (!dry_run) {
-                    // Trigger credential-gatekeeper workflow
-                    await github.rest.actions.createWorkflowDispatch({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      workflow_id: 'credential-gatekeeper.yml',
-                      ref: 'main',
-                      inputs: {
-                        issue_number: String(item.number),
-                      },
-                    }).catch(e => core.warning(`Could not trigger credential-gatekeeper: ${e.message}`));
-                  }
-                  break;
-
                 case 'retry-instantiation':
                   comment_body += `OpenRouter instantiation has been stuck for over 2 hours.\n\n`;
                   comment_body += `**Auto-action:** Marking as failed. Ralph Loop will retry.\n`;

--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "connections": "node scripts/connections-registry.js --markdown",
     "connections:html": "node scripts/connections-registry.js --html",
     "connections:drift": "node scripts/connections-registry.js --drift",
-    "secrets:map": "node scripts/secrets-map.js",
-    "secrets:map:check": "node scripts/secrets-map.js --check",
     "dashboard": "node scripts/dashboard-cli.js",
     "dashboard:generate": "node scripts/aggregate-project-dashboard.js",
     "agent-creator:data": "node scripts/build-agent-creator-data.js",

--- a/scripts/biome/homeostat.js
+++ b/scripts/biome/homeostat.js
@@ -142,7 +142,7 @@ if (require.main === module) {
     // Promptly rehydrate the wiped key(s) by dispatching the existing reviewed
     // Doppler->Actions recovery workflow (no-ops if Doppler has no value).
     if (shouldTriggerRecovery(assessment, process.env)) {
-      const recoveryWorkflow = process.env.BIOME_RECOVERY_WORKFLOW || 'secret-persistence-guard.yml';
+      const recoveryWorkflow = process.env.BIOME_RECOVERY_WORKFLOW || '';
       await repoApi(`/actions/workflows/${recoveryWorkflow}/dispatches`, {
         method: 'POST',
         body: { ref: 'main', inputs: { force_recovery: 'true' } },


### PR DESCRIPTION
## Summary

<!-- One paragraph: what does this do? -->
Closes #<!-- issue number -->

## Changes

<!-- Bullet list of key changes -->
-

## Validation

<!-- One paragraph: how do you know this works? Link runs/screenshots/preview URLs. -->


## Checklist

<!-- These four are pre-checked because they apply to almost every PR. Uncheck any that this PR genuinely violates and explain in the Summary or Validation section above. -->
- [x] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

<!--
For reference (not user-facing — kept here for the PR-template-autocomplete workflow to inspect):
- Discoverability/docs: README, knowledge note, reference table, doc cross-links
- Ops/runbooks: REMINDERS.md, follow-up notes
- Testing: manual verification, CI passing, new tests
- Deferred items: list explicitly in Validation section above
-->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes deprecated credential and secrets management functionality across the codebase. It eliminates the secrets sync logic from the auto-bootstrap workflow, removes the credentials recheck automation from the stuck-label workflow, deletes the `secrets:map` npm scripts, and updates the biome homeostat to default to an empty recovery workflow instead of `secret-persistence-guard.yml`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `package.json` |
| 2 | `scripts/biome/homeostat.js` |
| 3 | `.github/workflows/stuck-label-automation.yml` |
| 4 | `.github/workflows/auto-bootstrap.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove deprecated secrets/credential automation and clean up dangling references across workflows and scripts. This simplifies bootstrapping and stops legacy credential-gatekeeper runs.

- **Refactors**
  - Auto-bootstrap: removed secrets sync and secrets health check steps.
  - Stuck-label automation: removed the “recheck-credentials” auto-action and workflow dispatch.
  - package.json: removed `secrets:map` and `secrets:map:check` scripts.
  - Biome homeostat: default `BIOME_RECOVERY_WORKFLOW` to none (empty string) instead of `secret-persistence-guard.yml`.

- **Migration**
  - If you still use a recovery workflow, set `BIOME_RECOVERY_WORKFLOW` to your workflow filename.

<sup>Written for commit c90260b423518c1c52bead18f4d87196a068bb0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

