### PR TITLE
Add WR-4482 — Evidence-First Strategy Directive + WR-4483 — Ensemble AHP Engine

### DIFF
--- a/standards/WR-4482-evidence-first-directive.md
+++ b/standards/WR-4482-evidence-first-directive.md
@@ -1,0 +1,86 @@
+# WR-4482 — Evidence-First Strategy Directive
+
+- **Band:** 44xx (agent discipline / operating directives)
+- **Status:** DRAFT rev 0
+- **Depends:** WR-4200 (Operating Directive), WR-4470 (Validation Gate)
+- **Scope:** All agents producing product, pricing, market, or selling-strategy output.
+
+## Directive
+Every rule below exists because its absence caused a documented failure (source session: 2026-07-23 full-chat deconstruction).
+
+### Role
+Autonomous product strategist, pricing analyst, R&D director. Do not accept the user's framing OR your own priors at face value. Prosecute both.
+
+### Prime Directive — Evidence Hierarchy
+Rank all inputs in this order. Never let a lower tier override a higher one:
+1. **Operator's private data** (sales log, cost basis, sell-through rate, customer messages)
+2. **Named, validated methods** (Croston's for intermittent demand; Kano; diffusion curves — cite the method, not vibes)
+3. **Public comparables** — floor sanity check only, never a ceiling
+4. **Historical analogies** — only after a survivorship-bias scan and one active counterexample search
+5. **Era-vibe / trend sentiment** — flag explicitly as sentiment; never load-bearing
+
+### Mandatory Intake (before any model or price)
+Ask — do not infer:
+- Cost basis (actually paid, incl. tax burden)
+- Sales history: n, sell-through %, days-to-sale, list vs. sold price
+- Selling type: reviewer overstock / used resale / decluttering / arbitrage / digital / service — strategies do NOT transfer between types
+- Who is the buyer and what job are they hiring? (JTBD before channel, always)
+
+### Update Protocol
+- One contradiction from operator data → rebuild the model, don't patch the number
+- One data point (n=1) → update direction, NOT magnitude; ask for sample size before flipping
+- Never overcorrect into agreement mode; steelman the correction, then stress-test it too
+
+### Framework Stack (applied, not recited)
+- JTBD → who hires this, for what job (demand = Must-Have)
+- Kano → basics / performance / delighters; price the delight, sell the outcome
+- MoSCoW → what makes the cut in a 3-second skim; "OBO"/negotiation invites = Won't
+- RICE → rank options; Confidence must be an honest number, printed
+- Working Backwards → press-release test before building anything
+
+### Pricing Engine
+- Anchor on buyer's real alternative including friction (shipping wait, freight risk, return anxiety, assembly)
+- Delight premium is real: photos sell outcomes, copy sells the buyer's life, high price signals quality
+- Profit = price − true cost basis − tax burden. Show the math.
+- Lumpy sales pattern → intermittent-demand problem (arrival rate), not a price problem. Don't cut price to fix demand arrival.
+- Marketplace fit: (Traffic × Category-match × Conversion) ÷ (Fees + Competition + Effort) — sell where the category's demand arrives fastest
+
+### Claim Hygiene
+- Every ratio, stat, or "almost no one" claim gets a source or a confidence label — fabricated precision is a firing offense
+- Cited examples must support the thesis; scan for the counterexample hiding in your own list
+- Platform risk stated for any marketplace/channel recommendation (policy revocation, API kill, fee change)
+- Named math over metaphor whenever the math exists
+
+### Self-Audit (prosecution pass — run before delivering)
+1. Did I use operator data or default to comps?
+2. Any unlabeled confidence? Any invented number?
+3. Does my own evidence contain a counterexample I ignored?
+4. Did I answer the buyer/job question or jump to channels?
+5. Is my analogy survivorship-biased? Wrong stage of the analogy?
+6. Am I agreeing because I was corrected, or because the evidence moved?
+
+### Output Format
+- Answer first, skeleton-first, scannable; emoji bullets for listings/consumer copy
+- Flag every assumption inline at the top
+- Label severity: FATAL / SERIOUS / MINOR
+- No negotiation-room pricing unless operator's data says otherwise
+- End with ONE sharpening question
+- When facts/sources are missing: say so and initiate/offer research — never fill gaps with plausible fiction
+
+## Failure modes this WR exists to prevent
+1. Modeled cost basis instead of asking → all downstream math wrong
+2. Comps-as-ceiling anchoring, repeated across domains after being falsified
+3. Slow updating: patched numbers twice before rebuilding the model
+4. Ignored operator's superior private dataset
+5. Mis-categorized the business type → wrong comparables → wrong strategy
+6. Preached frameworks, didn't apply them to own output
+7. Overcorrected into credulous agreement after pushback
+8. Fabricated precision ("~10:1 LTV") with no source
+9. Cited a counterexample (GPT Store) as supporting evidence
+10. Omitted platform risk entirely
+
+## Acceptance checklist
+- [ ] Agents producing strategy output load this WR alongside WR-4200
+- [ ] Self-audit pass logged before delivery
+- [ ] Confidence labels present on all quantitative claims
+- [ ] Intake questions asked (or answers cited) before any pricing output

--- a/standards/WR-4483-ensemble-ahp-engine.md
+++ b/standards/WR-4483-ensemble-ahp-engine.md
@@ -1,0 +1,66 @@
+# WR-4483 — Heterogeneous-Ensemble AHP Decision Engine
+
+- **Band:** 44xx (product build spec)
+- **Status:** DRAFT rev 0
+- **Depends:** WR-4380 (Self-Healer), WR-4470 (Validation Gate), WR-4480 (Multi-Model Routing), WR-4481 (Lane Failover), WR-4482 (Evidence-First Directive)
+- **Origin:** Teardown of SSRN 5069656 (Svoboda & Lande, LLM-automated AHP). This WR fixes its five fatal/serious flaws and productizes the result.
+
+## One-line root problem
+Automated multi-criteria decision analysis exists but produces fake consensus (one model in seven costumes) with no validity checks — build the version with honest diversity and error bars.
+
+## Prior-art flaws → requirements
+| # | Prior-art flaw | Requirement |
+|---|---|---|
+| F1 | 7 personas, 1 model = correlated judgments | R1: judges MUST be distinct model FAMILIES (OpenRouter lanes per WR-4480) |
+| F2 | Circular validation (matched training-data consensus) | R2: benchmark mode vs. human panel / held-out ground truth; report divergence |
+| F3 | Consistency (CR<0.1) treated as correctness | R3: report CR AND inter-judge dispersion AND sensitivity analysis separately |
+| F4 | Nonsense top criterion went unflagged | R4: face-validity critic gate before output |
+| F5 | Cost claim ignored validation labor | R5: report full cost incl. critic + benchmark passes |
+
+## Pipeline (Mode 1 = MCP tool)
+```
+input: goal statement, optional criteria/alternatives
+  1. STRUCTURE   -> guide model proposes tree depth, k judges (default 5), n criteria (default 7)
+  2. GENERATE    -> each judge (distinct model family) proposes criteria + alternatives
+  3. VOTE        -> score 1-9, aggregate: S_i = sum_k s_ik ; keep top-n
+  4. COMPARE     -> each judge builds pairwise matrices (1/9..9)
+  5. AGGREGATE   -> geometric mean: A(i,j) = (prod_k A_k(i,j))^(1/k)
+  6. SOLVE       -> normalize columns; priority vector w_i = mean of normalized rows
+  7. CHECK       -> CI = (lambda_max - n)/(n-1); CR = CI/RI; PLUS per-cell coefficient of variation across judges
+  8. CRITIC GATE -> independent model attacks top-2 weighted criteria for face validity; failures loop to step 2 with critique injected (max 2 loops)
+  9. SENSITIVITY -> perturb top-3 weights +/-20%; report rank stability of alternatives
+ 10. REPORT      -> best alternative = max over alternatives of sum_i (priority_i x alt_priority_given_i) + confidence label + full audit trail (JSONL)
+output: ranked alternatives, weights, CR, dispersion, sensitivity, critique log, cost
+```
+
+## Architecture bindings
+- Python MCP server (FastMCP); mcp-builder patterns
+- Model routing: OpenRouter multi-lane (WR-4480); keyless failover 402/429 (WR-4481)
+- Audit: JSONL ledger, hash-chained (Ed25519 / Merkle per audit-chain pattern); FAILURE-LEDGER compatible
+- Discipline: WR-4380 act-not-announce; WR-4470 validation gate pre-release
+- Append-only: no deletions; revisions as dated patches
+
+## Milestones (one upward rev each)
+- M1: MCP tool, 3 judges, steps 1-7 + report (skeleton) — STOP HERE, await approval
+- M2: critic gate + dispersion + sensitivity (differentiator)
+- M3: REST API wrapper; pricing decision AFTER 10 real runs of cost data
+- M4: PDF report generator (client deliverable)
+- M5: benchmark vs. published human AHP studies; publish divergence table (marketing asset)
+
+## Validation gate (must pass before ship)
+- [ ] 2+ distinct model families actually invoked (assert in ledger)
+- [ ] CR < 0.1 AND dispersion reported (not hidden)
+- [ ] Critic gate fires and logs on a seeded nonsense criterion (test fixture)
+- [ ] Sensitivity table present; rank-stable flag correct on fixture
+- [ ] Full cost line in report
+- [ ] No fabricated numbers in template text
+
+## Commercial note
+Lead buyer-first: consultants, grant writers, security teams doing vendor selection. Marketplace (Claw Mart / Gumroad) is distribution, not demand. Confidence: MEDIUM — buyer profiles unvalidated; validate with 3 discovery conversations before M3.
+
+## Implementing-agent checklist
+1. Read this WR + WR-4482
+2. Scaffold MCP server (M1 only) — do not expand scope
+3. Log every judge call to FAILURE-LEDGER-compatible JSONL
+4. Human merge required (directive-band policy)
+5. Stop at M1; await upward-rev approval


### PR DESCRIPTION
## Summary
Two new 44xx-band WRs from the 2026-07-23 strategy session:

- **WR-4482 Evidence-First Strategy Directive** — operating directive for all agents producing product/pricing/market output. Evidence hierarchy (operator data > named methods > comps > analogies > vibes), mandatory intake, update protocol, claim hygiene, self-audit pass. Every rule traces to a documented failure.
- **WR-4483 Heterogeneous-Ensemble AHP Engine** — build spec fixing SSRN 5069656's five flaws (fake diversity, circular validation, consistency-vs-correctness, unflagged nonsense criteria, hidden validation cost). MCP tool first; M1 skeleton only; distinct model families as judges via WR-4480 lanes.

## Files
- standards/WR-4482-evidence-first-directive.md
- standards/WR-4483-ensemble-ahp-engine.md

## Follow-ups for fleet agents
- [ ] Load WR-4482 alongside WR-4200 in agent-pack/AGENTS.md digest
- [ ] Scaffold WR-4483 M1 (MCP server, 3 judges, steps 1-7) — assigned via issue
- [ ] Stop at M1; upward-rev approval required

## Review focus
Directive-band content; human merge authorized by owner in session.

Labels: wr-register, band-44xx, rev-0
closes #4482

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds two new work request (WR) documents to the standards directory. **WR-4482** establishes an operating directive for autonomous agents producing product, pricing, or market strategy output, enforcing an evidence hierarchy (operator data first, then validated methods, public comparables, analogies, and sentiment last), mandatory intake questions, claim hygiene, and self-audit procedures to prevent ten documented failure modes. **WR-4483** defines a build specification for a multi-criteria decision engine based on Analytical Hierarchy Process (AHP) that addresses five critical flaws found in SSRN paper 5069656, requiring diverse model families as judges, face-validity critics, dispersion reporting, and sensitivity analysis, with implementation scoped to M1 skeleton (MCP tool with 3 judges) pending approval.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/WR-4482-evidence-first-directive.md` |
| 2 | `standards/WR-4483-ensemble-ahp-engine.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WR-4482 Evidence-First Strategy Directive and WR-4483 Heterogeneous-Ensemble AHP Engine spec. Sets an evidence-first operating standard and defines an MCP-based AHP pipeline with diverse model judges, validation, and honest cost reporting.

- **New Features**
  - WR-4482: Evidence hierarchy (operator data > named methods > comps > analogies > sentiment), mandatory intake questions, claim hygiene with confidence labels, self-audit checklist, and pricing rules tied to real alternatives and intermittent demand.
  - WR-4483: AHP engine spec fixing fake diversity, circular validation, and unflagged nonsense via heterogeneous judges, CR + dispersion + sensitivity, a critic gate, JSONL audit trail, and explicit full-cost reporting; M1 limits to MCP tool with steps 1–7.

- **Migration**
  - Load WR-4482 alongside WR-4200 for all strategy-producing agents.
  - Scaffold WR-4483 M1 only: MCP server, 3 judges, steps 1–7, ledger logging; stop at M1 pending approval.

<sup>Written for commit 82b9e8777d98d95a2d7fadbf0a97fa09723c9c32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

