### PR TITLE
Add WR-4481 — Model-Lane Failover & Credit-Exhaustion Handling

### DIFF
--- a/standards/WR-4481-lane-failover.md
+++ b/standards/WR-4481-lane-failover.md
@@ -1,0 +1,35 @@
+# WR-4481 — Model-Lane Failover & Credit-Exhaustion Handling
+
+**Band:** 4480 (Multi-Model Routing)
+**Status:** DRAFT — rev 0
+**Depends:** WR-4480 (Multi-Model Routing), WR-4474 (Runtime Gateway Triage), FAILURE-LEDGER
+**Origin:** 2026-07-20 incident — OpenRouter credit exhaustion stalled agents instead of failing over to the keyless Perplexity lane.
+
+## Directive
+Credit or rate exhaustion on any model lane MUST degrade to the next lane automatically. A stalled agent due to 402/429 is a directive violation of the routing layer, not an operator problem.
+
+## Lane ladder (per modality lane in WR-4480)
+1. Primary: funded OpenRouter lane (per WR-4480 routing table)
+2. Tier-2: keyless/free lane — Perplexity (and OpenRouter :free models) — MUST exist as an explicit routing-table entry, not prose
+3. Tier-3: halt + `needs-human` only when the whole ladder is exhausted
+
+## Triggers (explicit, machine-checked)
+- HTTP 402 (payment/credits) → immediate failover to tier-2, no retry on primary
+- HTTP 429 → one backoff retry (≤30s), then failover
+- Timeout/5xx from provider ×2 consecutive → failover
+- Every failover event → FAILURE-LEDGER entry (lane, trigger code, task ref); no silent degradation
+
+## Recovery
+- Primary re-probed on a schedule (e.g. hourly) or on manual credit top-up signal; return upward automatically
+- Sticky-downgrade beyond 24h → open issue tagged `lane-degraded`
+
+## Rules
+- Failover is config, not code edits: routing table carries `fallback:` + `trigger:` fields per lane
+- No agent may respond to 402/429 by editing its own routing config (gate-tamper class, WR-4472)
+- If FAILURE-LEDGER has no 402/429 entries after a known dry window, capture is broken — that is itself a ledger entry
+
+## Acceptance
+- [ ] WR-4480 routing table shows explicit tier-2 keyless entries per lane with trigger conditions
+- [ ] Simulated 402 on primary → task completes on tier-2, ledger entry written
+- [ ] Simulated 429 → one backoff then failover, ledger entry written
+- [ ] Recovery probe returns traffic to primary after top-up


### PR DESCRIPTION
## Summary
Fixes the failover gap exposed 2026-07-20: OpenRouter credit exhaustion stalled agents instead of degrading to the keyless Perplexity lane. WR-4481 makes lane failover explicit and machine-checked: 402 → immediate tier-2, 429 → one backoff then tier-2, ledger entry on every failover, recovery probe back to primary.

## Files
- `standards/WR-4481-lane-failover.md` (new)

## Follow-ups for fleet agents
- [ ] Add `fallback:`/`trigger:` fields to the WR-4480 routing table (tier-2 keyless entries per lane)
- [ ] Wire 402/429 capture into FAILURE-LEDGER
- [ ] Run the two simulated-failure acceptance tests
- [ ] Cross-link WR-4480 ↔ 4481, WR-4474 ↔ 4481

## Review focus
- Backoff window (≤30s) and recovery probe cadence (hourly)
- Whether OpenRouter :free models belong in tier-2 alongside Perplexity

⚠️ Enforcement/routing machinery: HUMAN MERGE REQUIRED per 4470-band auto-merge policy.

Labels: wr-register, band-4480, rev-0
closes #4481