### PR TITLE
docs: record cloud dev-environment setup gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,8 +176,22 @@ npm test             # product-specific tests (if defined)
   not prevent the dev server from starting — check the product's `.env.example`
   and README for the required variables.
 - **Pre-existing workflow test failures:** A small number of root `npm test`
-  failures stem from intentionally malformed YAML fixtures used to validate
-  error paths. Treat the suite as green if only those known cases fail.
+ failures stem from intentionally malformed YAML fixtures used to validate
+ error paths. Treat the suite as green if only those known cases fail.
+- **Root `npm run lint` exits non-zero on a clean tree.** It runs
+ `markdownlint-cli2`, which does **not** honor the repo's `.markdownlintignore`,
+ so it still flags committed generated files under
+ `docs/agents/**/transcripts/*.md`. It also recurses into any installed
+ `products/*/node_modules/**/*.md`, producing tens of thousands of errors. These
+ are pre-existing / environment noise, not caused by your change — scope the
+ output to the specific `.md` files you touched (e.g.
+ `npx markdownlint-cli2 <your-file>.md`) rather than trying to green the whole
+ tree.
+- **`hvac-calc-service` install fails with `EOVERRIDE`.** Its `package.json`
+ `overrides.postcss` range conflicts with its direct `postcss` devDependency, so
+ `npm install` aborts. Other products install cleanly; use a different product
+ (e.g. `red-light-therapy-dosage-calculator`) when you just need a keyless
+ sample app to run.
 - **Port conflicts:** Always pass `-- -p <port>` to `npm run dev` when running
   more than one product simultaneously; defaults all collide on 3000.
 - **OpenRouter is NOT free-for-all:** `OPENROUTER_API_KEY` must belong to a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this monorepo (root tooling + product apps) and records two durable, non-obvious gotchas discovered during setup in the `## Cursor Cloud specific instructions` section of `AGENTS.md`.

No application code was changed — this PR only appends two bullets to `AGENTS.md`.

## What was verified

**Root tooling** (`revvel-standards`, Node 22.14 satisfies `>=22 <25`):

| Command | Result |
| --- | --- |
| `npm install` | up to date |
| `npm test` | 659/659 pass |
| `npm run typecheck` | pass (tsc clean) |
| `npm run lint` | runs; exits non-zero due to pre-existing noise (see gotcha below) |

**Sample product** (`red-light-therapy-dosage-calculator`, keyless Next.js app on port 3010):

| Command | Result |
| --- | --- |
| `npm install` | ok |
| `npm test` | pass |
| `npm run typecheck` | pass |
| `npm run lint` (eslint) | pass |
| `npm run dev` | serves HTTP 200 |

Hello-world: performed a live photobiomodulation dosage calculation in the running app — doubling Target Dose (10→20 J/cm²) doubled Estimated Session Time (4.76→9.52 min); applying x2.5 skin-reflection compensation raised it to 23.8 min.

[red_light_calculator_hello_world.mp4](https://cursor.com/agents/bc-2731f9b6-87b8-4314-a9ff-f1f8a4087b7d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fred_light_calculator_hello_world.mp4)

## Documented gotchas (new bullets in AGENTS.md)

- Root `npm run lint` exits non-zero on a clean tree because `markdownlint-cli2` ignores `.markdownlintignore` (still flags committed `docs/agents/**/transcripts/*.md`) and recurses into installed `products/*/node_modules`.
- `hvac-calc-service` `npm install` fails with `EOVERRIDE` (its `overrides.postcss` conflicts with its direct `postcss` devDependency).

## Update script

`npm install` (root dependency refresh only — per-product installs remain on-demand as already documented in `AGENTS.md`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2731f9b6-87b8-4314-a9ff-f1f8a4087b7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2731f9b6-87b8-4314-a9ff-f1f8a4087b7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR documents two development environment setup gotchas discovered during verification of the monorepo setup. It appends two new bullet points to the `AGENTS.md` file under the Cursor Cloud specific instructions section: one noting that the root `npm run lint` command exits non-zero on a clean tree due to `markdownlint-cli2` ignoring `.markdownlintignore` and recursing into `node_modules`, and another documenting that `hvac-calc-service` fails to install due to a `postcss` override conflict. No application code was modified.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `AGENTS.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two Cursor Cloud dev-setup notes to `AGENTS.md` to prevent confusion during setup.

Explains that root `npm run lint` can appear red because `markdownlint-cli2` ignores `.markdownlintignore`, flags `docs/agents/**/transcripts/*.md`, and recurses into `products/*/node_modules/**` (scope with `npx markdownlint-cli2 <your-file>.md`); and that `hvac-calc-service` `npm install` may fail with `EOVERRIDE` from a `postcss` override conflict (use `red-light-therapy-dosage-calculator` as a clean sample app).

<sup>Written for commit 703a4c887a9d9e339fa2b508d93f43452738354a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

