### PR TITLE
fix: cut OpenRouter triage token spend

### DIFF
--- a/.github/agent-models.yml
+++ b/.github/agent-models.yml
@@ -126,11 +126,11 @@ profiles:
 
   # Triage - quick classification, cheap
   triage:
-    description: "Quick issue classification and routing - use cheap model"
+    description: "Quick issue classification and routing - cheap model with tight output budget"
     provider: openrouter
     primary: "openai/gpt-4o-mini"
     fallback: "anthropic/claude-haiku-4.5"
-    max_tokens: 4000
+    max_tokens: 1500
     temperature: 0.3
     use_for: ["triage", "classify", "route", "label"]
 

--- a/.github/workflows/claude-renovate-review.yml
+++ b/.github/workflows/claude-renovate-review.yml
@@ -19,6 +19,7 @@ jobs:
     name: Claude Renovate Review
     if: github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/dependafix.yml
+++ b/.github/workflows/dependafix.yml
@@ -24,6 +24,7 @@ jobs:
   fix-build:
     name: DependaFix — auto-remediate breaking dependency changes
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     # Only run on Dependabot PRs — never on human-authored branches

--- a/.github/workflows/followup-checkbox-router.yml
+++ b/.github/workflows/followup-checkbox-router.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   route-followups:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Only run if the body actually changed (skip title-only edits, etc.).
     if: ${{ github.event.changes.body != null }}
     steps:

--- a/.github/workflows/jules-coding-agent.yml
+++ b/.github/workflows/jules-coding-agent.yml
@@ -22,6 +22,7 @@ jobs:
   jules-agent:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/jules'))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lane-canary.yml
+++ b/.github/workflows/lane-canary.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   canary:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/openrouter-coder.yml
+++ b/.github/workflows/openrouter-coder.yml
@@ -26,6 +26,7 @@ jobs:
       (github.event_name == 'issues' && (github.event.label.name == 'wr:code' || github.event.label.name == 'spec-approved')) ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/openrouter-triage.yml
+++ b/.github/workflows/openrouter-triage.yml
@@ -88,8 +88,9 @@ jobs:
             echo "OPENROUTER_API_KEY is configured (ensure the OpenRouter account is funded)."
           fi
       # Runs WITH or WITHOUT a key: scripts/openrouter-triage.js cascades
-      # OpenRouter → keyless Perplexity so triage never dead-ends.
-      - name: Run triage (OpenRouter → keyless Perplexity fallback)
+      # through SSOT OpenRouter triage, GitHub Models, keyless Perplexity,
+      # explicit backup models, and static fallback so triage never dead-ends.
+      - name: Run cost-governed triage cascade
         if: steps.labels.outputs.skip_triage != 'true'
         # Best-effort, fail-soft per this workflow's "never dead-end" design: when
         # neither lane succeeds (e.g. no funded OPENROUTER_API_KEY *and* the keyless
@@ -107,7 +108,6 @@ jobs:
           ISSUE_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
           ISSUE_BODY: ${{ github.event.issue.body || github.event.pull_request.body }}
           EVENT_KIND: ${{ github.event_name == 'issues' && 'issue' || 'pull_request' }}
-          MODEL: anthropic/claude-sonnet-4
           PROMPT: ${{ inputs.prompt }}
         run: node scripts/openrouter-triage.js
     timeout-minutes: 30
@@ -184,9 +184,9 @@ jobs:
             core.setOutput('matrix', JSON.stringify({ include: triageTargets }));
     timeout-minutes: 45
   sweep-triage:
-    name: Sweep triage (OpenRouter → keyless fallback)
+    name: Sweep cost-governed triage
     # Runs whenever there are queued items — even with no OpenRouter key, the
-    # script cuts over to the keyless Perplexity lane (never dead-end).
+    # script cuts over to GitHub Models, keyless Perplexity, and static fallback.
     if: needs.sweep-discover.outputs.count != '0'
     needs: sweep-discover
     runs-on: ubuntu-latest
@@ -208,7 +208,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Run OpenRouter triage for each queued item
+      - name: Run cost-governed triage for each queued item
         # Fail-soft, same rationale as route-new: a per-item triage failure
         # already self-reports (comment + needs-human) and must not dead-end or
         # fail the sweep for the remaining matrix items.
@@ -221,7 +221,6 @@ jobs:
           ISSUE_TITLE: ${{ matrix.issue_title }}
           ISSUE_BODY: ${{ matrix.issue_body }}
           EVENT_KIND: ${{ matrix.event_kind }}
