### PR TITLE
Add WR-4472 — CI Gate Self-Heal

### DIFF
--- a/standards/WR-4472-ci-gate-self-heal.md
+++ b/standards/WR-4472-ci-gate-self-heal.md
@@ -1,0 +1,26 @@
+# WR-4472 — CI Gate Self-Heal
+
+**Band:** 4470 (Validation Gate)
+**Status:** DRAFT — rev 0
+**Depends:** WR-4470, WR-4380 (Self-Healer), WR-4471
+
+## Directive
+A failed CI check on an open PR is a work item, not a notification. The assigned agent root-causes and pushes a fix commit to the SAME PR — no new branch, no new PR.
+
+## Flow
+1. GitHub Actions check fails → webhook/poll picks up run ID.
+2. Agent pulls failing job logs (last 200 lines minimum + first error block).
+3. Classify: `lint` → defer to WR-4471 loop | `build` | `test` | `infra/flake`.
+4. `infra/flake` (network, runner, rate-limit): retry once. Second identical failure → treat as real.
+5. Real failure → fix commit `fix(ci):` to PR branch → CI re-runs automatically.
+6. **Max heal attempts per PR: 2.** Exhausted → label `needs-human`, halt, FAILURE-LEDGER entry with classification + attempted fixes.
+
+## Rules
+- Never force-push over reviewer commits.
+- Never edit the workflow file itself to make the check pass (gate-tampering = prohibited; workflow changes require standalone PR).
+- Dragnet sentinel verifies heal commits against EWMA trust score before merge eligibility.
+
+## Acceptance
+- [ ] Log-pull tooling wired (Octokit / gh CLI)
+- [ ] Flake-retry vs real-failure split tested
+- [ ] Gate-tamper rule enforced by Dragnet review persona


### PR DESCRIPTION
## Summary
Adds WR-4472: failed CI checks become work items. Agent pulls logs, classifies (lint/build/test/infra-flake), pushes `fix(ci):` commit to the same PR. Max 2 heal attempts, then `needs-human` + FAILURE-LEDGER. Gate-tampering (editing workflow to pass) prohibited.

## Files
- `standards/WR-4472-ci-gate-self-heal.md` (new)

## Follow-ups for fleet agents
- [ ] Update register index/TOC
- [ ] Cross-link WR-4380, WR-4470, WR-4471
- [ ] Wire Dragnet review persona to enforce gate-tamper rule (follow-up issue if not in this PR)

## Review focus
- Heal-attempt cap (2)
- Flake-retry policy (1 retry before treating as real)

Labels: wr-register, band-4470, rev-0
closes #4472

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a new standard (WR-4472) that defines an automated CI self-healing process. When CI checks fail on a pull request, an agent automatically analyzes the failure logs, classifies the issue (lint, build, test, or infrastructure flake), and pushes a fix commit directly to the same PR. The system supports up to 2 heal attempts per PR with a special retry policy for infrastructure flakes. It includes safeguards against workflow tampering and requires human intervention after exhausting automated attempts.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/WR-4472-ci-gate-self-heal.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WR-4472: a CI self-heal gate that auto-fixes failures on the same PR. It retries infra flakes once, caps at 2 attempts, blocks workflow tampering, logs to FAILURE-LEDGER, and requires Dragnet trust before merge.

- New Features
  - CI failure → agent pushes `fix(ci):` to the same PR (no new branch/PR).
  - Classification: lint/build/test/infra-flake; infra flakes retried once, then treated as real.
  - Safeguards/enforcement: max 2 attempts, `needs-human` label, FAILURE-LEDGER entry; no workflow edits or force-pushing over reviewer commits; Dragnet trust check gates merge.

<sup>Written for commit a0ca94582ec31ba82429a6ce0e5eee69afc9a08b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

