### PR TITLE
Add WR-4471 — Lint Auto-Fix Loop

### DIFF
--- a/standards/WR-4471-lint-autofix-loop.md
+++ b/standards/WR-4471-lint-autofix-loop.md
@@ -1,0 +1,26 @@
+# WR-4471 — Lint Auto-Fix Loop
+
+**Band:** 4470 (Validation Gate)
+**Status:** DRAFT — rev 0
+**Depends:** WR-4470 (Validation Gate), WR-4480 (Multi-Model Routing)
+
+## Directive
+Any agent producing code MUST run the repo lint command and enter the fix loop on non-zero exit. No PR opens with lint failures.
+
+## Loop
+1. Run `LINT_CMD` (repo-defined; e.g. `ruff check .`, `eslint . --max-warnings 0`, `dotnet format --verify-no-changes`).
+2. Non-zero exit → capture stdout/stderr as fix context.
+3. Agent applies fix (act-not-announce per WR-4380). No suppression comments (`# noqa`, `// eslint-disable`) without a FAILURE-LEDGER entry.
+4. Re-run lint. Repeat.
+5. **Max cycles: 3.** On third failure → halt, open issue tagged `lint-loop-exhausted`, log to FAILURE-LEDGER.
+
+## Rules
+- Lint scope = whole project, not staged files only.
+- Fix commits use `chore(lint):` prefix, one commit per cycle (one upward rev per change).
+- Model lane: route lint fixes to the cheap/fast lane per WR-4480; escalate lane on cycle 2+.
+- Rule-config changes (editing lint config to silence an error) are PROHIBITED inside the loop — config changes require their own PR.
+
+## Acceptance
+- [ ] LINT_CMD defined per repo in CI config
+- [ ] Loop exhaustion path tested (deliberately unfixable error)
+- [ ] FAILURE-LEDGER entries written on suppression or exhaustion


### PR DESCRIPTION
## Summary
Adds WR-4471 to the 4470 Validation Gate band. Defines the mandatory lint fix loop for all code-producing agents: lint → capture → fix → re-lint, max 3 cycles, then halt + FAILURE-LEDGER.

## Files
- `standards/WR-4471-lint-autofix-loop.md` (new)

## Follow-ups for fleet agents
- [ ] Update register index/TOC with WR-4471 entry
- [ ] Cross-link from WR-4470 and WR-4480

## Review focus
- Max-cycle count (3)
- Suppression-comment ban scope

Labels: wr-register, band-4470, rev-0
closes #4471

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces **WR-4471**, a new standard document that mandates a lint auto-fix loop for all code-producing agents. The standard requires agents to automatically run linting commands, capture errors, apply fixes, and re-lint up to 3 times before halting with a failure. It establishes rules around suppression comments, commit prefixes, model routing, and prohibition of config changes within the fix loop. The document is part of the 4470 Validation Gate band and depends on WR-4470 and WR-4480.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/WR-4471-lint-autofix-loop.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WR-4471, a standard that enforces a lint auto-fix loop for all code-producing agents: run lint, auto-fix, and re-lint up to 3 cycles; then halt with a failure ledger and open `lint-loop-exhausted` if still failing. Aligns with WR-4470 (Validation Gate) and WR-4480 (Multi-Model Routing).

- New Features
  - New document: `standards/WR-4471-lint-autofix-loop.md`.
  - Loop: run `LINT_CMD`, capture stdout/stderr, apply fixes, re-lint; max 3 cycles. On third failure, halt, open `lint-loop-exhausted`, and write to FAILURE-LEDGER.
  - Rules and routing: lint the whole repo; no suppression comments without a FAILURE-LEDGER entry; no lint-config changes inside the loop; fix commits use `chore(lint):`; use the cheap/fast model lane and escalate on cycle 2+.

<sup>Written for commit fda062ee540edacd7c0fe162e1429fea25cb5bd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

