### PR TITLE
Add LM Studio lane-0a to wr_rewrite.py

### DIFF
--- a/scripts/wr_rewrite.py
+++ b/scripts/wr_rewrite.py
@@ -3,13 +3,14 @@
 
 Subcommands:
   select    -> parse lint report + placeholder scan, emit queue.json (WIP-capped)
-  run       -> rewrite (lane-0 Ollama -> lane-1 OpenRouter), judge (distinct
-               model families), gate (mean>=0.75, min>=0.50, lint-clean),
-               retry cap 2, JSONL ledger
+  run       -> rewrite (lane-0 LM Studio/Ollama -> lane-1 OpenRouter), judge
+               (distinct model families), gate (mean>=0.75, min>=0.50,
+               lint-clean), retry cap 2, JSONL ledger
   open-prs  -> one branch + PR per passed doc via gh CLI; failed docs flagged
 
-Stdlib only. Env: OLLAMA_ENDPOINT, OPENROUTER_API_KEY, REWRITE_MODEL,
-JUDGE_MODELS (csv), GITHUB_TOKEN (for gh).
+Stdlib only. Env: LMSTUDIO_ENDPOINT (e.g. http://127.0.0.1:1234/v1),
+LMSTUDIO_MODEL, OLLAMA_ENDPOINT, OLLAMA_MODEL, OPENROUTER_API_KEY,
+REWRITE_MODEL, JUDGE_MODELS (csv), GITHUB_TOKEN (for gh).
 Governing standard: standards/WR-4486-judge-gated-rewrite-sweep.md
 """
 import argparse
@@ -67,10 +68,23 @@ def post_json(url: str, payload: dict, headers: dict, timeout: int = 180) -> dic
         return json.loads(resp.read().decode())
 
 
+def call_lmstudio(prompt: str) -> tuple[str, str, int]:
+    endpoint = os.environ.get("LMSTUDIO_ENDPOINT", "").rstrip("/")
+    if not endpoint:
+        raise RuntimeError("lane-0a unavailable: LMSTUDIO_ENDPOINT unset")
+    model = os.environ.get("LMSTUDIO_MODEL", "local-model")
+    out = post_json(f"{endpoint}/chat/completions",
+                    {"model": model,
+                     "messages": [{"role": "user", "content": prompt}]}, {})
+    text = out["choices"][0]["message"]["content"]
+    tokens = (out.get("usage") or {}).get("total_tokens", 0)
+    return text, model, tokens
+
+
 def call_ollama(prompt: str, model: str = "") -> tuple[str, str, int]:
     endpoint = os.environ.get("OLLAMA_ENDPOINT", "").rstrip("/")
     if not endpoint:
-        raise RuntimeError("lane-0 unavailable: OLLAMA_ENDPOINT unset")
+        raise RuntimeError("lane-0b unavailable: OLLAMA_ENDPOINT unset")
     model = model or os.environ.get("OLLAMA_MODEL", "gemma3")
     out = post_json(f"{endpoint}/api/generate",
                     {"model": model, "prompt": prompt, "stream": False}, {})
@@ -182,10 +196,15 @@ def cmd_select(args) -> int:
 
 def rewrite_via_lanes(prompt: str) -> tuple[str, str, str, int]:
     try:
-        text, model, tokens = call_ollama(prompt)
-        return text, model, "lane-0-ollama", tokens
+        text, model, tokens = call_lmstudio(prompt)
+        return text, model, "lane-0a-lmstudio", tokens
     except Exception as exc:  # noqa: BLE001 - lane failover by design (WR-4481)
-        print(f"  lane-0 unavailable ({exc}); failing over to OpenRouter")
+        print(f"  lane-0a unavailable ({exc}); trying Ollama")
+    try:
+        text, model, tokens = call_ollama(prompt)
+        return text, model, "lane-0b-ollama", tokens
+    except Exception as exc:  # noqa: BLE001
+        print(f"  lane-0b unavailable ({exc}); failing over to OpenRouter")
     model = os.environ.get("REWRITE_MODEL", "moonshotai/kimi-k2")
     text, model, tokens = call_openrouter(prompt, model)
     return text, model, "lane-1-openrouter", tokens


### PR DESCRIPTION
Adds LM Studio as lane-0a in wr_rewrite.py (OpenAI-format local endpoint at LMSTUDIO_ENDPOINT, e.g. http://127.0.0.1:1234/v1). Ollama becomes lane-0b; OpenRouter stays lane-1. Owner's local server is LM Studio running qwen3 — different family from all judge defaults, so anti-self-grading holds.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds **LM Studio** support as the primary rewrite lane (lane-0a) in the `wr_rewrite.py` script, with **Ollama** moving to lane-0b as a fallback before OpenRouter. The change introduces a new `call_lmstudio()` function that connects to an OpenAI-compatible local endpoint and updates the lane failover logic to try LM Studio first, then Ollama, then OpenRouter. Environment variables `LMSTUDIO_ENDPOINT` and `LMSTUDIO_MODEL` are added to configure the new integration, maintaining the anti-self-grading property since LM Studio runs a different model family (qwen3) than the default judges.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/wr_rewrite.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LM Studio as lane-0a in `wr_rewrite.py`, using an OpenAI-format local endpoint for rewrites. Improves local reliability with a clear failover order: LM Studio → Ollama → OpenRouter.

- **New Features**
  - Added `call_lmstudio()` using `LMSTUDIO_ENDPOINT` (e.g. `http://127.0.0.1:1234/v1`) and `LMSTUDIO_MODEL`.
  - Renamed lanes: lane-0a LM Studio, lane-0b Ollama, lane-1 OpenRouter, with updated failover logs and error messages.
  - Keeps rewrite and judge model families distinct to avoid self-grading.

- **Migration**
  - Set `LMSTUDIO_ENDPOINT` and `LMSTUDIO_MODEL` to enable lane-0a.
  - Optional: set `OLLAMA_ENDPOINT` and `OLLAMA_MODEL` for lane-0b fallback.

<sup>Written for commit 866e47fab7b531c242ac34a6b7f237ec1a78a924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