-          MODEL: anthropic/claude-sonnet-4
           PROMPT: ${{ inputs.prompt }}
         run: node scripts/openrouter-triage.js
     timeout-minutes: 15

--- a/.github/workflows/patch-agent.yml
+++ b/.github/workflows/patch-agent.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   patch:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-lifecycle.yml
+++ b/.github/workflows/pr-lifecycle.yml
@@ -106,6 +106,7 @@ jobs:
   pr-state:
     if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Update PR state labels
         uses: actions/github-script@v7
@@ -119,6 +120,7 @@ jobs:
   check-state:
     if: github.event_name == 'check_suite' || github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Re-aggregate check state for head SHA
         uses: actions/github-script@v7

--- a/.github/workflows/proposal-prosecution.yml
+++ b/.github/workflows/proposal-prosecution.yml
@@ -20,6 +20,7 @@ jobs:
       (github.event_name == 'issues' && github.event.label.name == 'proposal')
       || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Post prosecution findings
         uses: actions/github-script@v7

--- a/.github/workflows/saml-sso-registration.yml
+++ b/.github/workflows/saml-sso-registration.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   disabled:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: false
     steps:
       - run: echo "REVVEL-DISABLED - see header comment"

--- a/.github/workflows/ship-status-audit.yml
+++ b/.github/workflows/ship-status-audit.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Post weekly Ship Status digest

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -13,6 +13,7 @@ jobs:
   super-linter:
     name: Super-Linter
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       contents: read

--- a/.github/workflows/update-agent-creator-data.yml
+++ b/.github/workflows/update-agent-creator-data.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   rebuild:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/wr-rewrite.yml
+++ b/.github/workflows/wr-rewrite.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   sweep:
     runs-on: self-hosted
+    timeout-minutes: 60
     env:
       LMSTUDIO_ENDPOINT: http://127.0.0.1:1234/v1
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}

--- a/AUTOMATION-DOCTOR-REPORT.md
+++ b/AUTOMATION-DOCTOR-REPORT.md
@@ -1,43 +1,14 @@
 # Automation Doctor Report
 
-Generated: 2026-06-14T18:42:39.065Z
+Generated: 2026-07-25T20:46:00.959Z
 
 ## Workflow Validation
 
-- Valid workflows: 150
-- Invalid workflows: 3
-- Jobs missing timeout: 8
-
-### Invalid Workflows
-
-- `api-rate-limit-handler.yml`: Map keys must be unique at line 7, column 1:
-
-  contents: read
-on:
-^
-
-- `flow-chart-sync.yml`: Map keys must be unique at line 3, column 13:
-
-permissions:
-            ^
-
-- `noimosai.yml`: Map keys must be unique at line 3, column 13:
-
-permissions:
-            ^
-
-### Jobs Missing timeout-minutes
-
-- `ci-error-prevention.yml`: error-prevention-tests, lint-workflows, token-security-check, wr-lint-check, automation-health, summary
-- `daily-news-briefing.yml`: news
-- `fix-wr-gate.yml`: gate
-- `news-with-cache.yml`: fetch
-- `no-root-junk.yml`: no-root-junk
-- `octopus-route.yml`: route-single, backfill
-- `verify-security-fix.yml`: verify
-- `wr-lint.yml`: lint
+- Valid workflows: 188
+- Invalid workflows: 0
+- Jobs missing timeout: 0
 
 ## Labels Check
 
-- Present: 12
+- Present: 0
 - Missing: 0

--- a/docs/OPENROUTER_TRIAGE_PROCESS.md
+++ b/docs/OPENROUTER_TRIAGE_PROCESS.md
@@ -8,14 +8,15 @@
 
 - This repository does **not** depend on the paid GitHub Copilot Coding Agent for automation.
 - `@Copilot` / `copilot-swe-agent` assignee routing is **not used** in this flow.
-- Triage routing is implemented directly through OpenRouter API calls using `OPENROUTER_API_KEY`.
+- Triage routing is implemented through the `triage` profile in
+  [`.github/agent-models.yml`](../.github/agent-models.yml), with non-OpenRouter
+  fallbacks when the key is missing or unfunded.
 - To opt out of triage, apply label `no-triage`.
 
 ## Environment variables
 
 Required:
 
-- `OPENROUTER_API_KEY`
 - `GITHUB_TOKEN`
 - `GITHUB_REPOSITORY`
 - `ISSUE_NUMBER`
@@ -25,7 +26,11 @@ Required:
 
 Optional:
 
