### PR TITLE
docs: clarify root markdown lint vs CI gate for cloud agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,8 +176,17 @@ npm test             # product-specific tests (if defined)
   not prevent the dev server from starting — check the product's `.env.example`
   and README for the required variables.
 - **Pre-existing workflow test failures:** A small number of root `npm test`
-  failures stem from intentionally malformed YAML fixtures used to validate
-  error paths. Treat the suite as green if only those known cases fail.
+ failures stem from intentionally malformed YAML fixtures used to validate
+ error paths. Treat the suite as green if only those known cases fail.
+- **Root `npm run lint` differs from the CI markdown gate.** The script's
+ ignore globs only exclude *root-level* `node_modules`/`transcripts`, so it
+ reports tens of thousands of errors from committed
+ `docs/agents/claude/transcripts/**` files and from any installed
+ `products/*/node_modules` (product deps are gitignored and absent in a fresh
+ CI checkout). The authoritative gate is `.github/workflows/lint-md.yml`
+ (`markdownlint-cli2`), which excludes those paths; the repo's own ~1000
+ markdown files lint clean. Don't treat the root script's error flood as a
+ regression you introduced.
 - **Port conflicts:** Always pass `-- -p <port>` to `npm run dev` when running
   more than one product simultaneously; defaults all collide on 3000.
 - **OpenRouter is NOT free-for-all:** `OPENROUTER_API_KEY` must belong to a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the development environment for this monorepo (root tooling + a representative Next.js product), and documented one non-obvious lint gotcha for future cloud agents.

## What was verified

**Root tooling** (`revvel-standards`, Node 22):
- `npm install` — up to date
- `npm test` — 659/659 pass
- `npm run build` (`tsc typecheck`) — clean
- `npm run lint` — see gotcha below

**Product: `products/music-video-creator`** (Next.js 15):
- `npm run dev -- -p 3000` — dev server boots, HTTP 200
- `npm run lint` — no ESLint warnings/errors
- `npm run build` — production build succeeds (7 routes)
- Hello-world: uploaded a `.wav` + avatar image, selected a theme, clicked **Generate Music Video** → app orchestrated the request end-to-end and returned the expected `Backend Wiring Required` status (no provider API keys set in this environment).

## Docs change

Added a **Known gotchas** bullet: the root `npm run lint` script's ignore globs only exclude *root-level* `node_modules`/`transcripts`, so it floods with errors from committed `docs/agents/claude/transcripts/**` and any installed `products/*/node_modules`. The authoritative gate is `.github/workflows/lint-md.yml`, which excludes those paths; the repo's own ~1000 markdown files lint clean. This prevents future agents from mistaking the flood for a regression.

## Environment update script

`npm install` (root). Products are self-contained and installed on-demand per the existing per-product instructions.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da498438-7348-43bc-8e4a-678986828e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da498438-7348-43bc-8e4a-678986828e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds documentation to clarify a known gotcha with the root `npm run lint` script for future cloud agents. The root markdown linting script reports tens of thousands of false-positive errors from nested `node_modules` and committed transcript files because its ignore globs only exclude root-level paths. The actual CI gate (`.github/workflows/lint-md.yml`) uses proper exclusions and passes cleanly. The documentation helps prevent agents from mistaking this noise for a real regression they introduced.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `AGENTS.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified in `AGENTS.md` that the root `npm run lint` is not the CI gate and can flood with errors from `docs/agents/claude/transcripts/**` and `products/*/node_modules`.
The CI workflow `.github/workflows/lint-md.yml` runs `markdownlint-cli2` with exclusions (product deps are gitignored and absent in CI) and is the authoritative check; the repo’s ~1000 markdown files lint clean.

<sup>Written for commit 895ee8317bdc8c2551124f353e5c1e218c8b2551. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

