### PR TITLE
wr_rewrite.py: LM Studio lane-0 + think-tag stripping

### DIFF
--- a/scripts/wr_rewrite.py
+++ b/scripts/wr_rewrite.py
@@ -3,8 +3,8 @@
 
 Subcommands:
   select    -> parse lint report + placeholder scan, emit queue.json (WIP-capped)
-  run       -> rewrite (lane-0 LM Studio/Ollama -> lane-1 OpenRouter), judge
-               (distinct model families), gate (mean>=0.75, min>=0.50,
+  run       -> rewrite (lane-0 LM Studio -> lane-0b Ollama -> lane-1 OpenRouter),
+               judge (distinct model families), gate (mean>=0.75, min>=0.50,
                lint-clean), retry cap 2, JSONL ledger
   open-prs  -> one branch + PR per passed doc via gh CLI; failed docs flagged
 
@@ -71,7 +71,7 @@ def post_json(url: str, payload: dict, headers: dict, timeout: int = 180) -> dic
 def call_lmstudio(prompt: str) -> tuple[str, str, int]:
     endpoint = os.environ.get("LMSTUDIO_ENDPOINT", "").rstrip("/")
     if not endpoint:
-        raise RuntimeError("lane-0a unavailable: LMSTUDIO_ENDPOINT unset")
+        raise RuntimeError("lane-0 unavailable: LMSTUDIO_ENDPOINT unset")
     model = os.environ.get("LMSTUDIO_MODEL", "local-model")
     out = post_json(f"{endpoint}/chat/completions",
                     {"model": model,
@@ -121,7 +121,8 @@ def lint_checks(text: str) -> tuple[bool, list]:
 
 
 def strip_wrapper_fence(text: str) -> str:
-    m = re.match(r"^```(?:markdown|md)?\s*\n(.*)\n```\s*$", text.strip(), re.S)
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.S).strip()
+    m = re.match(r"^```(?:markdown|md)?\s*\n(.*)\n```\s*$", text, re.S)
     return m.group(1) if m else text
 
 
@@ -154,6 +155,7 @@ def judge_prompt(doc: str) -> str:
 
 
 def parse_judge(text: str) -> tuple[dict, str]:
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.S)
     m = re.search(r"\{.*\}", text, re.S)
     if not m:
         raise ValueError("judge returned no JSON")
@@ -197,14 +199,14 @@ def cmd_select(args) -> int:
 def rewrite_via_lanes(prompt: str) -> tuple[str, str, str, int]:
     try:
         text, model, tokens = call_lmstudio(prompt)
-        return text, model, "lane-0a-lmstudio", tokens
+        return text, model, "lane-0-lmstudio", tokens
     except Exception as exc:  # noqa: BLE001 - lane failover by design (WR-4481)
-        print(f"  lane-0a unavailable ({exc}); trying Ollama")
+        print(f"  lane-0 lmstudio unavailable ({exc}); trying ollama")
     try:
         text, model, tokens = call_ollama(prompt)
         return text, model, "lane-0b-ollama", tokens
     except Exception as exc:  # noqa: BLE001
-        print(f"  lane-0b unavailable ({exc}); failing over to OpenRouter")
+        print(f"  lane-0b ollama unavailable ({exc}); failing over to OpenRouter")
     model = os.environ.get("REWRITE_MODEL", "moonshotai/kimi-k2")
     text, model, tokens = call_openrouter(prompt, model)
     return text, model, "lane-1-openrouter", tokens


### PR DESCRIPTION
Adds LM Studio as lane-0 in wr_rewrite.py (OpenAI-format endpoint at LMSTUDIO_ENDPOINT, e.g. http://127.0.0.1:1234/v1). Ollama becomes lane-0b; OpenRouter stays final fallback. Also strips <think> tags from reasoning-model output (owner's local qwen3 is a thinking model) before lint/judging.

Owner's local setup: LM Studio serving qwen3 at http://127.0.0.1:1234 — reachable only from a self-hosted runner on that machine.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR reorganizes the LLM provider fallback chain in the rewrite script, promoting **LM Studio** to the primary lane (lane-0) while **Ollama** becomes the secondary fallback (lane-0b), with **OpenRouter** remaining as the final fallback. Additionally, it adds `<think>` tag stripping functionality to clean reasoning-model output before linting and judging, accommodating local reasoning models like qwen3 that emit thinking process tags.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `scripts/wr_rewrite.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make LM Studio the primary rewrite lane and strip <think> tags from reasoning-model outputs to prevent lint/judge parsing issues.

- **New Features**
  - Lane order: LM Studio (lane-0) → Ollama (lane-0b) → OpenRouter (lane-1); updated labels and logs.
  - LM Studio via OpenAI-format endpoint at `LMSTUDIO_ENDPOINT` (uses `/chat/completions`); model from `LMSTUDIO_MODEL`.
  - Strip `<think>...</think>` before wrapper-fence extraction and judge JSON parsing.

<sup>Written for commit 560508fecbe8b9f0a7dbf62775e0597dae402fb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

