### PR TITLE
[openrouter] [openrouter] [openrouter] WR-4483: fix MD040 fenced-code language (lint cleanup 1/4)

### DIFF
--- a/docs/wr/WR-4483.md
+++ b/docs/wr/WR-4483.md
@@ -1,0 +1,7 @@
+# WR-4483
+
+Pipeline overview:
+
+```text
+input -> normalize -> enrich -> score -> output
+```


### PR DESCRIPTION
Automated code changes for
issue #16728.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16727.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
Automated code changes for
issue #16726.

**Agent used:** openrouter
**Fallback chain:** OpenRouter → OpenHands (opt-in)
**Fallback chain:** OpenRouter → OpenHands → manual (all free-tier)

### Issue
One-line lint fix: WR-4483 pipeline code fence gains a `text` language tag (markdownlint MD040). No content changes.

Part of the per-WR lint cleanup series. One WR per PR.

Closes #16726

Closes #16727

Closes #16728
closes #16728