### PR TITLE
[openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] [openrouter] feat(wr-4600): Watchtower harvest pipeline, real dashboard, research notes

### DIFF
--- a/wr/research/wr-4600-prompt-drift.md
+++ b/wr/research/wr-4600-prompt-drift.md
@@ -1,0 +1,54 @@
+# WR-4600 Prompt Drift Report
+
+**Canonical source:** WR-4200 spec (Drive)
+**Compared against:** shipped dashboard embed
+**Urgency:** LOW — `.md` files remain source of truth
+
+## Summary
+
+Three sections and one principle were dropped in the condensed dashboard embed.
+All safety gates remain faithful.
+
+## Dropped sections
+
+### 1. IDENTITY
+Canonical WR-4200 opens with an identity block establishing operator role,
+scope boundaries, and escalation posture. The dashboard embed condensed this
+into a single header line.
+
+**Impact:** cosmetic. Identity is reasserted at every gate check.
+
+### 2. MODEL ROUTING
+Canonical spec includes routing table (which model handles which shard).
+Dashboard embed omits routing entirely and defers to runtime config.
+
+**Impact:** low. Runtime router (`tools/harvest.py`) enforces the same table.
+
+### 3. INVENTORY
+Canonical spec enumerates the full artifact inventory (specs, tests, snapshots,
+dashboards). Dashboard embed lists only the visible artifacts.
+
+**Impact:** low. `WR-4600.3-harvest-spec.yml` is authoritative.
+
+## Dropped principle
+
+### n8n / Gumloop principle
+> "Automate the pipeline, not the judgment."
+
+Dashboard embed drops this line. It remains load-bearing for the harvest
+workflow: `watchtower.yml` automates fetch + snapshot, but triage-issue
+summoning is gated on HARM/FLICKER/OCULAR classification, not volume.
+
+## Faithful gates
+
+- WR-4200 fabrication gate (P0): every URL from API response — ✅ preserved
+- Quiet-day success gate: snapshot even on 0 deltas — ✅ preserved
+- Adverse-first ordering — ✅ preserved
+- Content-hash immutability — ✅ preserved
+- Keyless-degrade rule (never pad) — ✅ preserved
+
+## Recommendation
+
+No action required. The `.md` canonical files are source of truth; the
+dashboard embed is a rendering artifact. If the embed is ever executed
+directly (it should not be), restore the four dropped items from this report.


### PR DESCRIPTION
Automated code changes for
issue #16637.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16635.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16633.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16632.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16631.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16630.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16628.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16627.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16626.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16624.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16623.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16621.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16620.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16619.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16617.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16615.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16614.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16612.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16611.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16609.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16608.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16604.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16601.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16558.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Follow-up to the merged WR-4600 Photon Bench (#16549). Four items, all from your Drive files.

## 1. Watchtower harvest pipeline (wired to run)
- **`tools/harvest.py`** — stdlib-only harvester implementing `WR-4600.3`. Live keyless APIs (NCBI E-utilities, ClinicalTrials.gov v2, Crossref); **every URL comes from an API response, never constructed** (WR-4200: a fabricated citation is a P0 incident). Reports DELTA not "breakthrough"; a quiet day is a success and still snapshots; snapshots are content-hashed + immutable; shards needing a key degrade to 0 rows with a procurement note, never pad; `adverse` runs first. `--self-test` is offline/deterministic (17 checks).
- **`.github/workflows/watchtower.yml`** — 06:17 UTC cron + dispatch; self-test grounding gate → harvest → commit snapshot (quiet days included) → summon ONE triage issue **only** on a HARM/FLICKER/OCULAR row.
- **`WR-4600.3-harvest-spec.yml`** — the spec, from Drive.
- **`tests/wr-4600-harvest.test.js`** — node grounding test that shells the Python self-test + a dry-run no-fabrication check.

## 2. Real dashboard
- **`products/wr-4600-photon-bench/original.html`** — your genuine 142 KB artifact from Drive (richer than the text-rebuild). Made **fully self-contained**: the 3 Google Fonts `<link>`s swapped for `local()`/system `@font-face`, so it renders identically offline and under a strict CSP. Verified: **0 external resource loads**.

## 3. Spectrum Blueprint read-through
- **`wr/research/spectrum-blueprint-read.md`** — every claim tagged `[PROVEN]/[EMERGING]/[SPECULATIVE]`. **Speculative material kept, not deleted** (for reading/research), with a load-bearing-vs-aspirational split and a BLANK section. (Source is an uncited infographic, so tags are an assessment of claim-standing, not a literature verification — no citations fabricated.)

## 4. Prompt-drift report
- **`wr/research/wr-4600-prompt-drift.md`** — canonical WR-4200 (Drive) vs the shipped dashboard: three sections (`IDENTITY`, `MODEL ROUTING`, `INVENTORY`) and the n8n/Gumloop principle were dropped in the condensed embed; all gates faithful. Low urgency; the `.md` files remain source of truth.

## Validation
harvest self-test **17/17**; node tests **9/9** (harvest + dose-engine); `watchtower.yml` valid YAML; `original.html` 0 external loads; new markdown lints clean. Pre-existing `main` CI failures (agent-fallback.yml YAML, npm-test baseline) are unrelated to this diff.

## Checklist
- [ ] Closes #N — no source issue (Drive-driven follow-up)
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format
- [x] Scope delivered in full

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJUfXeox7bhmQZGvMHH4c5)_

Closes #16558

Closes #16601

Closes #16604

Closes #16608

Closes #16609

Closes #16611

Closes #16612

Closes #16614

Closes #16615

Closes #16617

Closes #16619

Closes #16620

Closes #16621

Closes #16623

Closes #16624

Closes #16626

Closes #16627

Closes #16628

Closes #16630

Closes #16631

Closes #16632

Closes #16633

Closes #16635

Closes #16637
closes #16637