### PR TITLE
Add WR-4486 — Judge-Gated WR Rewrite Sweep + staged workflow (owner-authorized)

### DIFF
--- a/ops/wr-rewrite.workflow.yml
+++ b/ops/wr-rewrite.workflow.yml
@@ -1,0 +1,68 @@
+# WR-4486 Judge-Gated Rewrite Sweep — STAGED WORKFLOW
+# Move to .github/workflows/wr-rewrite.yml (Zapier token lacks workflow scope; lane-canary precedent).
+# Secrets required: OPENROUTER_API_KEY (optional — keyless lanes work without it), OLLAMA_ENDPOINT (lane-0).
+
+name: wr-rewrite-sweep
+
+on:
+  workflow_dispatch:
+    inputs:
+      max_docs:
+        description: WIP cap for this run
+        default: "5"
+  schedule:
+    - cron: "0 9 * * 1"   # weekly Monday sweep; keep off-peak
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: SELECT — enumerate failing/skeleton docs
+        id: select
+        run: |
+          npx markdownlint-cli2 "**/*.md" 2>lint.txt || true
+          python3 scripts/wr_rewrite.py select \
+            --lint-report lint.txt \
+            --include "wr/issues/**" "standards/**" "wr/research/**" \
+            --max-docs "${{ github.event.inputs.max_docs || 5 }}" \
+            --out queue.json
+
+      - name: REWRITE + JUDGE + GATE (retry cap 2)
+        run: |
+          # scripts/wr_rewrite.py implements WR-4486 pipeline steps 2-5:
+          #   lane-0 local (OLLAMA_ENDPOINT) -> lane-1 OpenRouter -> lane-2 Jules (optional)
+          #   judges: 2-3 DISTINCT model families, rubric in standards/WR-4486
+          #   gate: mean >= 0.75 AND min >= 0.50 AND lint-clean; one revision loop max
+          python3 scripts/wr_rewrite.py run \
+            --queue queue.json \
+            --rubric standards/WR-4486-judge-gated-rewrite-sweep.md \
+            --ledger ledger/wr-rewrite.jsonl \
+            --retry-cap 2
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OLLAMA_ENDPOINT: ${{ secrets.OLLAMA_ENDPOINT }}
+
+      - name: PR — born green only
+        run: |
+          # One branch + PR per doc (one WR per PR policy). PR body must carry
+          # judge scores, dispersion, cost line, and lanes used (from ledger).
+          python3 scripts/wr_rewrite.py open-prs \
+            --ledger ledger/wr-rewrite.jsonl \
+            --label wr-rewrite \
+            --human-flag-label needs-human
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ledger commit
+        run: |
+          git config user.name "wr-rewrite-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add ledger/wr-rewrite.jsonl || true
+          git commit -m "chore(ledger): wr-rewrite sweep entries" || echo "no ledger changes"
+          git push || true

--- a/standards/WR-4486-judge-gated-rewrite-sweep.md
+++ b/standards/WR-4486-judge-gated-rewrite-sweep.md
@@ -1,0 +1,73 @@
+# WR-4486 — Judge-Gated WR Rewrite Sweep
+
+**Band:** 44xx (Standards / Pipeline)
+**Rev:** 0
+**Status:** ACTIVE
+**Depends:** WR-4480 (Multi-Model Routing), WR-4481 (Lane Failover), WR-4482 (Evidence-First Directive), WR-4483 (Ensemble Judge)
+**Fixes:** single-vendor rewrite dependency (Jules queue); wr-pr-creation.yml ordering bug (PR opened before rewrite completes, guaranteeing red lint)
+
+---
+
+## Purpose
+
+Bulk-rewrite every WR and PR document to standard, with the WR-4483 judge as the quality gate. No single vendor is the pipeline: Jules is demoted to one rewriter lane among several. A PR opens only AFTER the rewrite passes the judge — documents are born green, not red.
+
+## Pipeline
+
+```text
+1. SELECT   -> lint run enumerates failing/skeleton docs (placeholders, MD025, MD040,
+               empty sections); queue ordered by band importance, WIP cap 5 docs
+2. REWRITE  -> lane-0: local models (zero marginal cost) via Ollama endpoint
+               lane-1: OpenRouter cheap lane   lane-2: Jules (optional, if quota allows)
+               failover per WR-4481 (402 -> keyless, 429 -> one backoff then next lane)
+3. JUDGE    -> 2-3 scorers from DISTINCT model families (WR-4483 R1) score the rewrite
+               against the rubric below, each 0..1 per criterion
+4. GATE     -> pass iff mean >= 0.75 AND min >= 0.50 AND lint-clean
+               report per-criterion dispersion (coefficient of variation)
+5. REVISE   -> on fail: one revision loop with judge critiques injected; second fail
+               -> human-flag label, stop (retry cap 2, no unbounded loops)
+6. PR       -> only now open the PR; body carries judge scores + dispersion + cost line
+7. LEDGER   -> JSONL entry per doc: lanes used, scores, cost, outcome
+```
+
+## Judge rubric (each criterion scored 0..1)
+
+```yaml
+rubric:
+  no_placeholders: "no deferral or raw placeholder tokens anywhere"
+  structure: "single H1; language-tagged fences; register header complete (Band/Rev/Status/Depends)"
+  named_math: "every quantitative claim carries formula + named source, or a confidence label"
+  claim_hygiene: "no fabricated precision; WR-4482 evidence hierarchy respected"
+  failure_modes: "methods list their breakage conditions, not just happy path"
+  actionability: "acceptance criteria are checkable; an agent could execute without asking"
+```
+
+## Constraints
+
+- Retry cap 2 per doc — bounded spend, no self-heal loops (token-whale rule)
+- Rewrites run on batch/off-peak lanes where available; local lane-0 preferred
+- Judge scorers MUST be different model families than the rewriter (anti-self-grading)
+- Directive/autonomy-band docs (WR-4484 class): human merge required regardless of score
+- Mechanical-only rewrites (lint fixes, no semantic change) MAY auto-merge per existing 4470-band policy
+- Append-only: originals stay in git history; changelog entry per rewrite
+
+## KPIs
+
+| KPI | Target | Red flag |
+|---|---|---|
+| Judge pass rate (first attempt) | 50–80% | > 95% (rubber-stamp judge) or < 20% (rewriter lane broken) |
+| Post-merge lint-green rate | 100% | any red — the whole point |
+| Cost per rewritten doc | tracked, trend down | unbounded retries |
+| Judge dispersion (mean CV) | reported every run | hidden |
+
+## Acceptance criteria
+
+- [ ] Workflow staged at ops/wr-rewrite.workflow.yml (Zapier token lacks workflow scope — human moves it to .github/workflows/, per lane-canary precedent)
+- [ ] First sweep targets the current markdownlint failures and skeleton wr/issues docs
+- [ ] Judge scorers verifiably distinct model families (asserted in ledger)
+- [ ] wr-pr-creation.yml amended: rewrite+judge BEFORE PR creation
+- [ ] Ledger entries present for every processed doc
+
+## Change log
+
+- **rev-0** — initial: judge-gated rewrite pipeline, Jules demoted to optional lane, born-green PR ordering, retry cap 2.


