### PR TITLE
Add WR-4473 — Pre-Commit Enforcement

### DIFF
--- a/standards/WR-4473-precommit-enforcement.md
+++ b/standards/WR-4473-precommit-enforcement.md
@@ -1,0 +1,34 @@
+# WR-4473 — Pre-Commit Enforcement
+
+**Band:** 4470 (Validation Gate)
+**Status:** DRAFT — rev 0
+**Depends:** WR-4471
+
+## Directive
+Every fleet repo carries a Lefthook pre-commit gate. Agents cannot commit code that fails it, and cannot bypass it.
+
+## Config (skeleton)
+```yaml
+# lefthook.yml
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      run: {LINT_CMD}
+      fail_text: "Lint failed. For AI agents: enter WR-4471 fix loop. Do NOT use --no-verify."
+```
+
+## Bypass ban
+- `git commit --no-verify` / `-n` is PROHIBITED for all agents. Enforcement is two-layer because hooks alone are advisory:
+  1. WR-4200 Operating Directive amendment: bypass = directive violation.
+  2. Server-side backstop: CI re-runs the same lint (WR-4471) — a bypassed commit still fails at the gate, and Dragnet decrements EWMA trust for the committing agent.
+
+## Rules
+- Full-project lint scope (matches WR-4471), not staged-only.
+- `fail_text` is agent-directed context, kept in sync with WR-4471 wording.
+- Hook install verified in repo bootstrap (`lefthook install` in setup script).
+
+## Acceptance
+- [ ] lefthook.yml templated into repo scaffold
+- [ ] Trust-decrement on bypass wired into Dragnet
+- [ ] fail_text loop instruction verified against agent behavior


### PR DESCRIPTION
## Summary
Adds WR-4473: Lefthook pre-commit gate in every fleet repo, agent-directed fail_text, two-layer `--no-verify` ban (WR-4200 directive amendment + server-side CI backstop with Dragnet EWMA trust decrement).

## Files
- `standards/WR-4473-precommit-enforcement.md` (new)

## Follow-ups for fleet agents
- [ ] Update register index/TOC
- [ ] Add `templates/lefthook.yml` to repo scaffold
- [ ] Open follow-up PR against WR-4200 for the bypass-ban amendment
- [ ] Add `lefthook install` to repo bootstrap script(s)

## Review focus
- fail_text wording sync with WR-4471
- Trust-decrement magnitude on bypass

Labels: wr-register, band-4470, rev-0
closes #4473

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a new standard (WR-4473) that mandates Lefthook pre-commit hooks across all fleet repositories to enforce linting rules before commits. The standard prohibits agents from bypassing these checks using `--no-verify` through a two-layer enforcement mechanism: a directive amendment (WR-4200) that classifies bypasses as violations, and a server-side CI backstop that penalizes bypassing agents by decrementing their Dragnet EWMA trust scores. The `fail_text` in the hook configuration provides agent-directed instructions to enter the WR-4471 fix loop when lint failures occur.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/WR-4473-precommit-enforcement.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements WR-4473: a fleet-wide `lefthook` pre-commit gate that runs full-project lint and blocks failing commits. Bans `git commit --no-verify` with a CI backstop that re-runs lint and decrements Dragnet trust on bypass (aligns with WR-4471; amends WR-4200).

- **New Features**
  - Adds WR-4473 standard doc with skeleton `lefthook.yml` and agent-directed `fail_text` synced with WR-4471.
  - Enforces full-project lint; `--no-verify` is prohibited.
  - Two-layer enforcement: WR-4200 amendment + CI backstop.

- **Migration**
  - Template `lefthook.yml` into the repo scaffold and run `lefthook install` in bootstrap scripts.
  - Ensure CI runs WR-4471 lint and applies the trust decrement on bypass.

<sup>Written for commit e92f8c3dfb78bb5f99acceccf8da95c6fb8cd5ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

