### PR TITLE
Add tier-2 lane canary (staged — move to .github/workflows on merge)

### DIFF
--- a/ops/lane-canary.workflow.yml
+++ b/ops/lane-canary.workflow.yml
@@ -1,0 +1,67 @@
+# Lane Canary (WR-4481) — proves the keyless tier-2 lane is alive BEFORE it's needed.
+# STAGED HERE because the Zapier GitHub token lacks workflow scope.
+# ACTION REQUIRED: move this file to .github/workflows/lane-canary.yml (UI or PAT lane), then set repo variable PPLX_CANARY_URL.
+name: lane-canary
+
+on:
+  schedule:
+    - cron: "17 6 * * *"   # daily 06:17 UTC (~00:17 MDT)
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  PPLX_CANARY_URL: ${{ vars.PPLX_CANARY_URL }}
+  ORFREE_MODEL: ${{ vars.ORFREE_MODEL || 'meta-llama/llama-3.2-3b-instruct:free' }}
+  LEDGER_PATH: FAILURE-LEDGER.jsonl
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ping keyless Perplexity lane
+        id: pplx
+        continue-on-error: true
+        run: |
+          if [ -z "$PPLX_CANARY_URL" ]; then echo "skipped=true" >> "$GITHUB_OUTPUT"; exit 0; fi
+          code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 -X POST "$PPLX_CANARY_URL" \
+            -H 'Content-Type: application/json' \
+            -d '{"messages":[{"role":"user","content":"ping"}],"max_tokens":1}')
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          [ "$code" = "200" ]
+
+      - name: Ping OpenRouter :free lane (keyless probe)
+        id: orfree
+        continue-on-error: true
+        run: |
+          # 401 = reachable-but-auth-required (acceptable liveness signal); 200 = fully open
+          code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 https://openrouter.ai/api/v1/models)
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          [ "$code" = "200" ] || [ "$code" = "401" ]
+
+      - name: Write FAILURE-LEDGER entry
+        run: |
+          status="healthy"; class="lane-recovery"
+          if [ "${{ steps.pplx.outcome }}" = "failure" ] || [ "${{ steps.orfree.outcome }}" = "failure" ]; then
+            status="degraded"; class="lane-5xx"
+          fi
+          printf '{"ts":"%s","agent":"lane-canary","class":"%s","trigger":"canary pplx=%s orfree=%s","lane":"tier2","repo":"revvel-standards","summary":"tier-2 canary %s"}\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$class" "${{ steps.pplx.outputs.code || 'skip' }}" "${{ steps.orfree.outputs.code || 'na' }}" "$status" >> "$LEDGER_PATH"
+          git config user.name lane-canary; git config user.email canary@users.noreply.github.com
+          git add "$LEDGER_PATH"; git commit -m "chore(ledger): lane canary $status" && git push || echo "no change"
+
+      - name: Open lane-degraded issue on failure
+        if: steps.pplx.outcome == 'failure' || steps.orfree.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner, repo: context.repo.repo,
+              title: `lane-degraded: tier-2 canary failed ${new Date().toISOString().slice(0,10)}`,
+              labels: ['lane-degraded'],
+              body: 'Tier-2 keyless lane canary failed (WR-4481). pplx=${{ steps.pplx.outputs.code }} orfree=${{ steps.orfree.outputs.code }}. Failover ladder may be dead — verify before relying on it.'
+            });


### PR DESCRIPTION
## Summary
Daily canary proving the keyless tier-2 lane (Perplexity + OpenRouter :free) is alive before failover needs it (WR-4481). Success → FAILURE-LEDGER heartbeat; failure → `lane-degraded` issue + ledger entry.

## Files
- `ops/lane-canary.workflow.yml` — STAGED: the Zapier GitHub token lacks `workflow` scope, so it cannot write to `.github/workflows/` directly.

## Merge steps (you)
1. Merge this PR
2. Move file to `.github/workflows/lane-canary.yml` (GitHub UI rename works, or PAT lane)
3. Set repo variable `PPLX_CANARY_URL` = your keyless Perplexity proxy endpoint
4. Run once via workflow_dispatch to seed the ledger

## Review focus
- Cron 06:17 UTC daily — adjust?
- OpenRouter probe accepts 401 as liveness (keyless probe of a keyed endpoint) — acceptable?

Labels: ops, band-4480, lane-canary

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a daily scheduled canary workflow to proactively monitor the health of the keyless tier-2 lane (Perplexity and OpenRouter free endpoints) before they are needed for failover. The workflow pings both services, logs results to `FAILURE-LEDGER.jsonl`, and automatically creates a `lane-degraded` issue if either endpoint fails. The file is staged in `ops/` because the Zapier GitHub token lacks workflow scope, requiring manual relocation to `.github/workflows/` after merge.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `ops/lane-canary.workflow.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a daily canary workflow to verify the keyless tier-2 lane (Perplexity + OpenRouter free) is healthy before failover (WR-4481). Success writes a heartbeat to `FAILURE-LEDGER.jsonl`; failure opens a `lane-degraded` issue and logs the event.

- **New Features**
  - Runs daily at 06:17 UTC and supports manual dispatch.
  - Probes Perplexity via POST to `PPLX_CANARY_URL` (expects 200).
  - Probes OpenRouter models endpoint (accepts 200 or 401 as liveness).
  - Commits a JSONL entry to `FAILURE-LEDGER.jsonl` and pushes to the repo.

- **Migration**
  - Move `ops/lane-canary.workflow.yml` to `.github/workflows/lane-canary.yml`.
  - Set repo variable `PPLX_CANARY_URL` to your keyless Perplexity proxy.
  - Optionally adjust the cron schedule.
  - Run once via `workflow_dispatch` to seed the ledger.

<sup>Written for commit cc1090165d401da836c766d1653fdeadd5f8853a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