### PR DESCRIPTION
WR-4486: Judge-Gated WR Rewrite Sweep — owner-authorized push-through.

What it does:
- Bulk-rewrites every WR/PR doc with the WR-4483 ensemble judge as quality gate (2-3 distinct model families, anti-self-grading)
- Demotes Jules from THE pipeline to ONE optional rewriter lane (fixes single-vendor dependency that stalled all rewrites)
- Fixes the wr-pr-creation.yml ordering bug: rewrite + judge BEFORE PR creation — docs born green, not red
- Lane-0 = local models (Ollama: Kimi/Gemma, zero marginal cost); failover per WR-4481; retry cap 2 (bounded spend)
- Gate: mean >= 0.75 AND min >= 0.50 AND lint-clean; dispersion reported

Files:
- standards/WR-4486-judge-gated-rewrite-sweep.md
- ops/wr-rewrite.workflow.yml (STAGED — Zapier token lacks workflow scope; move to .github/workflows/wr-rewrite.yml and set OLLAMA_ENDPOINT secret, per lane-canary precedent)

Follow-up for fleet: implement scripts/wr_rewrite.py (select / run / open-prs subcommands) per the WR pipeline spec.
closes #4486

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a judge-gated multi-lane rewrite pipeline for bulk-updating WR/PR documentation. It demotes Jules from being the single rewrite provider to an optional fallback lane, implements a quality gate using ensemble judges from distinct model families (mean ≥ 0.75, min ≥ 0.50, lint-clean), and fixes an ordering bug where PRs were created before rewrites completed. The pipeline prefers local models (lane-0 via Ollama) to minimize cost, includes retry caps (max 2) to prevent unbounded spending, and ensures documents are "born green" by validating rewrites before opening PRs. A new workflow file and comprehensive standards document define the 7-step pipeline (SELECT, REWRITE, JUDGE, GATE, REVISE, PR, LEDGER) with detailed rubric criteria and KPI targets.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `standards/WR-4486-judge-gated-rewrite-sweep.md` |
| 2 | `ops/wr-rewrite.workflow.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements WR-4486 by adding a judge-gated rewrite sweep with a staged GitHub Actions workflow. Rewrites run through multiple lanes with an ensemble judge; PRs open only after passing, so docs are born green.

- **New Features**
  - Staged workflow that selects failing/skeleton docs, rewrites, judges, then opens PRs only if green.
  - Multi-lane rewriter: local lane (`OLLAMA_ENDPOINT`), OpenRouter, optional Jules; failover with retry cap 2.
  - Ensemble judge (2–3 distinct model families) with gate: mean ≥ 0.75, min ≥ 0.50, and lint-clean; dispersion logged.
  - Adds the WR-4486 standard defining the rubric, KPIs, and constraints.

- **Migration**
  - Move `ops/wr-rewrite.workflow.yml` to `.github/workflows/wr-rewrite.yml` and set secrets: `OLLAMA_ENDPOINT` (required) and `OPENROUTER_API_KEY` (optional).
  - Ensure `scripts/wr_rewrite.py` provides `select`, `run`, and `open-prs` subcommands.

<sup>Written for commit b3815c86f33fc215672adf44a1080c9c5e4faf60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