-- `MODEL` (default: `anthropic/claude-sonnet-4`)
+- `OPENROUTER_API_KEY` (enables the OpenRouter lanes; GitHub Models / keyless
+  Perplexity / static fallback still run without it)
+- `MODEL` (overrides the SSOT triage primary only for emergency operations)
+- `MODEL_FALLBACK` (overrides the SSOT triage fallback)
+- `MAX_OUTPUT_TOKENS` (default from SSOT triage profile: `1500`)
 
 ## OpenRouter request / response shape
 
@@ -33,12 +38,13 @@ Request (`POST https://openrouter.ai/api/v1/chat/completions`):
 
 ```json
 {
-  "model": "anthropic/claude-sonnet-4",
+  "models": ["openai/gpt-4o-mini", "anthropic/claude-haiku-4.5"],
   "messages": [
     { "role": "system", "content": "triage instructions" },
     { "role": "user", "content": "issue/pr payload" }
   ],
-  "temperature": 0.2
+  "temperature": 0.2,
+  "max_tokens": 1500
 }
 ```
 
@@ -55,24 +61,24 @@ Response use:
 
 ## Model selection table
 
-Source: [`skills/openrouter-swarms/SKILL.md`](../skills/openrouter-swarms/SKILL.md)
+Source: [`.github/agent-models.yml`](../.github/agent-models.yml)
 
-| Task Type | Recommended Model | OpenRouter ID |
+| Lane | Model policy | Cost posture |
 |---|---|---|
-| Code generation / debugging | Claude Sonnet 4 | `anthropic/claude-sonnet-4` |
-| Deep reasoning / architecture | Claude Opus 4 | `anthropic/claude-opus-4` |
-| Fast / cheap tasks | Claude Haiku 4.5 | `anthropic/claude-haiku-4-5` |
-| Code + physics problems | GitHub GPT-5 Nano | `github/gpt-5-nano` |
-| Cell sequencing / biology | GitHub o1 | `github/o1-cell-sequencing` |
-| General research | GPT-5 | `openai/gpt-5` |
-| Long documents | Gemini 2.5 Pro | `google/gemini-2.5-pro` |
-| Code completion (fast) | Codex 5.1 | `openai/codex-5.1` |
+| OpenRouter SSOT triage | `openai/gpt-4o-mini` → `anthropic/claude-haiku-4.5` | Cheap primary, explicit fallback |
+| GitHub Models | `gpt-4o-mini` | Uses `GITHUB_TOKEN`, no OpenRouter spend |
+| Keyless Perplexity | `perplexity/sonar` bridge | No API key required |
+| OpenRouter free-tier | `OR_FREE_MODELS` env or built-in `:free` list | Cheap, account-dependent |
+| OpenRouter backup | Explicit cheap backup models | Last paid lane; no `openrouter/auto` or `openrouter/fusion` |
+| Static fallback | Rule-based labels | No LLM spend |
 
 ## Cost guardrails
 
-- Default model: `anthropic/claude-sonnet-4`.
-- Escalate to larger models only when triage requires deep reasoning.
-- Keep output concise and actionable.
+- Default model comes from the SSOT `triage` profile: `openai/gpt-4o-mini`.
+- Output is capped at `1500` tokens by default, down from the prior uncapped
+  Sonnet request path.
+- Triage prompt is intentionally concise: no broad research packet, no repeated
+  issue text, and marketing/SEO only when it changes routing.
 - Hourly sweep only triages `triage:new` items missing `openrouter`.
 - Use `no-triage` to suppress unnecessary calls.
 

--- a/scripts/openrouter-triage.js
+++ b/scripts/openrouter-triage.js
@@ -12,7 +12,6 @@ const ISSUE_NUMBER = process.env.ISSUE_NUMBER || "";
 const ISSUE_TITLE = process.env.ISSUE_TITLE || "";
 const ISSUE_BODY = process.env.ISSUE_BODY || "";
 const EVENT_KIND = process.env.EVENT_KIND || "issue";
-const MODEL = process.env.MODEL || "anthropic/claude-sonnet-4";
 const PROMPT = process.env.PROMPT || "";
 
 const OPENROUTER_HOST = "openrouter.ai";
@@ -21,6 +20,60 @@ const MAX_PROMPT_COMMENTS = 8;
 const MAX_COMMENT_PREVIEW_CHARS = 500;
 const MAX_URLS_IN_CONTEXT = 25;
 const COMMENTS_PER_PAGE = 20;
