### PR TITLE
WR-4483: fix MD040 fenced-code language (lint cleanup 1/4)

### DIFF
--- a/standards/WR-4483-ensemble-ahp-engine.md
+++ b/standards/WR-4483-ensemble-ahp-engine.md
@@ -18,7 +18,7 @@ Automated multi-criteria decision analysis exists but produces fake consensus (o
 | F5 | Cost claim ignored validation labor | R5: report full cost incl. critic + benchmark passes |
 
 ## Pipeline (Mode 1 = MCP tool)
-```
+```text
 input: goal statement, optional criteria/alternatives
   1. STRUCTURE   -> guide model proposes tree depth, k judges (default 5), n criteria (default 7)
   2. GENERATE    -> each judge (distinct model family) proposes criteria + alternatives


### PR DESCRIPTION
One-line lint fix: WR-4483 pipeline code fence gains a `text` language tag (markdownlint MD040). No content changes.

Part of the per-WR lint cleanup series. One WR per PR.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a markdown linting violation (MD040) by adding a `text` language tag to a fenced code block in the WR-4483 pipeline documentation. This is a formatting-only change with no content modifications, part 1 of a 4-part lint cleanup series.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/WR-4483-ensemble-ahp-engine.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `text` language tag to the pipeline code fence in `standards/WR-4483-ensemble-ahp-engine.md` to resolve markdownlint rule MD040. Formatting-only change; no content updates.

<sup>Written for commit f8daa96ee485dc9b587326110b82db7e88af103c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

