### PR TITLE
fix: ChaosMender WORKFLOW-RUN-001 false positive on heavily-commented triggers

### DIFF
--- a/scripts/chaosmender.js
+++ b/scripts/chaosmender.js
@@ -117,12 +117,17 @@ function scanWorkflowRunMissingWorkflowsList(repoRoot) {
       // Matches `workflow_run:` as an on: event key (indented or not)
       if (!/^\s+workflow_run\s*:/.test(lines[i])) continue;
 
-      // Look ahead for a `workflows:` key before the next top-level key
+      // Scan the whole workflow_run block for a `workflows:` key. The block is
+      // every following line that is blank, a comment, or indented deeper than
+      // the workflow_run key itself. A fixed lookahead window undercounts
+      // heavily-commented triggers (false positive on pr-lifecycle.yml, whose
+      // workflows: list sits ~35 comment lines below the trigger).
+      const indent = lines[i].match(/^(\s*)/)[1].length;
       let foundWorkflows = false;
-      for (let j = i + 1; j < Math.min(i + 15, lines.length); j++) {
+      for (let j = i + 1; j < lines.length; j++) {
         const ahead = lines[j];
-        // If we hit a new top-level YAML key (no leading space on a non-blank line), stop
-        if (/^[a-zA-Z]/.test(ahead) && ahead.trim() !== '') break;
+        if (ahead.trim() === '' || ahead.trim().startsWith('#')) continue;
+        if (ahead.match(/^(\s*)/)[1].length <= indent) break; // left the block
         if (/^\s+workflows\s*:/.test(ahead)) { foundWorkflows = true; break; }
       }
 

--- a/tests/chaosmender.test.js
+++ b/tests/chaosmender.test.js
@@ -237,6 +237,25 @@ function writeWorkflow(dir, name, content) {
     assert.equal(findings.length, 0);
   });
 
+  await test('scanWorkflowRunMissingWorkflowsList: does NOT flag workflows key beyond a long comment block (pr-lifecycle regression)', () => {
+    const comments = Array.from({ length: 30 }, (_, i) => `    # explanatory comment line ${i + 1}`);
+    const root = writeWorkflow(tmpDir(), 'commented.yml', [
+      'name: Commented',
+      'on:',
+      '  workflow_run:',
+      ...comments,
+      '    workflows: ["CI"]',
+      '    types: [completed]',
+      'jobs:',
+      '  job:',
+      '    runs-on: ubuntu-latest',
+      '    steps: []',
+    ].join('\n'));
+
+    const findings = scanWorkflowRunMissingWorkflowsList(root);
+    assert.equal(findings.length, 0);
+  });
+
   await test('scanWorkflowRunMissingWorkflowsList: skips files with no workflow_run', () => {
     const root = writeWorkflow(tmpDir(), 'noevent.yml', [
       'name: No Event',


### PR DESCRIPTION
## Summary

The "Scan for known error patterns" check has been failing on every PR that touches `pr-lifecycle.yml` — including #16803/#16804/#16805 today — with `WORKFLOW-RUN-001: workflow_run event without 'workflows:' list`. The finding is false: the `workflows:` list exists, but it sits ~35 comment lines below the `workflow_run:` trigger, and the detector only looked ahead **15 lines**. This fixes the detector to scan the entire trigger block (blank/comment/deeper-indented lines) and stop only when indentation returns to the trigger's level — the same semantics as `check-workflow-yaml.js`'s `workflowRunMissingWorkflows`, which correctly passes the file.

docs-freshness: detector bugfix with regression test; no behavior added

## Changes

- `scripts/chaosmender.js`: `scanWorkflowRunMissingWorkflowsList` walks the whole `workflow_run` block instead of a fixed 15-line window.
- `tests/chaosmender.test.js`: regression test — a `workflow_run` block with 30 comment lines between the trigger and its `workflows:` key must produce no finding.

## Validation

Reproduced the false positive on `pr-lifecycle.yml` before the fix; after the fix the same scan reports zero findings. ChaosMender tests and the full suite pass 656/656. Both truly-missing and inline-present cases keep their existing test coverage.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge (fixes a live CI false positive; no source issue)
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011w5j3dYfYySs4B1TX4HkKs

---
_Generated by [Claude Code](https://claude.ai/code/session_011w5j3dYfYySs4B1TX4HkKs)_

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a false positive in the ChaosMender `WORKFLOW-RUN-001` detector that was incorrectly flagging workflow files with heavily-commented `workflow_run` triggers. The original implementation only scanned 15 lines ahead when looking for the required `workflows:` key, which failed for files like `pr-lifecycle.yml` where ~35 comment lines separated the trigger from its configuration. The fix replaces the fixed lookahead window with proper YAML block parsing that scans until indentation returns to the trigger's level, matching the semantics of the existing `check-workflow-yaml.js` validator. A regression test ensures the detector now correctly handles `workflow_run` blocks with 30+ intervening comment lines.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tests/chaosmender.test.js` |
| 2 | `scripts/chaosmender.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false positives in ChaosMender `WORKFLOW-RUN-001` when `workflow_run` triggers have long comment blocks. The detector now scans the full trigger block to find `workflows:`, so `pr-lifecycle.yml` and similar files no longer fail.

- **Bug Fixes**
  - Updated `scanWorkflowRunMissingWorkflowsList` to walk the entire `workflow_run` block and stop on dedent, replacing the 15-line lookahead.
  - Added a regression test with 30 comment lines between `workflow_run:` and `workflows:` to ensure no finding.

<sup>Written for commit 0e7ab24ca828754b2fbcc8e19bf80537bd779def. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