+
+function unquoteYamlScalar(value) {
+  const trimmed = String(value || "").trim();
+  return trimmed.replace(/^["']|["']$/g, "");
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value || ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function loadAgentModelProfile(profileName) {
+  const configPath = path.resolve(__dirname, "../.github/agent-models.yml");
+  try {
+    const raw = fs.readFileSync(configPath, "utf8");
+    const profile = {};
+    let inProfiles = false;
+    let inTargetProfile = false;
+
+    for (const line of raw.split(/\r?\n/)) {
+      if (/^profiles:\s*$/.test(line)) {
+        inProfiles = true;
+        continue;
+      }
+      if (!inProfiles) continue;
+
+      const profileHeader = line.match(/^ {2}([A-Za-z0-9_]+):\s*$/);
+      if (profileHeader) {
+        inTargetProfile = profileHeader[1] === profileName;
+        continue;
+      }
+      if (!inTargetProfile) continue;
+
+      const scalar = line.match(/^ {4}(primary|fallback|max_tokens|provider):\s*(.+?)\s*$/);
+      if (scalar) {
+        profile[scalar[1]] = unquoteYamlScalar(scalar[2]);
+      }
+    }
+
+    return profile;
+  } catch (error) {
+    console.log(`::warning::Could not read ${configPath}: ${error.message}`);
+    return {};
+  }
+}
+
+const TRIAGE_PROFILE = loadAgentModelProfile("triage");
+const MODEL = process.env.MODEL || TRIAGE_PROFILE.primary || "openai/gpt-4o-mini";
+const MODEL_FALLBACK = process.env.MODEL_FALLBACK || TRIAGE_PROFILE.fallback || "anthropic/claude-haiku-4.5";
+const MAX_OUTPUT_TOKENS = parsePositiveInt(
+  process.env.MAX_OUTPUT_TOKENS,
+  parsePositiveInt(TRIAGE_PROFILE.max_tokens, 1500),
+);
+const PRIMARY_OPENROUTER_MODELS = [...new Set([MODEL, MODEL_FALLBACK].filter(Boolean))];
 
 // Labels applied to an issue/PR to surface triage outcomes. Keep in sync with
 // `.github/labels.yml` so `sync-labels.yml` can propagate them to every repo.
@@ -62,19 +115,20 @@ function buildFailureComment({ kind, detail, model, issueNumber, eventKind }) {
     kind === "needs-key"
       ? "Add the secret under *Settings → Secrets and variables → Actions* and re-run this workflow (or wait for the hourly sweep). " +
         "This item has been labelled `openrouter:needs-key` + `needs-human` so it does not sit silently."
-      : "Triage tried **both** lanes and both failed. This item has been labelled " +
+      : "Triage tried every AI lane and all failed. This item has been labelled " +
         "`openrouter:triage-failed` + `needs-human` so it does not sit silently. " +
         "A later success will clear these labels automatically.",
     "",
     "<details><summary>For whoever is troubleshooting (you may not be the repo owner)</summary>",
     "",
-    "Triage cascades so it never dead-ends:",
+    "Triage cascades so it never dead-ends while keeping the hot path cheap:",
     "",
-    "1. **OpenRouter** — requires `OPENROUTER_API_KEY` tied to a **funded/verified** account. " +
+    "1. **OpenRouter SSOT triage profile** — requires `OPENROUTER_API_KEY` tied to a **funded/verified** account. " +
       "OpenRouter is *not* free-for-all: even `:free` models need a real, credited account, so a missing/unfunded key returns `401/402/403/429`, not a completion. Check the key **and** the account balance at <https://openrouter.ai/credits>.",
-    "2. **Perplexity (keyless)** — the no-API safety net. Needs `python3` + the `perplexity-ai` bridge (the workflow installs it). If this also failed, check the bridge install / network.",
+    "2. **GitHub Models** — uses `GITHUB_TOKEN` and the same small-output triage budget.",
+    "3. **Perplexity (keyless)** — the no-API safety net. Needs `python3` + the `perplexity-ai` bridge (the workflow installs it). If this also failed, check the bridge install / network.",
     "",
-    "If both are down, add another keyless lane in `scripts/openrouter-triage.js` → `triageWithFallback()`. Rule: always fall back to something.",
+    "If every AI lane is down, add another keyless or repository-local lane in `scripts/openrouter-triage.js` → `triageWithFallback()`. Rule: always fall back to something.",
     "</details>",
   ].join("\n");
   return body;
@@ -112,12 +166,11 @@ function buildSystemPrompt(labelNames) {
     "Infer the likely implementation ask from the title, labels, comments, and repository conventions, then propose the next concrete engineering action.",
     "Only require human attention when autonomous research still cannot determine a safe next step after using the available context.",
     "",
-    "RESEARCH MANDATE:",
-    "Every triage response must include (where applicable):",
-    "- Marketing viability signals (distribution, audience, monetization path)",
-    "- SEO keywords relevant to the topic or product",
-    "- GitHub star count / community traction for any tools referenced",
-    "- Factual citations — no ungrounded assertions",
+    "COST-GOVERNED TRIAGE:",
+    "- Keep the response concise: short bullets, no broad research packet, no repeated issue text.",
+    "- Use only context already present in the issue, PR, comments, or observed URLs.",
+    "- Include marketing/SEO signals only when they change the immediate routing decision; otherwise write `N/A`.",
+    "- Cite submitted URLs when they are relevant; do not invent external citations.",
     "",
     "Only suggest labels from this canonical `.github/labels.yml` set:",
     labelList,
@@ -253,7 +306,7 @@ function requestJson({ hostname, pathName, method, headers, payload }) {
   });
 }
 
-// OpenRouter free-tier models to try as lane 2 when the primary model fails.
+// OpenRouter free-tier models to try after the GitHub Models and keyless lanes.
 // These ":free" models still need a real OR account + API key, and are often
 // heavily rate-limited; treat this lane as "may work" rather than guaranteed.
 // Override via OR_FREE_MODELS env var (comma-separated) for operator flexibility.
@@ -288,12 +341,13 @@ async function callOpenRouter(systemPrompt, userPrompt) {
       "X-Title": `${GITHUB_REPOSITORY} OpenRouter Triage`,
     },
     payload: {
-      model: MODEL,
+      models: PRIMARY_OPENROUTER_MODELS,
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },
       ],
       temperature: 0.2,
+      max_tokens: MAX_OUTPUT_TOKENS,
     },
   });
 
