### PR TITLE
Add WR-4474 — Runtime Gateway 5xx Triage

### DIFF
--- a/standards/WR-4474-runtime-gateway-triage.md
+++ b/standards/WR-4474-runtime-gateway-triage.md
@@ -1,0 +1,29 @@
+# WR-4474 — Runtime Gateway 5xx Triage
+
+**Band:** 4470 (Validation Gate)
+**Status:** DRAFT — rev 0
+**Depends:** WR-4380 (Self-Healer), FAILURE-LEDGER
+
+## Directive
+Production/staging gateway errors (5xx, timeouts, upstream refusals) are captured, triaged, and routed to a fix agent automatically. Alert ≠ done; a ledger entry + assigned fix is done.
+
+## Flow
+1. **Capture:** Sentry (or platform logs, e.g. DigitalOcean app logs for MindMappr-class deploys) records the error with trace.
+2. **Classify:**
+   - `502/504 upstream` — app crashed / port mismatch / health-check fail
+   - `503` — capacity / cold start / deploy in flight
+   - `429 upstream` — rate limit on external API (OpenRouter/Perplexity lanes)
+   - `500 app` — unhandled exception with stack trace
+3. **Route:** `500 app` w/ stack → Dragnet assigns fix agent, issue auto-opened with trace attached. Infra classes → runbook action first (restart, scale, backoff), issue only on recurrence within 24h.
+4. **Ledger:** every triaged event → FAILURE-LEDGER (class, service, root cause, fix ref) so sub-fleet agents learn the pattern.
+5. **Close:** fix PR passes WR-4470 gate; Sentry issue linked and resolved by the merging agent.
+
+## Rules
+- No silent auto-restarts: restart actions log to ledger too.
+- 429 on model lanes triggers WR-4480 lane failover before any code change.
+- Recurrence threshold: same fingerprint 3× in 7 days → escalate `needs-human`.
+
+## Acceptance
+- [ ] Sentry → issue → agent-assignment path wired
+- [ ] Classification table matches observed error mix
+- [ ] Ledger write on every triage verified


### PR DESCRIPTION
## Summary
Adds WR-4474: capture → classify (502/504 upstream, 503 capacity, 429 model-lane, 500 app) → route (fix agent vs runbook) → FAILURE-LEDGER on every triage. 429 triggers WR-4480 lane failover before code changes. Recurrence 3×/7d → `needs-human`.

## Files
- `standards/WR-4474-runtime-gateway-triage.md` (new)

## Follow-ups for fleet agents
- [ ] Update register index/TOC
- [ ] Cross-link WR-4380, WR-4480, FAILURE-LEDGER doc
- [ ] Open follow-up issue: wire Sentry → issue → agent-assignment path

## Review focus
- Classification table vs observed error mix
- Recurrence threshold (3×/7d)

Labels: wr-register, band-4470, rev-0
closes #4474

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a new standard document (WR-4474) that defines a systematic process for triaging runtime gateway 5xx errors in production and staging environments. The document specifies a four-step workflow: capturing errors via Sentry or platform logs, classifying them by type (502/504 upstream issues, 503 capacity problems, 429 rate limits, or 500 application errors), routing them to either automated fix agents or runbooks based on error class, and recording every triage event in a failure ledger for fleet learning. The standard includes special handling for 429 model-lane errors (triggering WR-4480 lane failover) and escalation rules for recurring issues (3 occurrences within 7 days).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/WR-4474-runtime-gateway-triage.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the WR-4474 runtime gateway triage standard to capture, classify, route, and ledger 5xx/timeout errors. This improves incident handling with auto-assigned fixes, runbook-first handling for infra issues, and model-lane failover when needed.

- New Features
  - End-to-end flow across prod/staging: capture (Sentry or platform logs) → classify (502/504 upstream; 503 capacity/deploy; 429 model-lane; 500 app) → route (500 → agent+issue; infra → runbook, issue on recurrence within 24h) → write to `FAILURE-LEDGER`.
  - No silent auto-restarts; restart/scale/backoff actions are ledgered.
  - 429 on model lanes triggers WR-4480 lane failover before any code change; closure requires passing WR-4470 with Sentry issue linked.
  - Escalation: same fingerprint 3× in 7 days → needs-human.

<sup>Written for commit 48b3e850c05131ffe7673413d8b79b5fdbbc9aef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

