### PR TITLE
Add agent-pack: machine-loadable 447x/4481 artifacts (Hermes/OpenClaw/fleet)

### DIFF
--- a/agent-pack/AGENTS.md
+++ b/agent-pack/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md — REVVEL 447x/4481 Operating Digest
+
+Load this verbatim into any fleet agent context (Hermes, OpenClaw, Dragnet sub-fleet). Full standards: /standards/. This digest never overrides WR-4200.
+
+## LINT (WR-4471)
+- Run repo LINT_CMD before any PR. Non-zero exit → fix loop: capture output → fix → re-lint. Max 3 cycles.
+- Cycle 3 fail → STOP. Open issue `lint-loop-exhausted`, write FAILURE-LEDGER.
+- Never add suppression comments (# noqa, eslint-disable) without a ledger entry. Never edit lint config inside the loop.
+- Fix commits: `chore(lint):`, one per cycle.
+
+## CI SELF-HEAL (WR-4472)
+- Failed check on your PR = your work item. Pull failing job logs, classify: lint | build | test | infra-flake.
+- infra-flake: retry once; second identical failure = real.
+- Real → `fix(ci):` commit to the SAME PR branch. Max 2 heal attempts, then label `needs-human` + ledger.
+- NEVER edit workflow files to make a check pass. NEVER force-push over reviewer commits.
+
+## COMMITS (WR-4473)
+- Pre-commit hooks are mandatory. `git commit --no-verify` / `-n` is PROHIBITED — CI re-runs lint anyway and your trust score is decremented.
+
+## RUNTIME ERRORS (WR-4474)
+- 5xx/timeout in prod/staging: classify 502/504 upstream | 503 capacity | 429 model-lane | 500 app.
+- 500 w/ stack → issue with trace, assigned fix. Infra → runbook first, issue on recurrence <24h.
+- EVERY triage and EVERY restart → FAILURE-LEDGER. Alert ≠ done.
+
+## MODEL LANES (WR-4481)
+- 402 from provider → immediate failover to keyless tier-2 (Perplexity / :free). Do not retry primary. Do not stall.
+- 429 → one backoff ≤30s, then failover. 2× consecutive timeout/5xx → failover.
+- Every failover → ledger entry (lane, code, task). Never edit your own routing config in response to 402/429.
+
+## MERGE POLICY (4470 band)
+- Auto-merge only for changes that cannot alter enforcement machinery or operating directives.
+- WR-42xx amendments and enforcement code (personas, gates, triage wiring) → human merge, always.

--- a/agent-pack/failure-ledger.schema.json
+++ b/agent-pack/failure-ledger.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FAILURE-LEDGER entry (one JSON object per line, JSONL)",
+  "type": "object",
+  "required": ["ts", "agent", "class", "trigger", "summary"],
+  "properties": {
+    "ts": {"type": "string", "format": "date-time"},
+    "agent": {"type": "string", "description": "fleet agent id, e.g. dragnet/hunter, oaudrey, hermes"},
+    "class": {"type": "string", "enum": ["lint-loop-exhausted", "ci-heal-exhausted", "gate-tamper", "hook-bypass", "runtime-500", "runtime-502", "runtime-503", "runtime-504", "lane-402", "lane-429", "lane-5xx", "lane-failover", "lane-recovery", "restart", "capture-gap", "other"]},
+    "trigger": {"type": "string", "description": "HTTP code, exit code, or event that fired"},
+    "lane": {"type": "string", "description": "model lane if applicable (text|vision|audio|embed + tier)"},
+    "service": {"type": "string"},
+    "repo": {"type": "string"},
+    "task_ref": {"type": "string", "description": "PR/issue/run URL or id"},
+    "root_cause": {"type": "string"},
+    "fix_ref": {"type": "string", "description": "commit/PR that resolved it"},
+    "summary": {"type": "string", "maxLength": 500},
+    "attempts": {"type": "integer", "minimum": 0}
+  },
+  "additionalProperties": false
+}

--- a/agent-pack/lefthook.yml
+++ b/agent-pack/lefthook.yml
@@ -1,0 +1,7 @@
+# WR-4473 pre-commit gate template — copy to repo root, set LINT_CMD, run `lefthook install` in bootstrap.
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      run: {LINT_CMD}   # e.g. ruff check . | eslint . --max-warnings 0 | dotnet format --verify-no-changes
+      fail_text: "Lint failed. For AI agents: enter WR-4471 fix loop (capture output, fix, re-lint, max 3 cycles). Do NOT use --no-verify — CI re-runs this lint and bypass decrements your trust score (WR-4473)."

--- a/agent-pack/routing-failover.example.yml
+++ b/agent-pack/routing-failover.example.yml
@@ -1,0 +1,31 @@
+# WR-4481 routing failover skeleton — merge into the WR-4480 routing table.
+# fallback/trigger fields are REQUIRED per lane. Agents may read, never write (WR-4472 tamper class).
+
+defaults:
+  backoff_429_seconds: 30      # one retry, then failover
+  consecutive_5xx_failover: 2
+  recovery_probe: hourly       # re-probe primary; auto-return upward
+  sticky_downgrade_issue_after: 24h   # -> issue label: lane-degraded
+  ledger: FAILURE-LEDGER       # every failover event: {lane, trigger, task_ref, ts}
+
+lanes:
+  text:
+    primary:
+      provider: openrouter
+      model: <per WR-4480 table>
+      triggers: {402: failover, 429: backoff_then_failover, 5xx: count_then_failover}
+      fallback: text_tier2
+    text_tier2:
+      provider: perplexity     # keyless
+      alt: openrouter:free     # :free models
+      triggers: {402: halt_needs_human, 429: backoff_then_halt}
+      fallback: null           # end of ladder -> needs-human
+  vision:
+    primary: { provider: openrouter, model: <table>, triggers: {402: failover, 429: backoff_then_failover, 5xx: count_then_failover}, fallback: vision_tier2 }
+    vision_tier2: { provider: openrouter:free, triggers: {402: halt_needs_human}, fallback: null }
+  audio:
+    primary: { provider: openrouter, model: <table>, triggers: {402: failover, 429: backoff_then_failover, 5xx: count_then_failover}, fallback: audio_tier2 }
+    audio_tier2: { provider: openrouter:free, triggers: {402: halt_needs_human}, fallback: null }
+  embed:
+    primary: { provider: openrouter, model: <table>, triggers: {402: failover, 429: backoff_then_failover, 5xx: count_then_failover}, fallback: embed_tier2 }
+    embed_tier2: { provider: openrouter:free, triggers: {402: halt_needs_human}, fallback: null }


### PR DESCRIPTION
## Summary
Converts the 447x/4481 standards from prose into agent-consumable artifacts, loadable by Hermes, OpenClaw, and the Dragnet sub-fleet.

## Files
- `agent-pack/AGENTS.md` — compact operating digest (drop into any agent context; never overrides WR-4200)
- `agent-pack/routing-failover.example.yml` — WR-4481 lane ladder as config: `fallback:`/`trigger:` per lane, 402/429/5xx handling, recovery probe
- `agent-pack/failure-ledger.schema.json` — JSONL entry schema so all agents write uniform, queryable ledger entries
- `agent-pack/lefthook.yml` — WR-4473 pre-commit template with agent-directed fail_text

## Notes
- Routing config is agent-READ-ONLY (WR-4472 tamper class)
- Digest + templates are docs; the routing yml feeds enforcement → human merge per 4470-band policy

Labels: agent-pack, band-4470, band-4480
closes #447