@@ -302,9 +356,8 @@ async function callOpenRouter(systemPrompt, userPrompt) {
   return response?.choices?.[0]?.message?.content || "No triage output returned by model.";
 }
 
-// Lane 2: OpenRouter free-tier models — OR_FREE_MODELS don't consume credits,
-// so this can succeed even when the primary model hits a 402/balance error.
-// Requires a valid OPENROUTER_API_KEY (even unfunded).
+// Lane 4: OpenRouter free-tier models. These can be cheaper than paid backup
+// models, but still need a funded/verified OpenRouter account in practice.
 async function callOpenRouterFreeModels(systemPrompt, userPrompt) {
   if (!OPENROUTER_API_KEY) throw new Error("OPENROUTER_API_KEY not configured");
   const referer = `https://github.com/${GITHUB_REPOSITORY}`;
@@ -324,6 +377,7 @@ async function callOpenRouterFreeModels(systemPrompt, userPrompt) {
         { role: "user", content: userPrompt },
       ],
       temperature: 0.2,
+      max_tokens: MAX_OUTPUT_TOKENS,
     },
   });
   const text = response?.choices?.[0]?.message?.content;
@@ -331,11 +385,13 @@ async function callOpenRouterFreeModels(systemPrompt, userPrompt) {
   return text;
 }
 
-// Lane 4: OpenRouter multi-provider fusion — routes across multiple providers;
-// may succeed when single-provider lanes fail due to provider-side outages.
-async function callOpenRouterFusion(systemPrompt, userPrompt) {
+// Lane 5: Explicit OpenRouter backup models. Do not use openrouter/fusion here:
+// `.github/agent-models.yml` deny-lists fusion/auto because they hide spend and
+// route choice. Keeping the fallback list explicit makes this hot path auditable.
+async function callOpenRouterBackupModels(systemPrompt, userPrompt) {
   if (!OPENROUTER_API_KEY) throw new Error("OPENROUTER_API_KEY not configured");
   const referer = `https://github.com/${GITHUB_REPOSITORY}`;
+  const backupModels = [...new Set(["deepseek/deepseek-chat", MODEL_FALLBACK, ...OR_FREE_MODELS].filter(Boolean))];
   const response = await requestJson({
     hostname: OPENROUTER_HOST,
     pathName: OPENROUTER_PATH,
@@ -343,19 +399,20 @@ async function callOpenRouterFusion(systemPrompt, userPrompt) {
     headers: {
       Authorization: `Bearer ${OPENROUTER_API_KEY}`,
       "HTTP-Referer": referer,
-      "X-Title": `${GITHUB_REPOSITORY} OpenRouter Triage (fusion)`,
+      "X-Title": `${GITHUB_REPOSITORY} OpenRouter Triage (backup models)`,
     },
     payload: {
-      models: ["openrouter/fusion", "anthropic/claude-haiku-4.5:beta", "deepseek/deepseek-v3:free"],
+      models: backupModels,
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },
       ],
       temperature: 0.2,
+      max_tokens: MAX_OUTPUT_TOKENS,
     },
   });
   const text = response?.choices?.[0]?.message?.content;
-  if (!text) throw new Error("No triage output from OpenRouter fusion.");
+  if (!text) throw new Error("No triage output from OpenRouter backup models.");
   return text;
 }
 
@@ -674,38 +731,36 @@ async function reportTriageFailure({ kind, detail }) {
 }
 
 // Always-fall-back triage cascade. Returns { text, lane, model }.
-// Cascades through all 6 lanes in order; lane 6 (static rule-based) never
-// throws, so this function always returns successfully.
-//   1. OpenRouter primary model — best quality, needs funded account key.
-//   2. OpenRouter free-tier models — no credits consumed, but needs valid key.
+// Cascades through all 6 lanes in cost-governed order; lane 6 (static
+// rule-based) never throws, so this function always returns successfully.
+//   1. OpenRouter SSOT triage profile — cheap primary + explicit fallback.
+//   2. GitHub Models — gpt-4o-mini via Azure; uses GITHUB_TOKEN.
 //   3. Keyless Perplexity bridge — needs no API key (python3 + perplexity-ai).
-//   4. OpenRouter multi-provider fusion — routes across providers; may succeed
-//      when single-provider lanes fail due to provider-side outages.
-//   5. GitHub Models — gpt-4o-mini via Azure; uses GITHUB_TOKEN (always set
-//      in Actions), no OpenRouter key required.
-//   6. Static rule-based fallback — never throws; keyword-only stub so that
-//      every issue always receives some triage output.
+//   4. OpenRouter free-tier models — cheap but still account/key dependent.
+//   5. Explicit OpenRouter backup models — no auto/fusion hidden routing.
+//   6. Static rule-based fallback — never throws; keyword-only output so that
+//      every issue always receives some triage result.
 // Lane 6 never fails, so triageWithFallback always returns a result.
 async function triageWithFallback(systemPrompt, userPrompt) {
-  // Lane 1: OpenRouter primary model
+  // Lane 1: OpenRouter SSOT triage profile.
   if (OPENROUTER_API_KEY) {
     try {
       const text = await callOpenRouter(systemPrompt, userPrompt);
-      return { text, lane: "OpenRouter", model: MODEL };
+      return { text, lane: "OpenRouter SSOT triage", model: PRIMARY_OPENROUTER_MODELS.join(" → ") };
     } catch (err) {
       // 401/402/403/429 almost always means the account is not funded/verified.
       console.log(`::warning::Lane 1 (OpenRouter) failed (${err.message}). Trying lane 2.`);
     }
-
-    // Lane 2: OpenRouter free-tier models
-    try {
-      const text = await callOpenRouterFreeModels(systemPrompt, userPrompt);
-      return { text, lane: "OpenRouter free-tier", model: OR_FREE_MODELS[0] };
-    } catch (err) {
-      console.log(`::warning::Lane 2 (OpenRouter free-tier) failed (${err.message}). Trying lane 3.`);
-    }
   } else {
-    console.log("::warning::OPENROUTER_API_KEY not configured — skipping lanes 1 & 2.");
+    console.log("::warning::OPENROUTER_API_KEY not configured — skipping lane 1.");
+  }
+
+  // Lane 2: GitHub Models (gpt-4o-mini via Azure; always available in Actions)
+  try {
+    const text = await callGitHubModels(systemPrompt, userPrompt);
+    return { text, lane: "GitHub Models", model: "gpt-4o-mini" };
+  } catch (err) {
+    console.log(`::warning::Lane 2 (GitHub Models) failed (${err.message}). Trying lane 3.`);
   }
 
   // Lane 3: Keyless Perplexity bridge
@@ -716,22 +771,24 @@ async function triageWithFallback(systemPrompt, userPrompt) {
     console.log(`::warning::Lane 3 (Perplexity keyless) failed (${err.message}). Trying lane 4.`);
   }
 
-  // Lane 4: OpenRouter fusion
+  // Lane 4: OpenRouter free-tier models.
   if (OPENROUTER_API_KEY) {
     try {
-      const text = await callOpenRouterFusion(systemPrompt, userPrompt);
-      return { text, lane: "OpenRouter fusion", model: "openrouter/fusion" };
+      const text = await callOpenRouterFreeModels(systemPrompt, userPrompt);
+      return { text, lane: "OpenRouter free-tier", model: OR_FREE_MODELS[0] };
     } catch (err) {
-      console.log(`::warning::Lane 4 (OpenRouter fusion) failed (${err.message}). Trying lane 5.`);
+      console.log(`::warning::Lane 4 (OpenRouter free-tier) failed (${err.message}). Trying lane 5.`);
     }
   }
 
-  // Lane 5: GitHub Models (gpt-4o-mini via Azure; always available in Actions)
-  try {
-    const text = await callGitHubModels(systemPrompt, userPrompt);
-    return { text, lane: "GitHub Models", model: "gpt-4o-mini" };
-  } catch (err) {
-    console.log(`::warning::Lane 5 (GitHub Models) failed (${err.message}). Falling back to lane 6.`);
+  // Lane 5: Explicit OpenRouter backup models.
+  if (OPENROUTER_API_KEY) {
+    try {
+      const text = await callOpenRouterBackupModels(systemPrompt, userPrompt);
+      return { text, lane: "OpenRouter backup models", model: "deepseek/deepseek-chat" };
+    } catch (err) {
+      console.log(`::warning::Lane 5 (OpenRouter backup models) failed (${err.message}). Falling back to lane 6.`);
+    }
   }
 
   // Lane 6: Static rule-based fallback — never throws
@@ -815,5 +872,12 @@ module.exports = {
   normalizeUrl,
   extractUrls,
   collectUrlContext,
+  loadAgentModelProfile,
+  parsePositiveInt,
+  TRIAGE_PROFILE,
+  MODEL,
+  MODEL_FALLBACK,
+  MAX_OUTPUT_TOKENS,
+  PRIMARY_OPENROUTER_MODELS,
   FAILURE_LABELS,
 };

--- a/tests/openrouter-triage.test.js
+++ b/tests/openrouter-triage.test.js
@@ -12,6 +12,11 @@ const {
   normalizeUrl,
   extractUrls,
   collectUrlContext,
+  loadAgentModelProfile,
+  MODEL,
+  MODEL_FALLBACK,
+  MAX_OUTPUT_TOKENS,
+  PRIMARY_OPENROUTER_MODELS,
   FAILURE_LABELS,
 } = require('../scripts/openrouter-triage.js');
 
@@ -33,10 +38,24 @@ test('buildSystemPrompt includes triage sections and provided labels', () => {
   const prompt = buildSystemPrompt(['triage:new', 'openrouter', 'role:orchestrator']);
   assert.ok(prompt.includes('Classification'));
   assert.ok(prompt.includes('Suggested Labels'));
+  assert.ok(prompt.includes('COST-GOVERNED TRIAGE'));
+  assert.ok(!prompt.includes('RESEARCH MANDATE'));
   assert.ok(prompt.includes('triage:new'));
   assert.ok(prompt.includes('openrouter'));
   assert.ok(prompt.includes('do NOT classify them as incomplete just because sections are empty'));
   assert.ok(prompt.includes('Infer the likely implementation ask from the title, labels, comments, and repository conventions'));
+});
+
+test('default triage routing comes from cheap SSOT profile with tight cap', () => {
+  const profile = loadAgentModelProfile('triage');
+  assert.strictEqual(profile.primary, 'openai/gpt-4o-mini');
+  assert.strictEqual(profile.fallback, 'anthropic/claude-haiku-4.5');
+  assert.strictEqual(profile.max_tokens, '1500');
+  assert.strictEqual(MODEL, profile.primary);
+  assert.strictEqual(MODEL_FALLBACK, profile.fallback);
+  assert.strictEqual(MAX_OUTPUT_TOKENS, 1500);
+  assert.deepStrictEqual(PRIMARY_OPENROUTER_MODELS, [profile.primary, profile.fallback]);
+  assert.ok(PRIMARY_OPENROUTER_MODELS.every((model) => !/sonnet/i.test(model)));
 });
 
 test('buildUserPrompt includes event kind and fallback body behavior', () => {
@@ -100,7 +119,7 @@ test('buildFailureComment(needs-key) surfaces the operator action and labels', (
   const body = buildFailureComment({
     kind: 'needs-key',
     detail: 'OPENROUTER_API_KEY missing',
-    model: 'anthropic/claude-sonnet-4',
+    model: MODEL,
     issueNumber: '42',
     eventKind: 'issue',
   });
@@ -108,7 +127,7 @@ test('buildFailureComment(needs-key) surfaces the operator action and labels', (
   assert.ok(body.includes(FAILURE_LABELS.NEEDS_KEY));
   assert.ok(body.includes(FAILURE_LABELS.NEEDS_HUMAN));
   assert.ok(body.includes('#42'));
-  assert.ok(body.includes('anthropic/claude-sonnet-4'));
+  assert.ok(body.includes('openai/gpt-4o-mini'));
 });
 
 test('buildFailureComment(triage-failed) captures the error and references recovery', () => {
@@ -116,7 +135,7 @@ test('buildFailureComment(triage-failed) captures the error and references recov
   const body = buildFailureComment({
     kind: 'triage-failed',
     detail,
-    model: 'anthropic/claude-sonnet-4',
+    model: MODEL,
     issueNumber: '99',
     eventKind: 'pull_request',
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Route the high-volume OpenRouter triage path through the cheap SSOT triage profile and cap output spend while preserving the never-dead-end fallback cascade. Also makes the workflow standards validator green by adding job-level timeouts to the workflows it reported.

## Changes

- Load the `triage` profile from `.github/agent-models.yml` instead of hardcoding Sonnet in the triage workflow.
- Reduce the triage output cap from uncapped/4,000-token policy drift to a 1,500-token SSOT budget.
- Reorder fallbacks to prefer GitHub Models and keyless lanes before OpenRouter backup models, and remove `openrouter/fusion` from the triage cascade.
- Update the triage process docs and focused regression tests.
- Add job-level `timeout-minutes` to the 14 workflows reported by Automation Doctor.
- Refresh `AUTOMATION-DOCTOR-REPORT.md` to show 188 valid workflows, 0 invalid workflows, and 0 missing timeouts.

## Validation

- `node --test tests/openrouter-triage.test.js` — 11 focused triage assertions passed.
- `npm run workflows:validate` — 188 valid workflows, 0 invalid, 0 missing timeout.
- `npm test` — 659 tests passed.

## Checklist

- [ ] Closes #N is present so the issue auto-closes on merge
- [x] No hardcoded secrets or credentials
- [x] PR title uses conventional-commit format (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
- [x] WR/issue scope is delivered in full or partial-with-blocker is documented above
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cb42244-17e3-45d6-a4d8-0a160ad7927b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cb42244-17e3-45d6-a4d8-0a160ad7927b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR reduces OpenRouter triage costs by switching from a hardcoded Sonnet model to a cheaper `triage` profile defined in `.github/agent-models.yml` (using `gpt-4o-mini` as primary), cutting the output token limit from 4000 to 1500, and reordering the fallback cascade to prefer GitHub Models and keyless Perplexity before trying OpenRouter backup models. The changes update the triage workflow, script logic, documentation, and tests to reflect the new cost-governed approach while maintaining the never-dead-end fallback design.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `.github/agent-models.yml` |
| 2 | `scripts/openrouter-triage.js` |
| 3 | `.github/workflows/openrouter-triage.yml` |
| 4 | `docs/OPENROUTER_TRIAGE_PROCESS.md` |
| 5 | `tests/openrouter-triage.test.js` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts triage token spend by switching to the SSOT `triage` profile with a 1,500-token cap and a cheaper, resilient cascade. Enforces CI timeouts and updates docs/tests; Automation Doctor is clean.

- **Refactors**
  - Route triage via `.github/agent-models.yml` `triage` profile (`openai/gpt-4o-mini` → `anthropic/claude-haiku-4.5`) with env overrides `MODEL`/`MODEL_FALLBACK`/`MAX_OUTPUT_TOKENS`; send OpenRouter `models: [primary, fallback]` with `max_tokens: 1500`.
  - Tighten prompt to “COST-GOVERNED TRIAGE” (short bullets, no broad research packet).
  - Reorder cascade: OpenRouter SSOT → GitHub Models → keyless Perplexity → OpenRouter free models → explicit OpenRouter backups → static; drop `openrouter/fusion`. Rename steps to “cost-governed triage”, remove hardcoded `MODEL`, add `timeout-minutes`; update docs/tests; Automation Doctor shows 188 valid, 0 invalid, 0 missing timeouts.

- **Migration**
  - No action required; runs default to the new profile, cap, and cascade.
  - Optional: fund `OPENROUTER_API_KEY` to use OpenRouter lanes; without it, GitHub Models/keyless paths and static fallback run automatically.

<sup>Written for commit e6afdead3cbe869bb262dd03ba05eec95ea60e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midnghtsapphire/revvel-standards/pull/16822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

